### PR TITLE
Docker auto build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 node_modules
+.vscode

--- a/.github/workflows/docker_hub_build.yml
+++ b/.github/workflows/docker_hub_build.yml
@@ -1,0 +1,45 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - 'main'
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            tacoma/fqm-execution-service
+          flavor: |
+            latest=${{ github.ref == 'refs/heads/master' }}
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=ref,event=branch,pattern=latest
+            type=semver,pattern=release-latest
+            type=semver,pattern={{raw}}
+            type=semver,pattern=v{{major}}-latest
+            type=semver,pattern=v{{major}}.{{minor}}-latest
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker_hub_build.yml
+++ b/.github/workflows/docker_hub_build.yml
@@ -1,4 +1,4 @@
-name: ci
+name: Docker Build
 
 on:
   push:
@@ -19,9 +19,9 @@ jobs:
         with:
           # list of Docker images to use as base name for tags
           images: |
-            tacoma/fqm-execution-service
+            tacoma/deqm-test-server
           flavor: |
-            latest=${{ github.ref == 'refs/heads/master' }}
+            latest=${{ github.ref == 'refs/heads/main' }}
           # generate Docker tags based on the following events/attributes
           tags: |
             type=ref,event=branch,pattern=latest

--- a/.github/workflows/docker_hub_build.yml
+++ b/.github/workflows/docker_hub_build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'dockerignore'
     tags:
       - 'v*.*.*'
 

--- a/.github/workflows/docker_hub_build.yml
+++ b/.github/workflows/docker_hub_build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 'main'
-      - 'dockerignore'
     tags:
       - 'v*.*.*'
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .vscode/
+connectathon


### PR DESCRIPTION
# Summary
Added a docker_hub_build file that publishes a new version to docker each time a branch is merged into main. Also updated .dockerignore to ignore the .vscode directory

## New behavior
- A new tag should be added to the deqm-test-server docker image each time a branch is merged into main.
- The docker images now should not include the .vscode directory

## Code changes
- Added file .github/workflow/docker_hub_build.yml
- Added .vscode to .gitignore

# Testing guidance
This one is tricky to test since the functionality depends on pushing to main. I recommend pulling this branch and adding `- 'dockerignore'` inside `on.push.branches` in .github/workflows/docker_hub_build.yml, then committing and pushing the changes to this branch. Then, immediately delete this line from docker_hub_build.yml, commit and push again. Navigate to the [deqm-test-server docker image](https://hub.docker.com/r/tacoma/deqm-test-server/tags?page=1&ordering=last_updated) and ensure a new tag called 'dockerignore' has been published 'a few seconds ago'. If so, the autobuild is working correctly and the branch should be in exactly the same position as before. 

