### PR TITLE
Resource search params

### DIFF
--- a/src/services/base.service.js
+++ b/src/services/base.service.js
@@ -133,7 +133,7 @@ const baseSearch = async (args, { req }, resourceType, paramDefs) => {
   const dataType = resolveSchema(args.base_version, resourceType.toLowerCase());
   const Bundle = resolveSchema(args.base_version, 'bundle');
 
-  // Reprsents search params retrieved from fhir spec, or custom params specified by resource service
+  // Represents search params retrieved from fhir spec, or custom params specified by resource service
   let searchParams;
 
   if (!paramDefs) {

--- a/src/services/base.service.js
+++ b/src/services/base.service.js
@@ -1,5 +1,5 @@
 const { v4: uuidv4 } = require('uuid');
-const { resolveSchema, ServerError } = require('@asymmetrik/node-fhir-server-core');
+const { resolveSchema, ServerError, loggers } = require('@asymmetrik/node-fhir-server-core');
 const {
   findResourceById,
   createResource,
@@ -9,7 +9,9 @@ const {
 } = require('../util/mongo.controller');
 const QueryBuilder = require('@asymmetrik/fhir-qb');
 const url = require('url');
-const { getSearchParameters } = require('@asymmetrik/node-fhir-server-core/src/server/utils/params.utils');
+const { getSearchParameters } = require('@asymmetrik/node-fhir-server-core/dist/server/utils/params.utils');
+
+const logger = loggers.get('default');
 
 /**
  * Query Builder Parameter Definitions for all resources
@@ -79,6 +81,7 @@ const qb = new QueryBuilder({
  * @returns the id of the created object
  */
 const baseCreate = async ({ req }, resourceType) => {
+  logger.info(`${resourceType} >>> create`);
   checkHeaders(req.headers);
   const data = req.body;
   //Create a new id regardless of whether one is passed
@@ -95,6 +98,7 @@ const baseCreate = async ({ req }, resourceType) => {
  * @returns the object with the desired id cast to the requested type
  */
 const baseSearchById = async (args, resourceType) => {
+  logger.info(`${resourceType} >>> read`);
   const dataType = resolveSchema(args.base_version, resourceType.toLowerCase());
   const result = await findResourceById(args.id, resourceType);
   if (!result) {
@@ -120,22 +124,28 @@ const baseSearchById = async (args, resourceType) => {
  * @param {*} req The Express request object. This is used by the query builder.
  * @param {*} resourceType The resource type we are searching on.
  * @param {*} paramDefs Optional parameter definitions for the specific resource types. Specific
- *                      resource services should call this and pass
+ *                      resource services should call this and pass along supported params
  * @returns Search set result bundle
  */
 const baseSearch = async (args, { req }, resourceType, paramDefs) => {
+  logger.info(`${resourceType} >>> search`);
   // grab the schemas for the data type and Bundle to use for response
   const dataType = resolveSchema(args.base_version, resourceType.toLowerCase());
   const Bundle = resolveSchema(args.base_version, 'bundle');
 
+  // Reprsents search params retrieved from fhir spec, or custom params specified by resource service
+  let searchParams;
+
   if (!paramDefs) {
+    searchParams = {};
     const searchParameterList = getSearchParameters(resourceType, args.base_version);
-    paramDefs = {};
     searchParameterList.forEach(async paramDef => {
       {
-        paramDefs[paramDef.name] = paramDef;
+        searchParams[paramDef.name] = paramDef;
       }
     });
+  } else {
+    searchParams = paramDefs;
   }
 
   // wipe out params since the 'base_version' here breaks the query building
@@ -148,7 +158,7 @@ const baseSearch = async (args, { req }, resourceType, paramDefs) => {
     total: 0
   });
   // build the aggregation query
-  const filter = qb.buildSearchQuery({ req: req, includeArchived: true, parameterDefinitions: paramDefs });
+  const filter = qb.buildSearchQuery({ req: req, includeArchived: true, parameterDefinitions: searchParams });
 
   // if the query builder was able to build a query actually execute it.
   if (filter.query) {
@@ -199,6 +209,7 @@ const baseSearch = async (args, { req }, resourceType, paramDefs) => {
  * @returns the id of the updated/created document
  */
 const baseUpdate = async (args, { req }, resourceType) => {
+  logger.info(`${resourceType} >>> update`);
   checkHeaders(req.headers);
   const data = req.body;
   //The user passes in an id in the request body and it doesn't match the id arg in the url
@@ -228,6 +239,7 @@ const baseUpdate = async (args, { req }, resourceType) => {
  * @returns an object containing deletedCount: the number of documents deleted
  */
 const baseRemove = async (args, resourceType) => {
+  logger.info(`${resourceType} >>> delete`);
   return removeResource(args.id, resourceType);
 };
 

--- a/src/services/base.service.js
+++ b/src/services/base.service.js
@@ -9,6 +9,7 @@ const {
 } = require('../util/mongo.controller');
 const QueryBuilder = require('@asymmetrik/fhir-qb');
 const url = require('url');
+const { getSearchParameters } = require('@asymmetrik/node-fhir-server-core/src/server/utils/params.utils');
 
 /**
  * Query Builder Parameter Definitions for all resources
@@ -122,10 +123,20 @@ const baseSearchById = async (args, resourceType) => {
  *                      resource services should call this and pass
  * @returns Search set result bundle
  */
-const baseSearch = async (args, { req }, resourceType, paramDefs = {}) => {
+const baseSearch = async (args, { req }, resourceType, paramDefs) => {
   // grab the schemas for the data type and Bundle to use for response
   const dataType = resolveSchema(args.base_version, resourceType.toLowerCase());
   const Bundle = resolveSchema(args.base_version, 'bundle');
+
+  if (!paramDefs) {
+    const searchParameterList = getSearchParameters(resourceType, args.base_version);
+    paramDefs = {};
+    searchParameterList.forEach(async paramDef => {
+      {
+        paramDefs[paramDef.name] = paramDef;
+      }
+    });
+  }
 
   // wipe out params since the 'base_version' here breaks the query building
   req.params = {};


### PR DESCRIPTION
# Summary

Disclaimer: @hossenlopp did this. Not me.

This PR enables more dynamic searching capabilities by resource type, pulling in the search parameter definitions from node-fhir-server-core. This doesn't get us 100% of the way there, but it gets us most of the way there. Some things I noticed:

* The query builder for the search parameters doesn't quite know how to handle searching for doubly nested arrays in objects all the time (E.g. `GET /Encounter?type=99201` returns empty in our server but resolves properly in HAPI). I imagine that the query builder doesn't know how to process that `type` is an array of objects where those objects are also arrays of objects
* Searching for specific references require the full string content (E.g. `GET /Encounter?subject=numer-EXM130` doesn't work, but `GET /Encounter?subject=Patient/numer-EXM130`). It's possible that in the future we want to handle reference lookup differently (maybe we can re-use the logic to check if references are resourceType/id or canonical, and modify the query as needed

The important thing with this is that we have an approach that we can build on. Remember that we can always modify the incoming params for certain cases, or modify them in the core library entirely. So I think this task as is is sufficient, with potentially more work to come.

## New behavior

Can now search by any supported parameter for the resources (note the above exceptions)

## Code changes

Base search function pulls in the search parameter defs from asymmetrik. If no override is provided, it will use asymmetrik's by default.

# Testing guidance

Upload EXM130 bundle from connectathon to get Patient/Encounter/Procedure/ValueSet resources

Use some of the resources uploaded by a measure bundle (e.g. encounter, procedure, patient), and try searching by some params that aren't the default ones we already supported. You can see valid search parameters at the bottom of the resource page (e.g. https://www.hl7.org/fhir/encounter.html#search). Here are some example cases that are supported now:

* `http://localhost:3000/4_0_0/Patient?family=dere` should return the patient with name "Ben Dere"
* `http://localhost:3000/4_0_0/Patient?gender=male` should return both test patients
* `http://localhost:3000/4_0_0/ValueSet?url=http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836` should return one matching ValueSet
* `http://localhost:3000/4_0_0/Encounter?subject=Patient/numer-EXM130` should return one encounter

Try some other search parameters, note any things that don't work and we can prioritize them accordingly