### PR TITLE
Use ModelInfo to Query for Patient References

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3047,48 +3047,6 @@
         "@babel/helper-define-polyfill-provider": "^0.2.2"
       }
     },
-    "babel-plugin-dynamic-import-node": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
-      "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
-      "requires": {
-        "object.assign": "^4.1.0"
-      }
-    },
-    "babel-plugin-polyfill-corejs2": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.2.2.tgz",
-      "integrity": "sha512-kISrENsJ0z5dNPq5eRvcctITNHYXWOA4DUZRFYCz3jYCcvTb/A546LIddmoGNMVYg2U38OyFeNosQwI9ENTqIQ==",
-      "requires": {
-        "@babel/compat-data": "^7.13.11",
-        "@babel/helper-define-polyfill-provider": "^0.2.2",
-        "semver": "^6.1.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-        }
-      }
-    },
-    "babel-plugin-polyfill-corejs3": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.2.4.tgz",
-      "integrity": "sha512-z3HnJE5TY/j4EFEa/qpQMSbcUJZ5JQi+3UFjXzn6pQCmIKc5Ug5j98SuYyH+m4xQnvKlMDIW4plLfgyVnd0IcQ==",
-      "requires": {
-        "@babel/helper-define-polyfill-provider": "^0.2.2",
-        "core-js-compat": "^3.14.0"
-      }
-    },
-    "babel-plugin-polyfill-regenerator": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.2.2.tgz",
-      "integrity": "sha512-Goy5ghsc21HgPDFtzRkSirpZVW35meGoTmTOb2bxqdl60ghub4xOidgNTHaZfQ2FaxQsKmwvXtOAkcIS4SMBWg==",
-      "requires": {
-        "@babel/helper-define-polyfill-provider": "^0.2.2"
-      }
-    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -4935,12 +4893,6 @@
       "version": "1.14.3",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.3.tgz",
       "integrity": "sha512-3MkHxknWMUtb23apkgz/83fDoe+y+qr0TdgacGIA7bew+QLBo3vdgEN2xEsuXNivpFy4CyDhBBZnNZOtalmenw=="
