### PR TITLE
Base Search Implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,58 @@
         "grapheme-splitter": "^1.0.4"
       }
     },
+    "@asymmetrik/fhir-qb": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@asymmetrik/fhir-qb/-/fhir-qb-0.12.5.tgz",
+      "integrity": "sha512-FtogyM05UackveZhhDpWaOonIGlOouLI0XipdEW4Hqeoy8JyBletWvKl228UW+w2nqB6WFjaVwRaS7QzvUXkGg==",
+      "requires": {
+        "@asymmetrik/fhir-qb-mongo": "^0.12.3",
+        "@asymmetrik/fhir-sanitize-param": "^1.1.6",
+        "mathjs": "^5.2.3",
+        "moment": "^2.24.0",
+        "sequelize": "^5.19.0",
+        "xregexp": "^4.2.0"
+      }
+    },
+    "@asymmetrik/fhir-qb-mongo": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/@asymmetrik/fhir-qb-mongo/-/fhir-qb-mongo-0.12.3.tgz",
+      "integrity": "sha512-XCXYFrsQTl+pa9rymC+ZftY8X4BuZBFu7qQ1dMsdZ49aXRqF7VTkXeOMCqEYAIzi2ZsKe5VvqU5Ov4qS1qhFBw==",
+      "requires": {
+        "xregexp": "^4.2.0"
+      }
+    },
     "@asymmetrik/fhir-response-util": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@asymmetrik/fhir-response-util/-/fhir-response-util-1.2.4.tgz",
       "integrity": "sha512-GL75AWd0kYkfBv8YVZv1yLpIqzSx/TA5Se9GGGg3YlIrUNoVqqO6aRLGGjuYHJGJY56h2LnV8z9f9+lIl/31kg=="
+    },
+    "@asymmetrik/fhir-sanitize-param": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@asymmetrik/fhir-sanitize-param/-/fhir-sanitize-param-1.1.6.tgz",
+      "integrity": "sha512-ROleb0keH+LnfaJfpkA5igctLQZ7I/B6mEIvOsfFrD2p2teiIAFwwsgKNALRnf8HZTedtk1TbN492Hfywp4pmg==",
+      "requires": {
+        "moment-timezone": "^0.5.21",
+        "sanitize-html": "^1.20.0",
+        "validator": "^10.8.0",
+        "xss": "^1.0.3"
+      },
+      "dependencies": {
+        "validator": {
+          "version": "10.11.0",
+          "resolved": "https://registry.npmjs.org/validator/-/validator-10.11.0.tgz",
+          "integrity": "sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw=="
+        },
+        "xss": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.9.tgz",
+          "integrity": "sha512-2t7FahYnGJys6DpHLhajusId7R0Pm2yTmuL0GV9+mV0ZlaLSnb2toBmppATfg5sWIhZQGlsTLoecSzya+l4EAQ==",
+          "requires": {
+            "commander": "^2.20.3",
+            "cssfilter": "0.0.10"
+          }
+        }
+      }
     },
     "@asymmetrik/node-fhir-server-core": {
       "version": "2.2.3",
@@ -667,9 +715,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.6.tgz",
-      "integrity": "sha512-S/TSCcsRuCkmpUuoWijua0Snt+f3ewU/8spLo+4AXJCZfT0bVCzLD5MuOKdrx0mlAptbKzn5AdgEIIKXxXkz9Q=="
+      "version": "7.15.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.7.tgz",
+      "integrity": "sha512-rycZXvQ+xS9QyIcJ9HXeDWf1uxqlbVFAUq0Rq0dbc50Zb/+wUe/ehyfzGfm9KZZF0kBejYgxltBXocP+gKdL2g=="
     },
     "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
       "version": "7.15.4",
@@ -1354,6 +1402,15 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
       "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
       "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "@babel/runtime-corejs3": {
+      "version": "7.15.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.15.3.tgz",
+      "integrity": "sha512-30A3lP+sRL6ml8uhoJSs+8jwpKzbw8CqBvDc1laeptxPm5FahumJxirigcbD2qTs71Sonvj1cyZB0OKGAmxQ+A==",
+      "requires": {
+        "core-js-pure": "^3.16.0",
         "regenerator-runtime": "^0.13.4"
       }
     },
