### PR TITLE
added param/error handling for evaluate-measure

### DIFF
--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -3,7 +3,8 @@ const { Calculator } = require('fqm-execution');
 const { baseCreate, baseSearchById, baseRemove, baseUpdate, baseSearch } = require('./base.service');
 const { createTransactionBundleClass } = require('../resources/transactionBundle');
 const { uploadTransactionBundle } = require('./bundle.service');
-const { getMeasureBundleFromId, getPatientDataBundle, validateEvalMeasureParams } = require('../util/bundleUtils');
+const { validateEvalMeasureParams } = require('../util/measureOperationsUtils');
+const { getMeasureBundleFromId, getPatientDataBundle } = require('../util/bundleUtils');
 
 const logger = loggers.get('default');
 /**

--- a/src/util/bundleUtils.js
+++ b/src/util/bundleUtils.js
@@ -266,9 +266,73 @@ function replaceReferences(entries) {
   return newEntries;
 }
 
+/**
+ * Checks that the parameters input to $evaluate-measure are valid. Throws a ServerError
+ * for missing parameters, the use of unsupported parameters, and the use of unsuppported
+ * report types.
+ * @param {Object} req http request object
+ */
+function validateEvalMeasureParams(req) {
+  const REQUIRED_PARAMS = ['periodStart', 'periodEnd', 'subject'];
+  const UNSUPPORTED_PARAMS = ['measure', 'practitioner', 'lastReceivedOn'];
+
+  const missingParams = REQUIRED_PARAMS.filter(key => !req.query[key]);
+  const includedUnsupportedParams = UNSUPPORTED_PARAMS.filter(key => req.query[key]);
+
+  // returns all required params that are missing in the http request
+  if (missingParams.length > 0) {
+    throw new ServerError(null, {
+      statusCode: 400,
+      issue: [
+        {
+          severity: 'error',
+          code: 'BadRequest',
+          details: {
+            text: `Missing required parameters: ${missingParams.join(', ')} for $evaluate-measure`
+          }
+        }
+      ]
+    });
+  }
+  // returns all unsupported params that are included in the http request
+  if (includedUnsupportedParams.length > 0) {
+    throw new ServerError(null, {
+      statusCode: 400,
+      issue: [
+        {
+          severity: 'error',
+          code: 'BadRequest',
+          details: {
+            text: `The following parameters were included and are not supported for $evaluate-measure: ${includedUnsupportedParams.join(
+              ', '
+            )}`
+          }
+        }
+      ]
+    });
+  }
+
+  // returns unsupported report type that is included in the http request
+  if (!['individual', 'summary', undefined].includes(req.query.reportType)) {
+    throw new ServerError(null, {
+      statusCode: 400,
+      issue: [
+        {
+          severity: 'error',
+          code: 'BadRequest',
+          details: {
+            text: `reportType ${req.query.reportType} not supported for $evaluate-measure`
+          }
+        }
+      ]
+    });
+  }
+}
+
 module.exports = {
   mapArrayToSearchSetBundle,
   getMeasureBundleFromId,
   replaceReferences,
-  getPatientDataBundle
+  getPatientDataBundle,
+  validateEvalMeasureParams
 };

--- a/src/util/bundleUtils.js
+++ b/src/util/bundleUtils.js
@@ -266,73 +266,9 @@ function replaceReferences(entries) {
   return newEntries;
 }
 
-/**
- * Checks that the parameters input to $evaluate-measure are valid. Throws a ServerError
- * for missing parameters, the use of unsupported parameters, and the use of unsuppported
- * report types.
- * @param {Object} req http request object
- */
-function validateEvalMeasureParams(req) {
-  const REQUIRED_PARAMS = ['periodStart', 'periodEnd', 'subject'];
-  const UNSUPPORTED_PARAMS = ['measure', 'practitioner', 'lastReceivedOn'];
-
-  const missingParams = REQUIRED_PARAMS.filter(key => !req.query[key]);
-  const includedUnsupportedParams = UNSUPPORTED_PARAMS.filter(key => req.query[key]);
-
-  // returns all required params that are missing in the http request
-  if (missingParams.length > 0) {
-    throw new ServerError(null, {
-      statusCode: 400,
-      issue: [
-        {
-          severity: 'error',
-          code: 'BadRequest',
-          details: {
-            text: `Missing required parameters: ${missingParams.join(', ')} for $evaluate-measure`
-          }
-        }
-      ]
-    });
-  }
-  // returns all unsupported params that are included in the http request
-  if (includedUnsupportedParams.length > 0) {
-    throw new ServerError(null, {
-      statusCode: 400,
-      issue: [
-        {
-          severity: 'error',
-          code: 'BadRequest',
-          details: {
-            text: `The following parameters were included and are not supported for $evaluate-measure: ${includedUnsupportedParams.join(
-              ', '
-            )}`
-          }
-        }
-      ]
-    });
-  }
-
-  // returns unsupported report type that is included in the http request
-  if (!['individual', 'summary', undefined].includes(req.query.reportType)) {
-    throw new ServerError(null, {
-      statusCode: 400,
-      issue: [
-        {
-          severity: 'error',
-          code: 'BadRequest',
-          details: {
-            text: `reportType ${req.query.reportType} not supported for $evaluate-measure`
-          }
-        }
-      ]
-    });
-  }
-}
-
 module.exports = {
   mapArrayToSearchSetBundle,
   getMeasureBundleFromId,
   replaceReferences,
-  getPatientDataBundle,
-  validateEvalMeasureParams
+  getPatientDataBundle
 };

