### PR TITLE
Unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,4 +61,4 @@ jobs:
         uses: artiomtr/jest-coverage-report-action@v2.0-rc.4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          threshold: 45
+          threshold: 60

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -160,8 +160,6 @@ const submitData = async (args, { req }) => {
     tb.addEntryFromResource(param.resource, 'POST');
   });
   req.body = tb.toJSON();
-  console.log(req);
-  console.log(req.res);
   const output = await uploadTransactionBundle(req, req.res);
   return output;
 };

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -160,6 +160,8 @@ const submitData = async (args, { req }) => {
     tb.addEntryFromResource(param.resource, 'POST');
   });
   req.body = tb.toJSON();
+  console.log(req);
+  console.log(req.res);
   const output = await uploadTransactionBundle(req, req.res);
   return output;
 };
@@ -196,20 +198,7 @@ const bulkImport = async (args, { req }) => {
     measureId = measureResource.id;
     measureBundle = await getMeasureBundleFromId(measureId);
   }
-  if (!measureBundle) {
-    throw new ServerError(null, {
-      statusCode: 400,
-      issue: [
-        {
-          severity: 'error',
-          code: 'BadRequest',
-          details: {
-            text: `Could not find measure bundle with id ${measureId}`
-          }
-        }
-      ]
-    });
-  }
+
   // retrieve data requirements
   const exportURL = retrieveExportURL(parameters);
 
@@ -341,6 +330,7 @@ const careGaps = async (args, { req }) => {
     });
   }
   const measureBundle = await assembleCollectionBundleFromMeasure(measure.entry[0].resource);
+
   const dataReq = Calculator.calculateDataRequirements(measureBundle);
 
   const patientBundle = await getPatientDataBundle(subject, dataReq.results.dataRequirement);