@@ -3846,12 +3903,12 @@
       }
     },
     "babel-plugin-polyfill-corejs3": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.2.4.tgz",
-      "integrity": "sha512-z3HnJE5TY/j4EFEa/qpQMSbcUJZ5JQi+3UFjXzn6pQCmIKc5Ug5j98SuYyH+m4xQnvKlMDIW4plLfgyVnd0IcQ==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.2.5.tgz",
+      "integrity": "sha512-ninF5MQNwAX9Z7c9ED+H2pGt1mXdP4TqzlHKyPIYmJIYz0N+++uwdM7RnJukklhzJ54Q84vA4ZJkgs7lu5vqcw==",
       "requires": {
         "@babel/helper-define-polyfill-provider": "^0.2.2",
-        "core-js-compat": "^3.14.0"
+        "core-js-compat": "^3.16.2"
       }
     },
     "babel-plugin-polyfill-regenerator": {
@@ -3984,6 +4041,11 @@
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
       }
+    },
+    "bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "bn.js": {
       "version": "4.12.0",
@@ -4512,6 +4574,15 @@
         "mimic-response": "^1.0.0"
       }
     },
+    "cls-bluebird": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cls-bluebird/-/cls-bluebird-2.1.0.tgz",
+      "integrity": "sha1-N+8eCAqP+1XC9BZPU28ZGeeWiu4=",
+      "requires": {
+        "is-bluebird": "^1.0.2",
+        "shimmer": "^1.1.0"
+      }
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -4596,6 +4667,11 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
+    "complex.js": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.0.11.tgz",
+      "integrity": "sha512-6IArJLApNtdg1P1dFtn3dnyzoZBEF0MwMnrfF1exSBRpZYoy4yieMkpZhQDC0uwctw48vii0CFVyHfpgZ/DfGw=="
     },
     "component-emitter": {
       "version": "1.3.0",
@@ -4716,6 +4792,11 @@
           "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A=="
         }
       }
+    },
+    "core-js-pure": {
+      "version": "3.16.4",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.16.4.tgz",
+      "integrity": "sha512-bY1K3/1Jy9D8Jd12eoeVahNXHLfHFb4TXWI8SQ4y8bImR9qDPmGITBAfmcffTkgUvbJn87r8dILOTWW5kZzkgA=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -5181,6 +5262,11 @@
         "xml2js": "0.4.23"
       }
     },
+    "dottie": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
+      "integrity": "sha512-fmrwR04lsniq/uSr8yikThDTrM7epXHBAAjH9TbeH3rEA8tdCO7mRzB9hdmdGyJCxF8KERo9CITcm3kGuoyMhg=="
+    },
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
@@ -5323,6 +5409,11 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "escape-latex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/escape-latex/-/escape-latex-1.2.0.tgz",
+      "integrity": "sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw=="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -6110,6 +6201,11 @@
         }
       }
     },
+    "fraction.js": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.0.12.tgz",
+      "integrity": "sha512-8Z1K0VTG4hzYY7kA/1sj4/r1/RWLBD3xwReT/RCrUCbzPszjNQCCsy3ktkU/eaEqX3MYa4pY37a52eiBlPMlhA=="
+    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -6694,6 +6790,11 @@
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
     },
+    "inflection": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.12.0.tgz",
+      "integrity": "sha1-ogCTVlbW9fa8TcdQLhrstwMihBY="
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -6831,6 +6932,11 @@
         "binary-extensions": "^1.0.0"
       }
     },
+    "is-bluebird": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-bluebird/-/is-bluebird-1.0.2.tgz",
+      "integrity": "sha1-CWQ5Bg9KpBGr7hkUOoTWpVNG1uI="
+    },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
@@ -6841,23 +6947,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
       "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w=="
-    },
-    "is-ci": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.0.tgz",
-      "integrity": "sha512-kDXyttuLeslKAHYL/K28F2YkM3x5jvFPEw3yXbRptXydjD9rpLEz+C5K5iutY9ZiUu6AP41JdvRQwF4Iqs4ZCQ==",
-      "dev": true,
-      "requires": {
-        "ci-info": "^3.1.1"
-      },
-      "dependencies": {
-        "ci-info": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.2.0.tgz",
-          "integrity": "sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==",
-          "dev": true
-        }
-      }
     },
     "is-core-module": {
       "version": "2.6.0",
@@ -6956,16 +7045,6 @@
       "resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz",
       "integrity": "sha1-bKiwe5nHeZgCWQDlVc7Y7YCHmoM="
     },
