### PR TITLE
Care gaps params

### DIFF
--- a/src/services/base.service.js
+++ b/src/services/base.service.js
@@ -136,7 +136,6 @@ const baseSearch = async (args, { req }, resourceType, paramDefs = {}) => {
     meta: { lastUpdated: new Date().toISOString() },
     total: 0
   });
-  console.log(req);
   // build the aggregation query
   const filter = qb.buildSearchQuery({ req: req, includeArchived: true, parameterDefinitions: paramDefs });
 

--- a/src/services/base.service.js
+++ b/src/services/base.service.js
@@ -58,6 +58,11 @@ const GLOBAL_PARAMETER_DEFINITIONS = {
     type: 'token',
     fhirtype: 'Identifier',
     xpath: 'Resource.identifier'
+  },
+  url: {
+    type: 'token',
+    fhirtype: 'uri',
+    xpath: 'Resource.url'
   }
 };
 
@@ -131,7 +136,7 @@ const baseSearch = async (args, { req }, resourceType, paramDefs = {}) => {
     meta: { lastUpdated: new Date().toISOString() },
     total: 0
   });
-
+  console.log(req);
   // build the aggregation query
   const filter = qb.buildSearchQuery({ req: req, includeArchived: true, parameterDefinitions: paramDefs });
 

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -310,6 +310,21 @@ const validateCareGapsParams = req => {
       ]
     });
   }