--- a/test/base.service.test.js
+++ b/test/base.service.test.js
@@ -13,6 +13,57 @@ describe('base.service', () => {
   beforeAll(async () => {
     await testSetup(testMeasure, testPatient, testLibrary);
   });
+  describe('searchById', () => {
+    test('test searchById with correctHeaders and the id should be in database', async () => {
+      await supertest(server.app)
+        .get('/4_0_1/Patient/testPatient')
+        .set('Accept', 'application/json+fhir')
+        .expect(200)
+        .then(async response => {
+          expect(response.body.id).toEqual(testPatient.id);
+        });
+    });
+
+    test('test searchById when the id cannot be found in the database', async () => {
+      await supertest(server.app)
+        .get('/4_0_1/Patient/invalidID')
+        .set('Accept', 'application/json+fhir')
+        .expect(404)
+        .then(async response => {
+          expect(response.body.issue[0].code).toEqual('ResourceNotFound');
+          expect(response.body.issue[0].details.text).toEqual(
+            `No resource found in collection: Patient, with: id invalidID`
+          );
+        });
+    });
+  });
+
+  describe('search', () => {
+    test('test search with correct args and headers', async () => {
+      await supertest(server.app)
+        .get('/4_0_1/Patient')
+        .set('Accept', 'application/json+fhir')
+        .expect(200)
+        .then(async response => {
+          expect(response.body.resourceType).toEqual('Bundle');
+          expect(response.body.type).toEqual('searchset');
+          expect(response.body.total).toEqual(1);
+          expect(response.body.entry[0].resource.id).toEqual(testPatient.id);
+          expect(response.body.entry[0].resource.resourceType).toEqual('Patient');
+        });
+    });
+
+    test('test search with unsupported parameter', async () => {
+      await supertest(server.app)
+        .get('/4_0_1/Patient?publisher=abc')
+        .set('Accept', 'application/json+fhir')
+        .expect(400)
+        .then(async response => {
+          expect(response.body.issue[0].code).toEqual('BadRequest');
+          expect(response.body.issue[0].details.text).toEqual(`Unknown parameter 'publisher'`);
+        });
+    });
+  });
 
   describe('create', () => {
     test('test create with correct headers', async () => {
@@ -28,19 +79,7 @@ describe('base.service', () => {
         });
     });
   });
-  describe('searchById', () => {
-    test('test searchById with correctHeaders and the id should be in database', async () => {
-      await supertest(server.app)
-        .get('/4_0_1/Patient/testPatient')
-        .set('Accept', 'application/json+fhir')
-        .expect(200)
-        .then(async response => {
-          expect(response.body.id).toEqual(testPatient.id);
-        });
-    });
-  });
   describe('update', () => {
-    //*a put request*/
     test('test update with correctHeaders and the id is in database', async () => {
       await supertest(server.app)
         .put('/4_0_1/Patient/testPatient')
@@ -51,6 +90,19 @@ describe('base.service', () => {
         .then(async response => {
           // Check the response
           expect(response.headers.location).toBeDefined();
+        });
+    });
+
+    test('test update with invalid arg id', async () => {
+      await supertest(server.app)
+        .put('/4_0_1/Patient/invalidID')
+        .send(updatePatient)
+        .set('Accept', 'application/json+fhir')
+        .set('content-type', 'application/json+fhir')
+        .expect(400)
+        .then(async response => {
+          expect(response.body.issue[0].code).toEqual('BadRequest');
+          expect(response.body.issue[0].details.text).toEqual('Argument id must match request body id for PUT request');
         });
     });
   });

--- a/test/bundle.service.test.js
+++ b/test/bundle.service.test.js
@@ -1,0 +1,28 @@
+const { uploadTransactionBundle } = require('../src/services/bundle.service');
+
+const NON_BUNDLE_REQ = {
+  body: { resourceType: 'invalidType', type: 'transaction' },
+  params: { base_version: '4_0_1' }
+};
+const NON_TXN_REQ = { body: { resourceType: 'Bundle', type: 'invalidType' }, params: { base_version: '4_0_1' } };
+describe('uploadTransactionBundle Server errors', () => {
+  test('error thrown if resource type is not Bundle', async () => {
+    try {
+      await uploadTransactionBundle(NON_BUNDLE_REQ, {});
+    } catch (e) {
+      expect(e.statusCode).toEqual(400);
+      expect(e.issue[0].details.text).toEqual(
+        `Expected 'resourceType: Bundle', but received 'resourceType: invalidType'.`
+      );
+    }
+  });
+
+  test('error thrown if type is not transaction', async () => {
+    try {
+      await uploadTransactionBundle(NON_TXN_REQ, {});
+    } catch (e) {
+      expect(e.statusCode).toEqual(400);
+      expect(e.issue[0].details.text).toEqual(`Expected 'type: transaction'. Received 'type: invalidType'.`);
+    }
+  });
+});

--- a/test/bundleUtils.test.js
+++ b/test/bundleUtils.test.js
@@ -1,4 +1,4 @@
-const { replaceReferences, getPatientDataBundle } = require('../src/util/bundleUtils');
+const { replaceReferences, getPatientDataBundle, getQueryFromReference } = require('../src/util/bundleUtils');
 const supertest = require('supertest');
 const { buildConfig } = require('../src/util/config');
 const { initialize } = require('../src/server/server');
@@ -87,5 +87,20 @@ describe('Testing dynamic querying for patient references using compartment defi
     const procedure = patientBundle.entry.filter(e => e.resource.resourceType === 'Procedure')[0];
     const reference = procedure.resource.performer.actor;
     expect(reference).toEqual({ reference: 'Patient/test-patient' });
+  });
+});
+
+describe('Testing getQueryFromReference', () => {
+  test('test getQueryFromReference with canonical url', () => {
+    const TEST_REF = 'http://hl7.org/fhir/StructureDefinition/Patient';
+    expect(getQueryFromReference(TEST_REF)).toEqual({ url: TEST_REF });
+  });
+
+  test('test getQueryFromReference with canonical url containing |', () => {
+    const TEST_REF = 'http://hl7.org/fhir/StructureDefinition/Patient|3.5.0';
+    expect(getQueryFromReference(TEST_REF)).toEqual({
+      url: 'http://hl7.org/fhir/StructureDefinition/Patient',
+      version: '3.5.0'
+    });
   });
 });

--- a/test/fixtures/parametersObjs/emptyParam.json
+++ b/test/fixtures/parametersObjs/emptyParam.json
@@ -1,0 +1,3 @@
+{
+  "resourceType": "Parameters"
+}

--- a/test/fixtures/parametersObjs/paramInvalidType.json
+++ b/test/fixtures/parametersObjs/paramInvalidType.json
@@ -1,0 +1,17 @@
+{
+  "resourceType": "InvalidType",
+  "parameter": [
+    {
+      "name": "measureReport",
+      "resource": {
+        "resourceType": "MeasureReport",
+        "id": "measurereport-testMeasure",
+        "measure": "Measure/testMeasure"
+      }
+    },
+    {
+      "name": "exportURL",
+      "valueString": "https://bulk-data.smarthealthit.org/eyJlcnIiOiIiLCJwYWdlIjoxMDAwMCwiZHVyIjoxMCwidGx0IjoxNSwibSI6MSwic3R1IjozLCJkZWwiOjB9/fhir"
+    }
+  ]
+}

--- a/test/fixtures/parametersObjs/paramTwoMeasureReports.json
+++ b/test/fixtures/parametersObjs/paramTwoMeasureReports.json
@@ -1,0 +1,25 @@
+{
+  "resourceType": "Parameters",
+  "parameter": [
+    {
+      "name": "measureReport1",
+      "resource": {
+        "resourceType": "MeasureReport",
+        "id": "measurereport-testMeasure",
+        "measure": "Measure/testMeasure"
+      }
+    },
+    {
+      "name": "measureReport2",
+      "resource": {
+        "resourceType": "MeasureReport",
+        "id": "measurereport2-testMeasure",
+        "measure": "Measure/testMeasure"
+      }
+    },
+    {
+      "name": "exportURL",
+      "valueString": "https://bulk-data.smarthealthit.org/eyJlcnIiOiIiLCJwYWdlIjoxMDAwMCwiZHVyIjoxMCwidGx0IjoxNSwibSI6MSwic3R1IjozLCJkZWwiOjB9/fhir"
+    }
+  ]
+}

--- a/test/fixtures/testCareGapsMeasureReport.json
+++ b/test/fixtures/testCareGapsMeasureReport.json
@@ -1,0 +1,74 @@
+{
+  "id": "example",
+  "resourceType": "MeasureReport",
+  "subject": {
+    "reference": "Patient/example"
+  },
+  "period": {
+    "start": "2020-01-01",
+    "end": "2020-12-31"
+  },
+  "status": "complete",
+  "type": "individual",
+  "measure": "testMeasure",
+  "group": [
+    {
+      "id": "group-1",
+      "population": [
+        {
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "initial-population",
+                "display": "Initial Population"
+              }
+            ]
+          },
+          "count": 1
+        },
+        {
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "numerator",
+                "display": "Numerator"
+              }
+            ]
+          },
+          "count": 0
+        },
+        {
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "denominator",
+                "display": "Denominator"
+              }
+            ]
+          },
+          "count": 1
+        },
+        {
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "denominator-exclusion",
+                "display": "Denominator Exclusion"
+              }
+            ]
+          },
+          "count": 0
+        }
+      ],
+      "measureScore": {
+        "value": 0
+      }
+    }
+  ],
+  "contained": [],
+  "evaluatedResource": []
+}