-    "is-installed-globally": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
-      "integrity": "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==",
-      "dev": true,
-      "requires": {
-        "global-dirs": "^3.0.0",
-        "is-path-inside": "^3.0.2"
-      }
-    },
     "is-integer": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.7.tgz",
@@ -6978,12 +7057,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
       "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w=="
-    },
-    "is-npm": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-5.0.0.tgz",
-      "integrity": "sha512-WW/rQLOazUq+ST/bCAVBp/2oMERWLsR7OrKyt052dNDk4DHcDE0/7QSXITlmi+VBcV13DfIbysG3tZJm5RfdBA==",
-      "dev": true
     },
     "is-number": {
       "version": "7.0.0",
@@ -7162,6 +7235,11 @@
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
       }
+    },
+    "javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha1-+eIwPUUH9tdDVac2ZNFED7Wg71k="
     },
     "jest": {
       "version": "27.2.1",
@@ -7463,6 +7541,12 @@
             "supports-color": "^7.1.0"
           }
         },
+        "ci-info": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.2.0.tgz",
+          "integrity": "sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==",
+          "dev": true
+        },
         "color-convert": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -7483,6 +7567,15 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
+        },
+        "is-ci": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.0.tgz",
+          "integrity": "sha512-kDXyttuLeslKAHYL/K28F2YkM3x5jvFPEw3yXbRptXydjD9rpLEz+C5K5iutY9ZiUu6AP41JdvRQwF4Iqs4ZCQ==",
+          "dev": true,
+          "requires": {
+            "ci-info": "^3.1.1"
+          }
         },
         "micromatch": {
           "version": "4.0.4",
@@ -8439,6 +8532,12 @@
             "supports-color": "^7.1.0"
           }
         },
+        "ci-info": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.2.0.tgz",
+          "integrity": "sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==",
+          "dev": true
+        },
         "color-convert": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -8460,6 +8559,15 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
+        "is-ci": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.0.tgz",
+          "integrity": "sha512-kDXyttuLeslKAHYL/K28F2YkM3x5jvFPEw3yXbRptXydjD9rpLEz+C5K5iutY9ZiUu6AP41JdvRQwF4Iqs4ZCQ==",
+          "dev": true,
+          "requires": {
+            "ci-info": "^3.1.1"
+          }
+        },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -8472,9 +8580,9 @@
       }
     },
     "jest-validate": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-27.2.0.tgz",
-      "integrity": "sha512-uIEZGkFKk3+4liA81Xu0maG5aGDyPLdp+4ed244c+Ql0k3aLWQYcMbaMLXOIFcb83LPHzYzqQ8hwNnIxTqfAGQ==",
+      "version": "27.2.2",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-27.2.2.tgz",
+      "integrity": "sha512-01mwTAs2kgDuX98Ua3Xhdhp5lXsLU4eyg6k56adTtrXnU/GbLd9uAsh5nc4MWVtUXMeNmHUyEiD4ibLqE8MuNw==",
       "dev": true,
       "requires": {
         "@jest/types": "^27.1.1",
@@ -8482,9 +8590,15 @@
         "chalk": "^4.0.0",
         "jest-get-type": "^27.0.6",
         "leven": "^3.1.0",
-        "pretty-format": "^27.2.0"
+        "pretty-format": "^27.2.2"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -8530,6 +8644,26 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
+        },
+        "pretty-format": {
+          "version": "27.2.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.2.2.tgz",
+          "integrity": "sha512-+DdLh+rtaElc2SQOE/YPH8k2g3Rf2OXWEpy06p8Szs3hdVSYD87QOOlYRHWAeb/59XTmeVmRKvDD0svHqf6ycA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.1.1",
+            "ansi-regex": "^5.0.1",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^17.0.1"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+              "dev": true
+            }
+          }
         },
         "supports-color": {
           "version": "7.2.0",
@@ -9313,6 +9447,28 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
           "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        }
+      }
+    },
+    "mathjs": {
+      "version": "5.10.3",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-5.10.3.tgz",
+      "integrity": "sha512-ySjg30BC3dYjQm73ILZtwcWzFJde0VU6otkXW/57IjjuYRa3Qaf0Kb8pydEuBZYtqW2OxreAtsricrAmOj3jIw==",
+      "requires": {
+        "complex.js": "2.0.11",
+        "decimal.js": "10.2.0",
+        "escape-latex": "1.2.0",
+        "fraction.js": "4.0.12",
+        "javascript-natural-sort": "0.7.1",
+        "seed-random": "2.2.0",
+        "tiny-emitter": "2.1.0",
+        "typed-function": "1.1.0"
+      },
+      "dependencies": {
+        "decimal.js": {
+          "version": "10.2.0",
+          "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.0.tgz",
+          "integrity": "sha512-vDPw+rDgn3bZe1+F/pyEwb1oMG2XTlRVgAa6B4KccTEpYgF8w6eQllVbQcfIJnZyvzFtFpxnpGtx8dd7DJp/Rw=="
         }
       }
     },