--- a/src/util/measureOperationsUtils.js
+++ b/src/util/measureOperationsUtils.js
@@ -1,0 +1,66 @@
+const { ServerError } = require('@asymmetrik/node-fhir-server-core');
+
+/**
+ * Checks that the parameters input to $evaluate-measure are valid. Throws a ServerError
+ * for missing parameters, the use of unsupported parameters, and the use of unsuppported
+ * report types.
+ * @param {Object} req http request object
+ */
+function validateEvalMeasureParams(req) {
+  const REQUIRED_PARAMS = ['periodStart', 'periodEnd', 'subject'];
+  const UNSUPPORTED_PARAMS = ['measure', 'practitioner', 'lastReceivedOn'];
+
+  const missingParams = REQUIRED_PARAMS.filter(key => !req.query[key]);
+  const includedUnsupportedParams = UNSUPPORTED_PARAMS.filter(key => req.query[key]);
+
+  // returns all required params that are missing in the http request
+  if (missingParams.length > 0) {
+    throw new ServerError(null, {
+      statusCode: 400,
+      issue: [
+        {
+          severity: 'error',
+          code: 'BadRequest',
+          details: {
+            text: `Missing required parameters: ${missingParams.join(', ')} for $evaluate-measure`
+          }
+        }
+      ]
+    });
+  }
+  // returns all unsupported params that are included in the http request
+  if (includedUnsupportedParams.length > 0) {
+    throw new ServerError(null, {
+      statusCode: 400,
+      issue: [
+        {
+          severity: 'error',
+          code: 'BadRequest',
+          details: {
+            text: `The following parameters were included and are not supported for $evaluate-measure: ${includedUnsupportedParams.join(
+              ', '
+            )}`
+          }
+        }
+      ]
+    });
+  }
+
+  // returns unsupported report type that is included in the http request
+  if (!['individual', 'summary', undefined].includes(req.query.reportType)) {
+    throw new ServerError(null, {
+      statusCode: 400,
+      issue: [
+        {
+          severity: 'error',
+          code: 'BadRequest',
+          details: {
+            text: `reportType ${req.query.reportType} not supported for $evaluate-measure`
+          }
+        }
+      ]
+    });
+  }
+}
+
+module.exports = { validateEvalMeasureParams };

--- a/src/util/measureOperationsUtils.js
+++ b/src/util/measureOperationsUtils.js
@@ -46,8 +46,23 @@ function validateEvalMeasureParams(req) {
     });
   }
 
+  if (['population', 'subject-list'].includes(req.query.reportType)) {
+    throw new ServerError(null, {
+      statusCode: 501,
+      issue: [
+        {
+          severity: 'error',
+          code: 'NotImplemented',
+          details: {
+            text: `The ${req.query.reportType} reportType is not currently supported by the server.`
+          }
+        }
+      ]
+    });
+  }
+
   // returns unsupported report type that is included in the http request
-  if (!['individual', 'summary', undefined].includes(req.query.reportType)) {
+  if (!['individual', 'population', 'subject-list', undefined].includes(req.query.reportType)) {
     throw new ServerError(null, {
       statusCode: 400,
       issue: [
@@ -55,7 +70,7 @@ function validateEvalMeasureParams(req) {
           severity: 'error',
           code: 'BadRequest',
           details: {
-            text: `reportType ${req.query.reportType} not supported for $evaluate-measure`
+            text: `reportType ${req.query.reportType} is not supported for $evaluate-measure`
           }
         }
       ]


### PR DESCRIPTION
# Summary
Additional parameter validation and handling was added to the `$evaluate-measure` operation so that more input parameters are supported and properly handled.

## New behavior
Previously, the `$evaluate-measure` operation simply checked for the presence of the subject parameter and did not support all possible report types. Now, errors are thrown when required parameters are not included in the http request, when unsupported parameters (`measure`, `practitioner`, `lastReceivedOn`) are included in the request, when an unsupported `reportType` is provided (`population` or `subject-list`), and when an invalid `reportType` is provided.


## Code changes
The `validateEvalMeasureParams` function was created in `measureOperationsUtils.js` to throw `ServerError`s is faulty input is given. A `ServerError` may be thrown with all the missing required params, all the included but unsupported params, an included but unsupported `reportType`, and an included but invalid `reportType`. This function is called in `evaluateMeasure` before calling `calculateMeasureReports`. 

# Testing guidance
* POST the EXM130 bundle to `http://localhost:3000/4_0_0/`. You should then have a Measure in the database with id `measure-EXM130-7.3.000`, as well as Patients with IDs `numer-EXM130` and `denom-EXM130`. 
* Run `GET http://localhost:3000/4_0_0/Measure/measure-EXM130-7.3.000/$evaluate-measure?subject=numer-EXM130&periodStart=2019-01-01&periodEnd=2019-12-31` and check that you get the desired MeasureReport.

Then, check that ServerErrors are thrown when:
* You are missing one or more required params (`periodStart`, `periodEnd`, `subject`)
* You have included one or more unsupported params (`measure`, `practitioner`, `lastReceivedOn`)
* You have included an unsupported reportType (for example, `subject-list`, which has not been implemented yet in `fqm-execution`)
* You have included an invalid reportType (anything aside from `individual`, `subject-list`, `population`)

**NOTE**: As someone who hasn’t done much work in `fqm-execution` with the calculator functions for MeasureReports, please check that I did not miss any important parameter handling (I tried to base my work off of this: https://www.hl7.org/fhir/operation-measure-evaluate-measure.html). If other situations fall under the scope of this task, please let me know and I will add them.

Also, I am a little confused about when we are supposed to use `subject`, `subject-list` and `population` versus `individual`, `subject-list`, or `summary`, so if I used the wrong report types for `$evaluate-measure` please let me know. 
