### PR TITLE
added dotenv and configured mongo config to us variables defined there

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+DB_HOST = localhost
+DB_PORT = 27017
+DB_NAME = deqm-test-server

--- a/package-lock.json
+++ b/package-lock.json
@@ -2286,6 +2286,11 @@
         "is-obj": "^2.0.0"
       }
     },
+    "dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
+    },
     "dotnet-deps-parser": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/dotnet-deps-parser/-/dotnet-deps-parser-5.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@asymmetrik/node-fhir-server-core": "^2.2.3",
     "axios": "^0.21.1",
+    "dotenv": "^10.0.0",
     "express": "^4.17.1",
     "mongodb": "^4.1.0",
     "uuid": "^8.3.2"

--- a/src/util/mongo.js
+++ b/src/util/mongo.js
@@ -1,10 +1,10 @@
+/* eslint-disable no-undef */
 const { MongoClient } = require('mongodb');
 
+require('dotenv').config();
+
 // Connection URL
-const url = 'mongodb://localhost:27017';
+const url = `mongodb://${process.env.DB_HOST}:${process.env.DB_PORT}`;
 const client = new MongoClient(url);
 
-// Database Name
-const dbName = 'deqm-test-server';
-
-module.exports = { client, db: client.db(dbName) };
+module.exports = { client, db: client.db(process.env.DB_NAME) };


### PR DESCRIPTION
# Summary
mongo.js now uses the variables defined in the .env file to set up the db connection

## New behavior
^ All other functionality should be unchanged

## Code changes

- Added dotenv to the project
- Added .env file with DB_HOST, DB_PORT, and DB_NAME variables
- changed utils/mongo.js to pull variables from .env using dotenv instead of defining them in the file
- disabled es-lint no-undef warnings for util/mongo.js to prevent warnings thrown on variables defined during `require('dotenv').config()` step

# Testing guidance

- Test all CRUD operations (POST, GET, PUT, DELETE) and ensure functionality remains unchanged. Checkout [CRUD](https://github.com/projecttacoma/deqm-test-server/pull/4) for more information on how to go about this.
- Refer to the [dotenv docs](https://www.npmjs.com/package/dotenv) and ensure that all added/altered files are of the expected format
