### PR TITLE
Update measure.service.js

### DIFF
--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -171,7 +171,7 @@ const bulkImport = async (args, { req }) => {
 const dataRequirements = async (args, { req }) => {
   logger.info('Measure >>> $data-requirements');
 
-  const id = args.id || req.params.id;
+  const id = args.id;
 
   const measureBundle = await getMeasureBundleFromId(id);
 


### PR DESCRIPTION
# Summary
This is a companion update to a change in node server core ([here](https://github.com/projecttacoma/node-fhir-server-core/pull/6))
## New behavior
const id = args.id || req.params.id; was changed to always use args.id since it shouldn't be undefined once the change to node server core is merged and used
## Code changes
measure.service.js - made a minor change to always use args.id 

# Testing guidance
Made the same change referenced here: [link to pr](https://github.com/projecttacoma/node-fhir-server-core/pull/6)in the asymetrik version of the server and sent a measure request, noted the server didn't crash or behave oddly after the request was sent. (also double checked against the unit tests to be sure that nothing was broken there