### PR TITLE
Add keycloak to docker setup

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
 DB_HOST = localhost
 DB_PORT = 27017
 DB_NAME = deqm-test-server
+KEYCLOAK_VERSION = 15.0.2

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Follow the [MongoDB Community Edition installation guide](https://docs.mongodb.c
 ### Docker
 
 This test server can be run with Docker by calling `docker-compose up --build`.
+Debugging with terminal input can be facilitated with `stdin_open: true` and `tty: true` added to the service specification for the service you want to debug. You can then attach to the image of interest using `docker attach <imagename>`. If you're unsure of the image name, use `docker ps` to find the image of interest.
 
 ## Usage
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
     volumes:
       - ./src:/usr/src/app/src
     command: npm start
+    stdin_open: true
+    tty: true
 
   mongo:
     image: mongo:4.4.4
@@ -23,6 +25,16 @@ services:
       - '27017'
     volumes:
       - mongo_data:/data/db
+      
+  keycloak:
+    environment:
+      DB_VENDOR: h2
+      KEYCLOAK_USER: user
+      KEYCLOAK_PASSWORD: password
+    image: jboss/keycloak:${KEYCLOAK_VERSION}
+    ports:
+      - "28080:8080"
+    restart: unless-stopped
 
 volumes:
   mongo_data:


### PR DESCRIPTION
# Summary
Adds keycloak setup to the docker-compose.yml file to easily start an instance alongside the deqm-test-server. Also adds details about console debugging with docker to the README.
Note: keycloak cannot use mongodb https://lists.jboss.org/pipermail/keycloak-user/2017-February/009417.html . This uses the default h2 database instead.

## New behavior
Upon `running docker-compose up --build` a keycloak instance is also started.

## Code changes
Adds stdin_open and tty options for the test server and the keycloak server. The `.env` file is used to configure the keycloak version. Uses default user and password for simple local keycloak access.

# Testing guidance
Currently, there are issues with internal certificates and the fhir test service. Comment out the `fhir` service and run `running docker-compose up --build` to start the keycloak (and mongo) service. Go to http://localhost:28080/ to check the service is up (can use 'user' and 'password' to log in).
