### PR TITLE
Check for "prefer": 'respond-async' in submit-data

### DIFF
--- a/src/services/base.service.js
+++ b/src/services/base.service.js
@@ -124,7 +124,7 @@ const baseSearch = async (args, { req }, resourceType) => {
 
 /**
  * checks if the headers are incorrect and throws and error with guidance if so
- * @param {*} requestBody the body of the request
+ * @param {*} requestHeaders the headers from the request body
  */
 const checkHeaders = requestHeaders => {
   if (

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -155,11 +155,11 @@ const submitData = async (args, { req }) => {
 const bulkImport = async (args, { req }) => {
   logger.info('Measure >>> $bulk-import');
   throw new ServerError(null, {
-    statusCode: 400,
+    statusCode: 501,
     issue: [
       {
         severity: 'error',
-        code: 'BadRequest',
+        code: 'NotImplemented',
         details: {
           text: `bulkImport has not been implemented yet`
         }

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -111,10 +111,13 @@ const submitData = async (args, { req }) => {
       ]
     });
   }
+  // check if we want to do a bulk import
+  if (req.headers['prefer'] === 'respond-async') {
+    return await bulkImport(args, { req });
+  }
   const { base_version: baseVersion } = req.params;
   const tb = createTransactionBundleClass(baseVersion);
   const parameters = req.body.parameter;
-
   // Ensure exactly 1 measureReport is in parameters
   const numMeasureReportsInput = parameters.filter(param => param.name === 'measureReport').length;
   if (numMeasureReportsInput !== 1) {
@@ -141,6 +144,28 @@ const submitData = async (args, { req }) => {
   req.body = tb.toJSON();
   const output = await uploadTransactionBundle(req, req.res);
   return output;
+};
+
+/**
+ *
+ * @param {*} args the args object passed in by the user
+ * @param {*} req the request object passed in by the user
+ */
+// eslint-disable-next-line no-unused-vars
+const bulkImport = async (args, { req }) => {
+  logger.info('Measure >>> $bulk-import');
+  throw new ServerError(null, {
+    statusCode: 400,
+    issue: [
+      {
+        severity: 'error',
+        code: 'BadRequest',
+        details: {
+          text: `bulkImport not implemented yet`
+        }
+      }
+    ]
+  });
 };
 
 /**

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -147,7 +147,7 @@ const submitData = async (args, { req }) => {
 };
 
 /**
- *
+ * TO-DO: add bulk import functionality
  * @param {*} args the args object passed in by the user
  * @param {*} req the request object passed in by the user
  */
@@ -161,7 +161,7 @@ const bulkImport = async (args, { req }) => {
         severity: 'error',
         code: 'BadRequest',
         details: {
-          text: `bulkImport not implemented yet`
+          text: `bulkImport has not been implemented yet`
         }
       }
     ]


### PR DESCRIPTION
# Summary
Our submit-data operation has been updated to recognize when the `”prefer”: ‘respond-async’”` request header is present and make a call to `bulkImport` if it is present.

## New behavior
If the request header includes `”prefer”: ‘respond-async’”` , the submit-data operation calls the `bulkImport` function (which has not yet been implemented). If `”prefer”: ‘respond-async’”` is not present, the standard submit-data flow remains the same with creating and uploading a transaction bundle.

## Code changes
Within `submit-data`, we now check if the `”prefer”: ‘respond-async’”` header is present. If so, we call `bulkImport`, which throws a `ServerError` - we are not implementing the operation in this PR. We are just getting things set up to call functions depending on what headers are present.

# Testing guidance
* Get the test server running with `npm start`. 
* Create a valid FHIR parameters object, or use an [existing one](https://www.hl7.org/fhir/measure-operation-submit-data.html). 
* Submit the body in a POST request to `http://localhost:3000/4_0_0/Measure/$submit-data` without the `prefer` header, and check that the `submit-data` functionality is unchanged. Check out [this PR](https://github.com/projecttacoma/deqm-test-server/pull/7) for more information on `submit-data`. 
* Submit the body in a POST request to `http://localhost:3000/4_0_0/Measure/$submit-data`  with the `”prefer”: ‘respond-async’”` header and check that the `ServerError` is thrown. 