--- a/test/measure.service.test.js
+++ b/test/measure.service.test.js
@@ -5,6 +5,10 @@ const testPatient = require('./fixtures/testPatient.json');
 const testParam = require('./fixtures/parametersObjs/paramNoExport.json');
 const testParamTwoExports = require('./fixtures/parametersObjs/paramTwoExports.json');
 const testParamNoValString = require('./fixtures/parametersObjs/paramNoValueString.json');
+const testParamInvalidResourceType = require('./fixtures/parametersObjs/paramInvalidType.json');
+const testEmptyParam = require('./fixtures/parametersObjs/emptyParam.json');
+const testParamTwoMeasureReports = require('./fixtures/parametersObjs/paramTwoMeasureReports.json');
+const testCareGapsMeasureReport = require('./fixtures/testCareGapsMeasureReport.json');
 const { testSetup, cleanUpDb } = require('./populateTestData');
 const supertest = require('supertest');
 const { buildConfig } = require('../src/util/config');
@@ -106,6 +110,65 @@ describe('testing custom measure operation', () => {
   beforeAll(async () => {
     await testSetup(testMeasure, testPatient, testLibrary);
   });
+
+  test('$submit-data returns 400 for incorrect resourceType', async () => {
+    await supertest(server.app)
+      .post('/4_0_1/Measure/$submit-data')
+      .send(testParamInvalidResourceType)
+      .set('Accept', 'application/json+fhir')
+      .set('content-type', 'application/json+fhir')
+      .expect(400)
+      .then(async response => {
+        expect(response.body.issue[0].code).toEqual('BadRequest');
+        expect(response.body.issue[0].details.text).toEqual(
+          `Expected 'resourceType: Parameters'. Received 'type: InvalidType'.`
+        );
+      });
+  });
+
+  test('$submit-data returns 400 for empty parameter body', async () => {
+    await supertest(server.app)
+      .post('/4_0_1/Measure/$submit-data')
+      .send(testEmptyParam)
+      .set('Accept', 'application/json+fhir')
+      .set('content-type', 'application/json+fhir')
+      .expect(400)
+      .then(async response => {
+        expect(response.body.issue[0].code).toEqual('BadRequest');
+        expect(response.body.issue[0].details.text).toEqual(
+          `Unreadable or empty entity for attribute 'parameter'. Received: undefined`
+        );
+      });
+  });
+
+  test('$submit-data returns 400 for invalid number of measure reports', async () => {
+    await supertest(server.app)
+      .post('/4_0_1/Measure/$submit-data')
+      .send(testParamTwoMeasureReports)
+      .set('Accept', 'application/json+fhir')
+      .set('content-type', 'application/json+fhir')
+      .expect(400)
+      .then(async response => {
+        expect(response.body.issue[0].code).toEqual('BadRequest');
+        expect(response.body.issue[0].details.text).toEqual(
+          `Expected exactly one resource with name: 'measureReport' and/or resourceType: 'MeasureReport. Received: 2`
+        );
+      });
+  });
+
+  test('$submit-data uploads txn bundle for valid parameters request', async () => {
+    await supertest(server.app)
+      .post('/4_0_1/Measure/$submit-data')
+      .send(testParam)
+      .set('Accept', 'application/json+fhir')
+      .set('content-type', 'application/json+fhir')
+      .expect(200)
+      .then(async response => {
+        expect(response.body.entry[0].response.status).toEqual('201 Created');
+        expect(response.body.resourceType).toEqual('Bundle');
+        expect(response.body.type).toEqual('transaction-response');
+      });
+  });
   test('$evaluate-measure returns 200 when subject is omitted and reportType is set to population', async () => {
     const { Calculator } = require('fqm-execution');
     const mrSpy = jest.spyOn(Calculator, 'calculateMeasureReports').mockImplementation(() => {
@@ -149,6 +212,49 @@ describe('testing custom measure operation', () => {
     });
   });
 
+  test('$evaluate-measure returns 200 when reportType is not set', async () => {
+    const { Calculator } = require('fqm-execution');
+    const mrSpy = jest.spyOn(Calculator, 'calculateMeasureReports').mockImplementation(() => {
+      return {
+        results: [
+          {
+            resourceType: 'MeasureReport',
+            period: {},
+            measure: '',
+            status: 'complete',
+            type: 'individual'
+          }
+        ],
+        debugOutput: {}
+      };
+    });
+    jest.spyOn(Calculator, 'calculateDataRequirements').mockImplementation(() => {
+      return {
+        results: {
+          resourceType: 'Library',
+          type: {
+            coding: [{ code: 'module-definition', system: 'http://terminology.hl7.org/CodeSystem/library-type' }]
+          },
+          status: 'draft',
+          dataRequirement: []
+        }
+      };
+    });
+    await supertest(server.app)
+      .get('/4_0_1/Measure/testMeasure/$evaluate-measure')
+      .query({
+        periodStart: '01-01-2020',
+        periodEnd: '01-01-2021',
+        subject: 'testPatient'
+      })
+      .expect(200);
+    expect(mrSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(), {
+      measurementPeriodStart: '01-01-2020',
+      measurementPeriodEnd: '01-01-2021',
+      reportType: 'individual'
+    });
+  });
+
   test('$data-requirements returns 400 when required param is omitted', async () => {
     const { Calculator } = require('fqm-execution');
     jest.spyOn(Calculator, 'calculateDataRequirements').mockImplementation(() => ({ results: null }));
@@ -170,6 +276,57 @@ describe('testing custom measure operation', () => {
       })
       .expect(200);
   });
+
+  test('$care-gaps returns 200 with valid params', async () => {
+    const { Calculator } = require('fqm-execution');
+    const gapsSpy = jest.spyOn(Calculator, 'calculateGapsInCare').mockImplementation(() => {
+      return {
+        results: testCareGapsMeasureReport
+      };
+    });
+    jest.spyOn(Calculator, 'calculateDataRequirements').mockImplementation(() => {
+      return {
+        results: {
+          resourceType: 'Library',
+          type: {
+            coding: [{ code: 'module-definition', system: 'http://terminology.hl7.org/CodeSystem/library-type' }]
+          },
+          status: 'draft',
+          dataRequirement: []
+        }
+      };
+    });
+    await supertest(server.app)
+      .get('/4_0_1/Measure/$care-gaps')
+      .query({
+        measureId: 'testMeasure',
+        subject: 'testPatient',
+        periodStart: '01-01-2020',
+        periodEnd: '01-01-2021',
+        status: 'open'
+      })
+      .expect(200);
+
+    expect(gapsSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(), {
+      measurementPeriodStart: '01-01-2020',
+      measurementPeriodEnd: '01-01-2021'
+    });
+  });
+
+  test('bulk import fails if measure bundle cannot be found', async () => {
+    await supertest(server.app)
+      .post('/4_0_1/Measure/invalid-id/$submit-data')
+      .send(testParam)
+      .set('Accept', 'application/json+fhir')
+      .set('content-type', 'application/json+fhir')
+      .set('prefer', 'respond-async')
+      .expect(400)
+      .then(async response => {
+        expect(response.body.issue[0].code).toEqual('internal');
+        expect(response.body.issue[0].details.text).toEqual('Measure with id invalid-id does not exist in the server');
+      });
+  });
+
   afterAll(async () => {
     await cleanUpDb();
   });

--- a/test/measureOperationsUtils.test.js
+++ b/test/measureOperationsUtils.test.js
@@ -1,4 +1,8 @@
-const { checkRequiredParams } = require('../src/util/measureOperationsUtils');
+const {
+  checkRequiredParams,
+  validateEvalMeasureParams,
+  validateCareGapsParams
+} = require('../src/util/measureOperationsUtils');
 
 describe('measureOperationsUtils functions', () => {
   test('check checkRequiredParams throws error on missing params', () => {
@@ -17,5 +21,114 @@ describe('measureOperationsUtils functions', () => {
     const req = { query: { test: true, test2: true } };
     const REQUIRED_PARAMS = ['test', 'test2'];
     checkRequiredParams(req, REQUIRED_PARAMS, 'test');
+  });
+
+  test('error thrown for unsupported $evaluate-measure params', async () => {
+    const UNSUPPORTEDREQ = {
+      query: { practitioner: 'testPractitioner', periodStart: '2019-01-01', periodEnd: '2019-12-31' }
+    };
+    try {
+      validateEvalMeasureParams(UNSUPPORTEDREQ);
+    } catch (e) {
+      expect(e.statusCode).toEqual(400);
+      expect(e.issue[0].details.text).toEqual(
+        `The following parameters were included and are not supported for $evaluate-measure: practitioner`
+      );
+    }
+  });
+
+  test('error thrown for unsupported $evaluate-measure reportType', async () => {
+    const UNSUPPORTEDREQ = {
+      query: { reportType: 'subject-list', periodStart: '2019-01-01', periodEnd: '2019-12-31' }
+    };
+    try {
+      validateEvalMeasureParams(UNSUPPORTEDREQ);
+    } catch (e) {
+      expect(e.statusCode).toEqual(501);
+      expect(e.issue[0].details.text).toEqual(`The subject-list reportType is not currently supported by the server.`);
+    }
+  });
+
+  test('error thrown for invalid $evaluate-measure reportType', async () => {
+    const INVALIDREQ = {
+      query: { reportType: 'invalid', periodStart: '2019-01-01', periodEnd: '2019-12-31' }
+    };
+    try {
+      validateEvalMeasureParams(INVALIDREQ);
+    } catch (e) {
+      expect(e.statusCode).toEqual(400);
+      expect(e.issue[0].details.text).toEqual(`reportType invalid is not supported for $evaluate-measure`);
+    }
+  });
+
+  test('error thrown for missing subject for $evaluate-measure', async () => {
+    const MISSING_SUBJECT_REQ = {
+      query: { reportType: 'individual', periodStart: '2019-01-01', periodEnd: '2019-12-31' }
+    };
+    try {
+      validateEvalMeasureParams(MISSING_SUBJECT_REQ);
+    } catch (e) {
+      expect(e.statusCode).toEqual(400);
+      expect(e.issue[0].details.text).toEqual(
+        `Must specify subject for all $evaluate-measure requests with reportType: individual`
+      );
+    }
+  });
+
+  test('error thrown for unsupported param for $care-gaps', async () => {
+    const UNSUPPORTEDREQ = {
+      query: {
+        periodStart: '2019-01-01',
+        periodEnd: '2019-12-31',
+        status: 'open',
+        subject: 'testPatient',
+        practitioner: 'testPractitioner'
+      }
+    };
+    try {
+      validateCareGapsParams(UNSUPPORTEDREQ);
+    } catch (e) {
+      expect(e.statusCode).toEqual(501);
+      expect(e.issue[0].details.text).toEqual(
+        `$care-gaps functionality has not yet been implemented for requests with parameters: practitioner`
+      );
+    }
+  });
+
+  test('error thrown for missing measure identification for $care-gaps', async () => {
+    const MISSING_MEASURE_REQ = {
+      query: {
+        periodStart: '2019-01-01',
+        periodEnd: '2019-12-31',
+        status: 'open',
+        subject: 'testPatient'
+      }
+    };
+    try {
+      validateCareGapsParams(MISSING_MEASURE_REQ);
+    } catch (e) {
+      expect(e.statusCode).toEqual(400);
+      expect(e.issue[0].details.text).toEqual(
+        `No measure identification parameter supplied. Must provide either 'measureId', 'measureUrl', or 'measureIdentifier' parameter for $care-gaps requests`
+      );
+    }
+  });
+
+  test('error thrown for missing open status for $care-gaps', async () => {
+    const UNSUPPORTED_STATUS_REQ = {
+      query: {
+        periodStart: '2019-01-01',
+        periodEnd: '2019-12-31',
+        status: 'invalid',
+        subject: 'testPatient',
+        measureId: 'testID'
+      }
+    };
+    try {
+      validateCareGapsParams(UNSUPPORTED_STATUS_REQ);
+    } catch (e) {
+      expect(e.statusCode).toEqual(501);
+      expect(e.issue[0].details.text).toEqual(`Currently only supporting $care-gaps requests with status='open'`);
+    }
   });
 });

--- a/test/measureOperationsUtils.test.js
+++ b/test/measureOperationsUtils.test.js
@@ -4,7 +4,7 @@ const {
   validateCareGapsParams
 } = require('../src/util/measureOperationsUtils');
 
-describe('measureOperationsUtils functions', () => {
+describe('checkRequiredParams', () => {
   test('check checkRequiredParams throws error on missing params', () => {
     const req = { query: {} };
     const REQUIRED_PARAMS = ['test', 'test2'];
@@ -22,7 +22,9 @@ describe('measureOperationsUtils functions', () => {
     const REQUIRED_PARAMS = ['test', 'test2'];
     checkRequiredParams(req, REQUIRED_PARAMS, 'test');
   });
+});
 
+describe('validateEvalMeasureParams', () => {
   test('error thrown for unsupported $evaluate-measure params', async () => {
     const UNSUPPORTEDREQ = {
       query: { practitioner: 'testPractitioner', periodStart: '2019-01-01', periodEnd: '2019-12-31' }
@@ -75,6 +77,13 @@ describe('measureOperationsUtils functions', () => {
     }
   });
 
+  test('validateEvalMeasureParams does not throw error with correct params', async () => {
+    const VALID_REQ = { query: { reportType: 'population', periodStart: '2019-01-01', periodEnd: '2019-12-31' } };
+    expect(validateEvalMeasureParams(VALID_REQ)).toBeUndefined();
+  });
+});
+
+describe('validateCareGapsParams', () => {
   test('error thrown for unsupported param for $care-gaps', async () => {
     const UNSUPPORTEDREQ = {
       query: {
@@ -130,5 +139,18 @@ describe('measureOperationsUtils functions', () => {
       expect(e.statusCode).toEqual(501);
       expect(e.issue[0].details.text).toEqual(`Currently only supporting $care-gaps requests with status='open'`);
     }
+  });
+
+  test('validateCareGapsParams does not throw error with correct params', async () => {
+    const VALID_REQ = {
+      query: {
+        periodStart: '2019-01-01',
+        periodEnd: '2019-12-31',
+        status: 'open',
+        subject: 'testPatient',
+        measureId: 'testID'
+      }
+    };
+    expect(validateCareGapsParams(VALID_REQ)).toBeUndefined();
   });
 });

--- a/test/transactionBundle.test.js
+++ b/test/transactionBundle.test.js
@@ -1,0 +1,42 @@
+const { createTransactionBundleClass } = require('../src/resources/transactionBundle');
+const testPatient = require('./fixtures/testPatient.json');
+describe('Test functionality for adding resource entry to the bundle', () => {
+  let tb;
+
+  beforeEach(() => {
+    // initialize empty transaction bundle
+    tb = createTransactionBundleClass('4_0_1');
+  });
+  test('POST request for adding entry from a resource', () => {
+    tb.addEntryFromResource(testPatient, 'POST');
+    // check that resource was added properly
+    expect(tb.entry[0].resource.id).toEqual(testPatient.id);
+    expect(tb.entry[0].resource.resourceType).toEqual(testPatient.resourceType);
+    // check that request was added properly
+    expect(tb.entry[0].request.url).toEqual(testPatient.resourceType);
+    expect(tb.entry[0].request.method).toEqual('POST');
+  });
+
+  test('PUT request for adding entry from a resource', () => {
+    tb.addEntryFromResource(testPatient, 'PUT');
+    // check that resource was added properly
+    expect(tb.entry[0].resource.id).toEqual(testPatient.id);
+    expect(tb.entry[0].resource.resourceType).toEqual(testPatient.resourceType);
+    // check that request was added properly
+    expect(tb.entry[0].request.url).toEqual(`${testPatient.resourceType}/${testPatient.id}`);
+    expect(tb.entry[0].request.method).toEqual('PUT');
+  });
+
+  test('Invalid request type received', () => {
+    try {
+      tb.addEntryFromResource(testPatient, 'INVALID');
+      throw new Error('addEntryFromResource failed to throw error');
+    } catch (e) {
+      expect(e.statusCode).toEqual(422);
+      expect(e.issue[0].details.text).toEqual(
+        `Invalid request type for transaction bundle entry for resource with id: ${testPatient.id}. 
+              Request must be of type POST or PUT, received type: INVALID`
+      );
+    }
+  });
+});


### PR DESCRIPTION
# Summary
The threshold in GitHub Actions was increased to 60. Additional unit tests and accompanying fixtures were added to the test server.

## New behavior
Behavior should remain unchanged.

## Code changes
Unit tests were added for the following files: `base.service.js`, `bundle.service.test.js`, `bundleUtiles.js`, `measure.service.js`, `measureOperationsUtils.js`, `transactionBundle.js`.
An error in `measure.service.js` is never reached (other ServerErrors are thrown in `getMeasureBundleFromId()`, so the error was removed.

# Testing guidance
Run `npm run test` and ensure that all the unit tests pass. Please check the unit tests to make sure their logic is correct.

Run `npm run test:coverage` to view the test coverage for all statements, branches, functions, and lines. Check that the test coverage percentages look good to you.

Please let me know if you think any of the uncovered lines should be covered, or if a file's test organization should be restructured using describe blocks.

Note that in `measure.service.js`, the `executePingandPull` code has not been unit tested because of the limitations mentioned in https://github.com/projecttacoma/deqm-test-server/pull/34. 