+
+  if (req.query.status !== 'open') {
+    throw new ServerError(null, {
+      statusCode: 501,
+      issue: [
+        {
+          severity: 'error',
+          code: 'NotImplemented',
+          details: {
+            text: `Currently only supporting $care-gaps request with status='open'`
+          }
+        }
+      ]
+    });
+  }
 };
 
 const retrieveSearchTerm = req => {

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -221,7 +221,7 @@ const careGaps = async (args, { req }) => {
   req.query = searchTerm;
   //Use the base search function here to allow search by measureId, measureUrl, and measureIdentifier
   const measure = await search(args, { req });
-  if (!measure.entry) {
+  if (measure.total === 0) {
     //We know the search term will have exactly one key and value, so just fill them in in the error message
     throw new ServerError(null, {
       statusCode: 400,

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -319,7 +319,7 @@ const validateCareGapsParams = req => {
           severity: 'error',
           code: 'NotImplemented',
           details: {
-            text: `Currently only supporting $care-gaps request with status='open'`
+            text: `Currently only supporting $care-gaps requests with status='open'`
           }
         }
       ]

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -294,8 +294,7 @@ const validateCareGapsParams = req => {
       ]
     });
   }
-
-  const measureIdentification = req.query.measureId || req.query.meaureIdentifier || req.query.measureUrl;
+  const measureIdentification = req.query.measureId || req.query.measureIdentifier || req.query.measureUrl;
 
   if (!measureIdentification) {
     throw new ServerError(null, {

--- a/src/util/bundleUtils.js
+++ b/src/util/bundleUtils.js
@@ -82,7 +82,6 @@ function getQueryFromReference(reference) {
  */
 async function getMeasureBundleFromId(measureId) {
   const measure = await findResourceById(measureId, 'Measure');
-  console.log(JSON.stringify(measure, null, 4));
   if (!measure) {
     throw new ServerError(null, {
       statusCode: 400,

--- a/src/util/bundleUtils.js
+++ b/src/util/bundleUtils.js
@@ -82,7 +82,7 @@ function getQueryFromReference(reference) {
  */
 async function getMeasureBundleFromId(measureId) {
   const measure = await findResourceById(measureId, 'Measure');
-
+  console.log(JSON.stringify(measure, null, 4));
   if (!measure) {
     throw new ServerError(null, {
       statusCode: 400,
@@ -98,6 +98,10 @@ async function getMeasureBundleFromId(measureId) {
     });
   }
 
+  return assembleCollectionBundleFromMeasure(measure);
+}
+
+async function assembleCollectionBundleFromMeasure(measure) {
   const [mainLibraryRef] = measure.library;
 
   const mainLibQuery = getQueryFromReference(mainLibraryRef);
@@ -111,7 +115,7 @@ async function getMeasureBundleFromId(measureId) {
           severity: 'error',
           code: 'internal',
           details: {
-            text: `Could not find Library ${mainLibraryRef} referenced by Measure ${measureId}`
+            text: `Could not find Library ${mainLibraryRef} referenced by Measure ${measure.id}`
           }
         }
       ]
@@ -270,5 +274,6 @@ module.exports = {
   mapArrayToSearchSetBundle,
   getMeasureBundleFromId,
   replaceReferences,
-  getPatientDataBundle
+  getPatientDataBundle,
+  assembleCollectionBundleFromMeasure
 };

--- a/src/util/bundleUtils.js
+++ b/src/util/bundleUtils.js
@@ -100,6 +100,12 @@ async function getMeasureBundleFromId(measureId) {
   return assembleCollectionBundleFromMeasure(measure);
 }
 
+/**
+ * Takes in a measure resource, finds all dependent library resources and bundles them
+ * together with the measure in a collection bundle
+ * @param {*} measure a fhir measure resource
+ * @returns FHIR Bundle of Measure resource and all dependent FHIR Library resources
+ */
 async function assembleCollectionBundleFromMeasure(measure) {
   const [mainLibraryRef] = measure.library;
 


### PR DESCRIPTION
# Summary
The $care-gaps operation now has stricter parameter checks which return detailed errors upon failure. It also allows requests to specify a measure using the measure's Identifier or url now.

## New behavior
- Uses Hoss's base search functionality to retrieve measures based on passed in measureId, measureIdentifier, and measureUrl
- Throws several new serverErrors with detailed messages for missing or unsupported parameters

## Code changes
- Broke up the getMeasureBundleById in src/util/bundleUtils.js to split the subsequent bundle assembly into a new assembleCollectionBundleFromMeasure function, which is useful for chaining a base search operation into the calculator.calculateDataRequirements function
- Added two new utility functions to measure.service.js: retrieveSearchTerm and validateCareGapsParams
- retrieveSearchTerm is essentially a conditional which takes the careGaps request query and converts the measure identification parameter into an appropriate input for the measure baseSearch function
- ValidateCareGapsParams checks all the notable params in a $care-gaps request and will throw a 400 error if required params are missing or a 501 error if unsupported params are included.
- Added url as a supported attribute for baseSearch

# Testing guidance
1. Use the transaction bundle upload functionality to upload the EXM-130 measure bundle. Directions for how to do this [here](https://github.com/projecttacoma/deqm-test-server/pull/6)
2. Send a `GET` request to the following url: `http://localhost:3000/4_0_0/Measure/$care-gaps?measureId=measure-EXM130-7.3.000&subject=denom-EXM130&periodStart=2019-01-01&periodEnd=2019-12-31&status=open`, and ensure that the request goes through and the output report is for the correct measure.
3. Change the `measureId` field to `measureUrl=http://hl7.org/fhir/us/cqfmeasures/Measure/EXM130` and ensure the output is unchanged
4. Change the `measureUrl` field to `measureIdentifier=130` and ensure the output is unchanged. Change it again to `measureIdentifier=0034` and ensure it is unchanged
5. Change the value for `measureIdentifier`, `measureUrl`, and `measureId` to `invalid` and expect a 400 error with comprehensive error message detailing inability to find matching measure
6. Omit the `measureIdentifier`, `measureUrl`, and `measureId` fields entirely, resend, and expect a 400 error with a comprehensive error message
7. Remove any or all of the `periodEnd`, `periodStart`, `subject`, and `status` fields to receive a 400 error telling you which required fields you omitted
8. Add any or all of the `topic`, `practitioner`, `organization`, or `program` params to get a 501 error saying the use of these parameters is not yet supported
9. Change the `status` parameter to `closed` or any other value to get a 501 error saying we only implement $care-gaps requests with `status=open`
10. Continue this process with other measures and ensure all existing functionality is unchanged.