@@ -10873,6 +11029,14 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "optional": true
     },
+    "retry-as-promised": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-3.2.0.tgz",
+      "integrity": "sha512-CybGs60B7oYU/qSQ6kuaFmRd9sTZ6oXSc0toqePvV74Ac6/IFZSI1ReFQmtCN+uvW1Mtqdwpvt/LGOiCBAY2Mg==",
+      "requires": {
+        "any-promise": "^1.3.0"
+      }
+    },
     "reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -10980,6 +11144,11 @@
         "xmlchars": "^2.2.0"
       }
     },
+    "seed-random": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/seed-random/-/seed-random-2.2.0.tgz",
+      "integrity": "sha1-KpsZ4lCoFwmSMaW5mk2vgLf77VQ="
+    },
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -11033,6 +11202,63 @@
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         }
       }
+    },
+    "sequelize": {
+      "version": "5.22.4",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-5.22.4.tgz",
+      "integrity": "sha512-xFQQ38HPg7EyDRDA+NdzMSRWbo9m6Z/RxpjnkBl3ggyQG+jRrup48x0jaw4Ox42h56wFnXOBC2NZOkTJfZeWCw==",
+      "requires": {
+        "bluebird": "^3.5.0",
+        "cls-bluebird": "^2.1.0",
+        "debug": "^4.1.1",
+        "dottie": "^2.0.0",
+        "inflection": "1.12.0",
+        "lodash": "^4.17.15",
+        "moment": "^2.24.0",
+        "moment-timezone": "^0.5.21",
+        "retry-as-promised": "^3.2.0",
+        "semver": "^6.3.0",
+        "sequelize-pool": "^2.3.0",
+        "toposort-class": "^1.0.1",
+        "uuid": "^3.3.3",
+        "validator": "^10.11.0",
+        "wkx": "^0.4.8"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        },
+        "validator": {
+          "version": "10.11.0",
+          "resolved": "https://registry.npmjs.org/validator/-/validator-10.11.0.tgz",
+          "integrity": "sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw=="
+        }
+      }
+    },
+    "sequelize-pool": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/sequelize-pool/-/sequelize-pool-2.3.0.tgz",
+      "integrity": "sha512-Ibz08vnXvkZ8LJTiUOxRcj1Ckdn7qafNZ2t59jYHMX1VIebTAOYefWdRYFt6z6+hy52WGthAHAoLc9hvk3onqA=="
     },
     "serialize-error": {
       "version": "7.0.1",
@@ -11129,6 +11355,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+    },
+    "shimmer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
     },
     "signal-exit": {
       "version": "3.0.3",
@@ -12779,6 +13010,11 @@
         "xtend": "~4.0.1"
       }
     },
+    "tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -12853,6 +13089,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
       "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
+    },
+    "toposort-class": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
+      "integrity": "sha1-f/0feMi+KMO6Rc1OGj9e4ZO9mYg="
     },
     "touch": {
       "version": "3.1.0",
@@ -12941,6 +13182,11 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
       }