-    },
-    "for-in": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-      "optional": true
     },
     "for-in": {
       "version": "1.0.2",

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -198,7 +198,11 @@ const evaluateMeasure = async (args, { req }) => {
   }
 
   const patientBundle = await getPatientDataBundle(subject, dataReq.results.dataRequirement);
-
+  console.log('patientBundle from getPatientDataBundle:');
+  patientBundle.entry.forEach(b => {
+    console.log(b);
+  });
+  //console.log(patientBundle);
   const { results } = await Calculator.calculateMeasureReports(measureBundle, [patientBundle], {
     measurementPeriodStart: periodStart,
     measurementPeriodEnd: periodEnd

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -198,11 +198,7 @@ const evaluateMeasure = async (args, { req }) => {
   }
 
   const patientBundle = await getPatientDataBundle(subject, dataReq.results.dataRequirement);
-  console.log('patientBundle from getPatientDataBundle:');
-  patientBundle.entry.forEach(b => {
-    console.log(b);
-  });
-  //console.log(patientBundle);
+
   const { results } = await Calculator.calculateMeasureReports(measureBundle, [patientBundle], {
     measurementPeriodStart: periodStart,
     measurementPeriodEnd: periodEnd


### PR DESCRIPTION
# Summary
The `getPatientDataBundle()` function was updated to dynamically query for patient references instead of being hardcoded to look for the subject.

## New behavior
We now have an object obtained by parsing the ModelInfo that tells us how all the different `resourceTypes` reference the patient. Using this, we can now dynamically query for the patient references in a bundle. The object allows us to obtain the appropriate keys to query for a reference with. This affects the `patientBundle` object that we then pass into the Calculator functions from `fqm-execution`.

## Code changes
A `const` was added to store the results obtained by the ModelInfo. The `getPatientDataBundle()` function was updated within the `.map()` on the `requiredTypes` array. Previously, a hardcoded query was used with `subject.reference`. Now, we start by instantiating an array of queries with `subject.reference` because the ModelInfo is incorrect in that it does not map the `subject` attribute to all the types that it should. For example, `subject` does not appear for `Encounter` or `Procedure` in the results of the ModelInfo script. Then, for each resourceType in our bundle, all the possible queries are pushed onto `allQueries`, and then `findResourcesWithQuery()` is called using  an `$or` query. 

**Note: In the future, we should change this approach because of the flaws in ModelInfo. Based on our dev hour discussion on 9/23, it may make more sense to parse through the [Compartmentdefinition](http://hl7.org/fhir/R4/compartmentdefinition-patient.json.html) for the search params instead of parsing for the attributes in ModelInfo.**

# Testing guidance
Unit testing does not yet exist for `deqm-test-server`.

We should test that the previous functionality is unchanged, and that the added functionality works. First,

- Add a `console.log` statement in `measure.service.js` within `evaluateMeasure()` that console.log's the `patientBundle` entries so we can see what gets picked up in the queries. This can be achieved by adding:
```
patientBundle.entry.forEach(b => {
    console.log(b);
  });
```
This should be added under the creation of the `patientBundle` object.
- Start up the test server and POST the EXM130 bundle to http://localhost:3000/4_0_0/
- Send a GET request to http://localhost:3000/4_0_0/Measure/measure-EXM130-7.3.000/$evaluate-measure?subject=numer-EXM130&periodStart=2019-01-01&periodEnd=2019-12-31
- In the terminal, you should see the following output:
```
{
  resource: {
    _id: new ObjectId("614dc6616c5631ce6c0a7fd2"),
    id: 'denom-EXM130-2',
    code: { coding: [Array] },
    meta: { profile: [Array] },
    performedPeriod: { start: '2009-12-30T12:00:00', end: '2009-12-30T13:00:00' },
    resourceType: 'Procedure',
    status: 'completed',
    subject: { reference: 'Patient/numer-EXM130' }
  }
}
{
  resource: {
    _id: new ObjectId("614dc6616c5631ce6c0a7fdc"),
    id: 'denom-EXM130-1',
    class: {
      system: 'http://terminology.hl7.org/CodeSystem/v3-ActCode',
      code: 'AMB',
      display: 'ambulatory'
    },
    meta: { profile: [Array] },
    period: {
      start: '2019-05-30T00:00:00-00:00',
      end: '2019-05-31T00:00:00-00:00'
    },
    resourceType: 'Encounter',
    status: 'finished',
    subject: { reference: 'Patient/numer-EXM130' },
    type: [ [Object] ]
  }
}
{
  resource: {
    _id: new ObjectId("614dc6616c5631ce6c0a7fcb"),
    id: 'numer-EXM130',
    birthDate: '1965-01-01',
    extension: [ [Object], [Object] ],
    gender: 'male',
    identifier: [ [Object] ],
    meta: { profile: [Array] },
    name: [ [Object] ],
    resourceType: 'Patient'
  }
}
```
This should appear because we have an entry for a Procedure and Encounter that both use `subject.reference`, and we also push the Patient resource in `getPatientDataBundle()`. If this works, then the previous functionality is unchanged. This can also be similarly tested with care gaps.

Next, to check the dynamic features of `getPatientDataBundle()`, 
- Based on `patient-references.json`, we can see that `actor` is a valid attribute for Procedure (although this doesn't seem to actually be true based on `Compartmentdefinition`, but let's pretend this is correct for now).
- In the EXM130 bundle, change `subject.reference` to `actor.reference` for the Procedure for the numerator EXM130 patient.
- Delete and reset the database.
- Send the same POST and GET request as above.
- The following output should be:
```
{
  resource: {
    _id: new ObjectId("614dcd1b6c5631ce6c0a9903"),
    id: 'numer-EXM130-1',
    actor: { reference: 'Patient/numer-EXM130' },
    code: { coding: [Array] },
    meta: { profile: [Array] },
    performedPeriod: {
      start: '2010-01-01T00:00:00-06:00',
      end: '2010-01-01T01:00:00-07:00'
    },
    resourceType: 'Procedure',
    status: 'completed'
  }
}
{
  resource: {
    _id: new ObjectId("614dcd1b6c5631ce6c0a98be"),
    id: 'numer-EXM130-4',
    class: {
      system: 'http://terminology.hl7.org/CodeSystem/v3-ActCode',
      code: 'AMB',
      display: 'ambulatory'
    },
    meta: { profile: [Array] },
    period: { start: '2019-05-30T00:00:00.0', end: '2019-05-31T00:00:00.0' },
    resourceType: 'Encounter',
    status: 'finished',
    subject: { reference: 'Patient/numer-EXM130' },
    type: [ [Object] ]
  }
}
{
  resource: {
    _id: new ObjectId("614dcd1b6c5631ce6c0a9900"),
    id: 'numer-EXM130',
    birthDate: '1965-01-01',
    extension: [ [Object], [Object] ],
    gender: 'male',
    identifier: [ [Object] ],
    meta: { profile: [Array] },
    name: [ [Object] ],
    resourceType: 'Patient'
  }
}
```
Now, we can see that `actor.reference` was found, and we have the Encounter and Patient resources as well.

- Remove the reference completely for the numerator EXM130 Procedure, and check that the resulting patient bundle only contains the Encounter and Patient resources, and not the Procedure resources. 
- This functionality can also be tested with care gaps and with changing different attributes for the references.

