### PR TITLE
updated appropriate codes from 400 -> 404

### DIFF
--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -315,11 +315,11 @@ const careGaps = async (args, { req }) => {
   if (measure.total === 0) {
     //We know the search term will have exactly one key and value, so just fill them in in the error message
     throw new ServerError(null, {
-      statusCode: 400,
+      statusCode: 404,
       issue: [
         {
           severity: 'error',
-          code: 'BadRequest',
+          code: 'ResourceNotFound',
           details: {
             text: `no measure found with ${Object.keys(searchTerm)[0]}: ${searchTerm[Object.keys(searchTerm)[0]]}.`
           }

--- a/src/util/bundleUtils.js
+++ b/src/util/bundleUtils.js
@@ -84,11 +84,11 @@ async function getMeasureBundleFromId(measureId) {
   const measure = await findResourceById(measureId, 'Measure');
   if (!measure) {
     throw new ServerError(null, {
-      statusCode: 400,
+      statusCode: 404,
       issue: [
         {
           severity: 'error',
-          code: 'internal',
+          code: 'ResourceNotFound',
           details: {
             text: `Measure with id ${measureId} does not exist in the server`
           }

--- a/test/measure.service.test.js
+++ b/test/measure.service.test.js
@@ -320,9 +320,9 @@ describe('testing custom measure operation', () => {
       .set('Accept', 'application/json+fhir')
       .set('content-type', 'application/json+fhir')
       .set('prefer', 'respond-async')
-      .expect(400)
+      .expect(404)
       .then(async response => {
-        expect(response.body.issue[0].code).toEqual('internal');
+        expect(response.body.issue[0].code).toEqual('ResourceNotFound');
         expect(response.body.issue[0].details.text).toEqual('Measure with id invalid-id does not exist in the server');
       });
   });


### PR DESCRIPTION
# Summary
There were a few spots in our measure services code that were returning 400:BadRequest  when they should have been returning 404:ResourceNotFound

## New behavior
When a client submits an $evaluate-measure, $data-requirements, $submit-data, or $care-gaps request with a measureId that is not in the database, they will now get a 404 status response code instead of a 400

## Code changes
care-gaps function returns 404 instead of 400 on measureId not found
getMeasureBundleFromId returns 404 instead of 400 on measureId not found
updated appropriate tests to reflect changes

# Testing guidance
Try executing a $evaluate-measure, $data-requirements, $submit-data, and $care-gaps with an invalid ID, but otherwise correct parameters. Information on how to do this can be found in the following PRs

- [$evaluate-measure](https://github.com/projecttacoma/deqm-test-server/pull/22)
- [$submit-data](https://github.com/projecttacoma/deqm-test-server/pull/7)
- [$care-gaps](https://github.com/projecttacoma/deqm-test-server/pull/23)
- [$data-requirements](https://github.com/projecttacoma/deqm-test-server/pull/11)