+    },
+    "typed-function": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-1.1.0.tgz",
+      "integrity": "sha512-TuQzwiT4DDg19beHam3E66oRXhyqlyfgjHB/5fcvsRXbfmWPJfto9B4a0TBdTrQAPGlGmXh/k7iUI+WsObgORA=="
     },
     "typedarray-to-buffer": {
       "version": "3.1.5",
@@ -13135,6 +13381,22 @@
           "requires": {
             "ci-info": "^2.0.0"
           }
+        },
+        "is-installed-globally": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
+          "integrity": "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==",
+          "dev": true,
+          "requires": {
+            "global-dirs": "^3.0.0",
+            "is-path-inside": "^3.0.2"
+          }
+        },
+        "is-npm": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-5.0.0.tgz",
+          "integrity": "sha512-WW/rQLOazUq+ST/bCAVBp/2oMERWLsR7OrKyt052dNDk4DHcDE0/7QSXITlmi+VBcV13DfIbysG3tZJm5RfdBA==",
+          "dev": true
         },
         "semver": {
           "version": "7.3.5",
@@ -13376,6 +13638,14 @@
         "triple-beam": "^1.2.0"
       }
     },
+    "wkx": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.4.8.tgz",
+      "integrity": "sha512-ikPXMM9IR/gy/LwiOSqWlSL3X/J5uk9EO2hHNRXS41eTLXaUFEVw9fn/593jW/tE5tedNg8YjT5HkCa4FqQZyQ==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -13505,6 +13775,14 @@
           "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.6.tgz",
           "integrity": "sha1-XWFr6KXmB9VOEUr65Vt+ry/MMkA="
         }
+      }
+    },
+    "xregexp": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.4.1.tgz",
+      "integrity": "sha512-2u9HwfadaJaY9zHtRRnH6BY6CQVNQKkYm3oLtC9gJXXzfsbACg5X5e4EZZGVAH+YIfa+QA9lsFQTTe3HURF3ag==",
+      "requires": {
+        "@babel/runtime-corejs3": "^7.12.1"
       }
     },
     "xss": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
+    "@asymmetrik/fhir-qb": "^0.12.5",
+    "@asymmetrik/fhir-qb-mongo": "^0.12.3",
     "@asymmetrik/node-fhir-server-core": "^2.2.3",
     "axios": "^0.21.2",
     "dotenv": "^10.0.0",

--- a/src/services/base.service.js
+++ b/src/services/base.service.js
@@ -28,7 +28,10 @@ const globalParameterDefinitions = {
   }
 };
 
