### PR TITLE
Connectathon script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .vscode/
+connectathon

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "db:setup": "node src/scripts/createCollections.js",
     "db:delete": "node src/scripts/deleteCollections.js",
     "db:reset": "npm run db:delete && npm run db:setup",
-    "parse-references": "node src/scripts/parseModelInfo.js"
+    "parse-references": "node src/scripts/parseModelInfo.js",
+    "connectathon-upload": "node src/scripts/getConnectathonBundles.js"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/src/scripts/getConnectathonBundles.js
+++ b/src/scripts/getConnectathonBundles.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const path = require('path');
+
+const connectathonPath = path.resolve(path.join(__dirname, '../../connectathon/fhir401/bundles/measure/'));
+
+/**
+ * Sends POST requests to the transaction bundle endpoint for every measure in the
+ * connectathon repo.
+ *
+ * TODO: Currently configured for fhir401 connectathon measure bundles,
+ * but may want to expand to other measure bundle providers in the future.
+ */
+async function main() {
+  console.log('hey');
+  console.log(connectathonPath);
+  // first try to just parse through the repo and get the measure bundle for each bundle
+  fs.readdir(connectathonPath, function (err, subDirs) {
+    if (err) {
+      console.error('could not access directories within connectathon repo');
+    }
+
+    subDirs.forEach(dir => {
+      // this works
+      console.log(dir);
+    });
+  });
+}
+
+main()
+  .catch(console.error)
+  .catch(e => {
+    console.error(e);
+  });
+//.finally(() => mongoUtil.client.close());

--- a/src/scripts/getConnectathonBundles.js
+++ b/src/scripts/getConnectathonBundles.js
@@ -1,34 +1,68 @@
 const fs = require('fs');
 const path = require('path');
+const mongoUtil = require('../util/mongo');
+const { createResource } = require('../util/mongo.controller');
 
 const connectathonPath = path.resolve(path.join(__dirname, '../../connectathon/fhir401/bundles/measure/'));
+// bundles that are not the latest available version
+const IGNORED_BUNDLES = ['EXM347-3.2.000-bundle.json'];
+// files containing EXM bundles of interest from connectathon repo
+const bundleFiles = [];
 
 /**
- * Sends POST requests to the transaction bundle endpoint for every measure in the
- * connectathon repo.
+ * Retrieves EXM bundle files from the connectathon repo using a regular expression.
+ * Uses recursion to parse through all available subdirectories.
+ * @param {string} directory - directory path to start at
+ * @returns array of string paths that represent the bundle files of interest
+ */
+const getBundleFiles = directory => {
+  const fileNameRegExp = new RegExp(/(^EXM.*.json$)/);
+  const filesInDirectory = fs.readdirSync(directory);
+  filesInDirectory.forEach(file => {
+    const absolute = path.join(directory, file);
+    if (fs.statSync(absolute).isDirectory()) {
+      getBundleFiles(absolute);
+    } else if (fileNameRegExp.test(file) && !IGNORED_BUNDLES.includes(file)) {
+      bundleFiles.push(absolute);
+    }
+  });
+  return bundleFiles;
+};
+
+/**
+ * Uploads all the resources from the connectathon measure bundles into the
+ * database.
  *
  * TODO: Currently configured for fhir401 connectathon measure bundles,
  * but may want to expand to other measure bundle providers in the future.
  */
 async function main() {
-  console.log('hey');
-  console.log(connectathonPath);
-  // first try to just parse through the repo and get the measure bundle for each bundle
-  fs.readdir(connectathonPath, function (err, subDirs) {
-    if (err) {
-      console.error('could not access directories within connectathon repo');
-    }
+  const bundleFiles = getBundleFiles(connectathonPath);
 
-    subDirs.forEach(dir => {
-      // this works
-      console.log(dir);
-    });
+  await mongoUtil.client.connect();
+  console.log('Connected successfully to server');
+
+  const bundlePromises = bundleFiles.map(async filePath => {
+    // read each EXM bundle file
+    const data = fs.readFileSync(filePath, 'utf8');
+    if (data) {
+      const bundle = await JSON.parse(data);
+      // retrieve each resource and insert into database
+      const uploads = bundle.entry.map(async res => {
+        try {
+          await createResource(res.resource, res.resource.resourceType);
+        } catch (e) {
+          console.log(e.message);
+        }
+      });
+      await Promise.all(uploads);
+    }
   });
+  await Promise.all(bundlePromises);
+  return 'Connectathon bundle entries uploaded.';
 }
 
 main()
+  .then(console.log)
   .catch(console.error)
-  .catch(e => {
-    console.error(e);
-  });
-//.finally(() => mongoUtil.client.close());
+  .finally(async () => await mongoUtil.client.close());

--- a/src/scripts/getConnectathonBundles.js
+++ b/src/scripts/getConnectathonBundles.js
@@ -26,7 +26,6 @@ const getBundleFiles = directory => {
       bundleFiles.push(absolute);
     }
   });
-  return bundleFiles;
 };
 
 /**
@@ -37,7 +36,7 @@ const getBundleFiles = directory => {
  * but may want to expand to other measure bundle providers in the future.
  */
 async function main() {
-  const bundleFiles = getBundleFiles(connectathonPath);
+  getBundleFiles(connectathonPath);
 
   await mongoUtil.client.connect();
   console.log('Connected successfully to server');
@@ -46,7 +45,7 @@ async function main() {
     // read each EXM bundle file
     const data = fs.readFileSync(filePath, 'utf8');
     if (data) {
-      const bundle = await JSON.parse(data);
+      const bundle = JSON.parse(data);
       // retrieve each resource and insert into database
       const uploads = bundle.entry.map(async res => {
         try {

--- a/src/scripts/getConnectathonBundles.js
+++ b/src/scripts/getConnectathonBundles.js
@@ -58,7 +58,7 @@ async function main() {
           await createResource(res.resource, res.resource.resourceType);
         } catch (e) {
           // ignore duplicate key errors for Libraries, ValueSets
-          if (res.resource.resourceType === 'Measure') {
+          if (e.code !== 11000 || res.resource.resourceType === 'Measure') {
             console.log(e.message);
           }
         }


### PR DESCRIPTION
# Summary
A new script was created that inserts the measure bundles from the Connectathon repository into our MongoDB database.

## New behavior
We can now insert all the measure bundles from the Connectathon repository into our database, which we can utilize in future tasks.

## Code changes
The `package.json` file was updated so that we can now use the command `npm run connectathon-upload` to run the `getConnectathonBundles.js` script. This script makes use of a gitignored connectathon repository and retrieves all the EXM bundle `JSON` files using the `getBundleFiles` function. Then, the script connects to the database, parses through each bundle file, and uploads the bundles’ resources to the appropriate collections using the `createResource` function from the mongo controller. 


# Testing guidance
`Git clone` the `connectathon` repository into the root directory of the `deqm-test-server` repository. Then, run `npm run connectathon-upload`, which will upload all the resources from the EXM bundles into the `deqm-test-server` database. Use Robo 3T to check that the appropriate collections (Patient, Encounter, ValueSet, Condition, etc.) are now populated. Note that some of the bundles make use of the same ValueSets and Libraries, so you should run into duplicate key errors in the terminal. 
