### PR TITLE
Status location

### DIFF
--- a/src/server/server.js
+++ b/src/server/server.js
@@ -1,10 +1,15 @@
 const { Server } = require('@asymmetrik/node-fhir-server-core');
 const configTransaction = require('../services/bundle.controller');
+const configBulkStatus = require('../services/bulkstatus.controller');
 
 class DEQMServer extends Server {
   enableTransactionRoute() {
     this.app.post('/:base_version/', configTransaction.transaction);
     // return self for chaining
+    return this;
+  }
+  enableBulkStatusRoute() {
+    this.app.get('/:base_version/bulkstatus/:client_id', configBulkStatus.bulkstatus);
     return this;
   }
 }
@@ -17,6 +22,7 @@ function initialize(config, app) {
     .configurePassport()
     .setPublicDirectory()
     .enableTransactionRoute()
+    .enableBulkStatusRoute()
     .setProfileRoutes()
     .setErrorRoutes();
 }

--- a/src/services/bulkstatus.controller.js
+++ b/src/services/bulkstatus.controller.js
@@ -1,0 +1,12 @@
+const service = require('./bulkstatus.service.js');
+
+/**
+ * @name exports
+ * @summary bulkstatus controller
+ */
+module.exports.bulkstatus = (req, res, next) => {
+  return service
+    .checkBulkStatus(req, res)
+    .then(result => res.status(200).json(result))
+    .catch(err => next(err));
+};

--- a/src/services/bulkstatus.service.js
+++ b/src/services/bulkstatus.service.js
@@ -1,0 +1,19 @@
+const { ServerError } = require('@asymmetrik/node-fhir-server-core');
+
+// eslint-disable-next-line no-unused-vars
+async function checkBulkStatus(req, res) {
+  throw new ServerError(null, {
+    statusCode: 501,
+    issue: [
+      {
+        severity: 'error',
+        code: 'NotImplemented',
+        details: {
+          text: `bulkImport has not been implemented yet`
+        }
+      }
+    ]
+  });
+}
+
+module.exports = { checkBulkStatus };

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -141,13 +141,12 @@ const submitData = async (args, { req }) => {
 };
 
 /**
- * TODO: implement bulk import stuff
+ * "TO-DO: add bulk import funtionality" (sic)
  * @param {*} args the args object passed in by the user
  * @param {*} req the request object passed in by the user
  */
 // eslint-disable-next-line no-unused-vars
 const bulkImport = async (args, { req }) => {
-  logger.info('Measure >>> $bulk-import');
   const res = req.res;
   logger.info('Measure >>> $bulk-import');
   res.status(202);

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -147,6 +147,7 @@ const submitData = async (args, { req }) => {
  */
 // eslint-disable-next-line no-unused-vars
 const bulkImport = async (args, { req }) => {
+  logger.info('Measure >>> $bulk-import');
   const res = req.res;
   logger.info('Measure >>> $bulk-import');
   res.status(202);

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -109,7 +109,7 @@ const submitData = async (args, { req }) => {
   if (req.headers['prefer'] === 'respond-async') {
     return await bulkImport(args, { req });
   }
-  const { base_version: baseVersion } = req;
+  const { base_version: baseVersion } = req.params;
   const tb = createTransactionBundleClass(baseVersion);
   const parameters = req.body.parameter;
   // Ensure exactly 1 measureReport is in parameters

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -109,7 +109,7 @@ const submitData = async (args, { req }) => {
   if (req.headers['prefer'] === 'respond-async') {
     return await bulkImport(args, { req });
   }
-  const { base_version: baseVersion } = req.params;
+  const { base_version: baseVersion } = req;
   const tb = createTransactionBundleClass(baseVersion);
   const parameters = req.body.parameter;
   // Ensure exactly 1 measureReport is in parameters
@@ -141,25 +141,20 @@ const submitData = async (args, { req }) => {
 };
 
 /**
- * TO-DO: add bulk import functionality
+ * TODO: implement bulk import stuff
  * @param {*} args the args object passed in by the user
  * @param {*} req the request object passed in by the user
  */
 // eslint-disable-next-line no-unused-vars
 const bulkImport = async (args, { req }) => {
+  const res = req.res;
   logger.info('Measure >>> $bulk-import');
-  throw new ServerError(null, {
-    statusCode: 501,
-    issue: [
-      {
-        severity: 'error',
-        code: 'NotImplemented',
-        details: {
-          text: `bulkImport has not been implemented yet`
-        }
-      }
-    ]
-  });
+  res.status(202);
+  res.setHeader('Content-Location', 'EXAMPLE-LOCATION');
+  //Temporary solution. Asymmetrik automatically rewrites this to a 200.
+  //Rewriting the res.status method prevents the code from being overwritten.
+  //TODO: change this once we fork asymmetrik
+  res.status = () => res;
 };
 
 /**

--- a/src/util/config.js
+++ b/src/util/config.js
@@ -3,7 +3,6 @@ const { VERSIONS } = constants;
 const supportedResources = require('./supportedResources');
 const { buildServiceModule } = require('../services/base.service');
 const path = require('path');
-//const configTransaction = require('../services/bundle.controller');
 
 /**
  * Build configuration object to pass to the Asymmetrik core FHIR server

--- a/src/util/config.js
+++ b/src/util/config.js
@@ -3,7 +3,7 @@ const { VERSIONS } = constants;
 const supportedResources = require('./supportedResources');
 const { buildServiceModule } = require('../services/base.service');
 const path = require('path');
-const configTransaction = require('../services/bundle.controller');
+//const configTransaction = require('../services/bundle.controller');
 
 /**
  * Build configuration object to pass to the Asymmetrik core FHIR server
@@ -12,18 +12,7 @@ const configTransaction = require('../services/bundle.controller');
  */
 const buildConfig = () => {
   const config = {
-    profiles: {},
-    routes: [
-      {
-        type: 'post',
-        path: '/:base_version/',
-        corsOptions: {
-          methods: ['POST']
-        },
-        args: [],
-        controller: configTransaction.transaction
-      }
-    ]
+    profiles: {}
   };
   supportedResources.forEach(resourceType => {
     switch (resourceType) {


### PR DESCRIPTION
# Summary
Deqm-test-server now responds with a 202 status code and a content location header when sent a submit-data request with the prefer header set to respond-async.

## New behavior
When sending a submit-data request with the prefer header set to 'respond-async', a barebones bulk data import function is now called which returns a 202 status code and a (hard-coded for now) content location to query for import status updates. The user can now send follow-up get requests to that endpoint and receive a 501 NotImplemented error.

## Code changes
- Implemented a bulkImport function that returns a 202 status code and a content-location header
- Added a bulkstatus controller which manages the flow of bulk data import status requests.
- Exposed a /bulkstatus/:id endpoint which can receive requests for bulk import status updates, but for now just returns a 501 NotImplemented error. 

# Testing guidance
- check out Sarah's recent PR for information on how to send bulkImport requests [here](https://github.com/projecttacoma/deqm-test-server/pull/18).
- Send a bulkImport request and ensure that the response code is a `202` and that the headers contain a contain a `Content-Location` field which is set to `EXAMPLE-LOCATION`.
- Send a `GET` request to `http://localhost:3000/4_0_0/bulkstatus/EXAMPLE-LOCATION` and ensure you receive a 501 NotImplemented error.
- If you have input on how to avoid the hijinks I pull on line 162 of measure.service.js to get Asymmetrik not to overwrite the status code, please let me know