-const qb = new QueryBuilder({ globalParameterDefinitions });
+const qb = new QueryBuilder({
+  globalParameterDefinitions,
+  implementationParameters: { archivedParamPath: '_isArchived' }
+});
 
 /**
  * creates an object and generates an id for it regardless of the id passed in
@@ -73,13 +76,15 @@ const baseSearchById = async (args, resourceType) => {
 };
 
 const baseSearch = async (args, context, resourceType) => {
-  console.log(context.req);
+  //console.log(context.req);
   const dataType = resolveSchema(args.base_version, resourceType.toLowerCase());
   const Bundle = resolveSchema(args.base_version, 'bundle');
   const BundleEntry = resolveSchema(args.base_version, 'bundleentry');
+  context.req.params = {};
   const filter = qb.buildSearchQuery(context);
-  console.log(filter);
+  console.log(JSON.stringify(filter));
   const results = await (await findResourcesWithFilter(filter, resourceType)).toArray();
+  console.log(results);
   const resultResources = results.map(result => new dataType(result));
   const entries = resultResources.map(resource => new BundleEntry({ resource: resource }));
   return new Bundle({ entry: entries });

--- a/src/services/base.service.js
+++ b/src/services/base.service.js
@@ -5,7 +5,7 @@ const {
   createResource,
   removeResource,
   updateResource,
-  findResourcesWithFilter
+  findResourcesWithAggregation
 } = require('../util/mongo.controller');
 const QueryBuilder = require('@asymmetrik/fhir-qb');
 
@@ -81,11 +81,12 @@ const baseSearch = async (args, context, resourceType) => {
   const Bundle = resolveSchema(args.base_version, 'bundle');
   const BundleEntry = resolveSchema(args.base_version, 'bundleentry');
   context.req.params = {};
+  context.includeArchived = true;
   const filter = qb.buildSearchQuery(context);
   console.log(JSON.stringify(filter));
-  const results = await (await findResourcesWithFilter(filter, resourceType)).toArray();
+  const results = (await (await findResourcesWithAggregation(filter.query, resourceType)).toArray())[0];
   console.log(results);
-  const resultResources = results.map(result => new dataType(result));
+  const resultResources = results.data.map(result => new dataType(result));
   const entries = resultResources.map(resource => new BundleEntry({ resource: resource }));
   return new Bundle({ entry: entries });
 };

--- a/src/services/base.service.js
+++ b/src/services/base.service.js
@@ -137,11 +137,11 @@ const baseSearch = async (args, { req }, resourceType, paramDefs = {}) => {
 
   // if the query builder was able to build a query actually execute it.
   if (filter.query) {
-    // grab the results from aggregation. has metadata about counts and data with resources
-    const results = (await (await findResourcesWithAggregation(filter.query, resourceType)).toArray())[0];
+    // grab the results from aggregation. has metadata about counts and data with resources in the first array position
+    const results = (await findResourcesWithAggregation(filter.query, resourceType))[0];
 
     // If this is undefined, there are no results.
-    if (results.metadata[0]) {
+    if (results && results.metadata[0]) {
       // create instances of each of the resulting resources
       const resultEntries = results.data.map(result => {
         return {

--- a/src/util/mongo.controller.js
+++ b/src/util/mongo.controller.js
@@ -73,9 +73,9 @@ const removeResource = async (id, resourceType) => {
   return collection.deleteOne({ id: id });
 };
 
-const findResourcesWithFilter = async (filter, resourceType) => {
+const findResourcesWithAggregation = async (query, resourceType) => {
   const collection = db.collection(resourceType);
-  return collection.find(filter);
+  return collection.aggregate(query);
 };
 
 module.exports = {
@@ -85,5 +85,5 @@ module.exports = {
   createResource,
   removeResource,
   updateResource,
-  findResourcesWithFilter
+  findResourcesWithAggregation
 };

--- a/src/util/mongo.controller.js
+++ b/src/util/mongo.controller.js
@@ -73,9 +73,15 @@ const removeResource = async (id, resourceType) => {
   return collection.deleteOne({ id: id });
 };
 
+/**
+ * Run an aggregation query on the database.
+ * @param {*[]} query Mongo aggregation pipeline array.
+ * @param {*} resourceType The resource type (collection) to aggregate on.
+ * @returns Array promise of results.
+ */
 const findResourcesWithAggregation = async (query, resourceType) => {
   const collection = db.collection(resourceType);
-  return collection.aggregate(query);
+  return (await collection.aggregate(query)).toArray();
 };
 
 module.exports = {

--- a/src/util/mongo.controller.js
+++ b/src/util/mongo.controller.js
@@ -73,11 +73,17 @@ const removeResource = async (id, resourceType) => {
   return collection.deleteOne({ id: id });
 };
 
+const findResourcesWithFilter = async (filter, resourceType) => {
+  const collection = db.collection(resourceType);
+  return collection.find(filter);
+};
+
 module.exports = {
   findResourcesWithQuery,
   findResourceById,
   findOneResourceWithQuery,
   createResource,
   removeResource,
-  updateResource
+  updateResource,
+  findResourcesWithFilter
 };


### PR DESCRIPTION
# Summary
Base search implementation that uses Asymmetrik's fhir-qb to build the mongo queries. 

## New behavior
Implements basic search parameters. `_id`, `_lastUpdated`, `_tag`, `_profile`, `_security`, `identifier` for all resources. Provides a way for services to use the base search functionality with resource specific parameter definitions. Measure service uses this to provide searching on `name` and `version`.

## Code changes
- Added baseSearch implementation to the base service.
- Added mongo controller capability to run aggregation query.
- Replaced Measure service search with a call to use the baseSearch with additional parameter definitions provided.

# Testing guidance
Load EXM130 bundle into the server. Run searching queries from the testing guidance in #12. 

Make sure some of the following url's return results in the search set.
```
http://localhost:3000/4_0_0/Patient?_profile=http%3A%2F%2Fhl7.org%2Ffhir%2Fus%2Fcore%2FStructureDefinition%2Fus-core-patient
```
```
http://localhost:3000/4_0_0/Measure?_id=measure-EXM130-7.3.000
```
```
http://localhost:3000/4_0_0/Patient
```

Make sure these don't return results.
```
http://localhost:3000/4_0_0/Measure?_id=measure-EXM69-4.2.000
```
```
http://localhost:3000/4_0_0/Measure?name=EXM000
```

Test with other parameters that are not supported (ex. `publisher`). You should get 400 errors stating so.