### PR TITLE
Inclusion of X-Provenance header

### DIFF
--- a/src/services/bundle.service.js
+++ b/src/services/bundle.service.js
@@ -48,7 +48,6 @@ const makeTransactionResponseBundle = (results, res, baseVersion, type) => {
  * @returns transaction-response bundle
  */
 async function uploadTransactionBundle(req, res) {
-  checkProvenanceHeader(req.headers);
   logger.info('Base >>> transaction');
   const { resourceType, type, entry: entries } = req.body;
   const { base_version: baseVersion } = req.params;
@@ -80,6 +79,7 @@ async function uploadTransactionBundle(req, res) {
       ]
     });
   }
+  checkProvenanceHeader(req.headers);
   const { protocol, baseUrl } = req;
   const scrubbedEntries = replaceReferences(entries);
   const requestsArray = scrubbedEntries.map(async entry => {

--- a/src/services/bundle.service.js
+++ b/src/services/bundle.service.js
@@ -3,6 +3,7 @@ const axios = require('axios').default;
 const { ServerError, loggers, resolveSchema } = require('@projecttacoma/node-fhir-server-core');
 const { v4: uuidv4 } = require('uuid');
 const { replaceReferences } = require('../util/bundleUtils');
+//const { checkContentTypeHeader, checkProvenanceHeader, populateProvenanceTarget } = require('./base.service');
 
 const logger = loggers.get('default');
 
@@ -43,6 +44,10 @@ const makeTransactionResponseBundle = (results, res, baseVersion, type) => {
  * @returns transaction-response bundle
  */
 async function uploadTransactionBundle(req, res) {
+  // used for testing provenance - pls delete
+  // checkContentTypeHeader(req.headers);
+  // checkProvenanceHeader(req.headers);
+  // populateProvenanceTarget(req, res, [{reference: 'testRef'}]);
   logger.info('Base >>> transaction');
   const { resourceType, type, entry: entries } = req.body;
   const { base_version: baseVersion } = req.params;

--- a/test/base.service.test.js
+++ b/test/base.service.test.js
@@ -72,24 +72,131 @@ describe('base.service', () => {
         .send(testPatient)
         .set('Accept', 'application/json+fhir')
         .set('content-type', 'application/json+fhir')
+        .set('x-provenance', '{ "resourceType": "Provenance"}')
         .expect(201)
         .then(async response => {
           // Check the response
           expect(response.headers.location).toBeDefined();
+          expect(JSON.parse(response.headers['x-provenance']).target).toBeDefined();
+        });
+    });
+
+    test('test create with missing provenance header', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/Patient')
+        .send(testPatient)
+        .set('Accept', 'application/json+fhir')
+        .set('content-type', 'application/json+fhir')
+        .expect(400)
+        .then(async response => {
+          // Check the response
+          expect(response.body.issue[0].code).toEqual('BadRequest');
+          expect(response.body.issue[0].details.text).toEqual(
+            `Ensure Provenance header is populated for this POST/PUT request`
+          );
+        });
+    });
+
+    test('test create with missing Provenance resourceType', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/Patient')
+        .send(testPatient)
+        .set('Accept', 'application/json+fhir')
+        .set('content-type', 'application/json+fhir')
+        .set('x-provenance', '{}')
+        .expect(400)
+        .then(async response => {
+          // Check the response
+          expect(response.body.issue[0].code).toEqual('BadRequest');
+          expect(response.body.issue[0].details.text).toEqual(
+            `Expected resourceType 'Provenance' for Provenance header. Received undefined.`
+          );
+        });
+    });
+
+    test('test create with populated provenance target', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/Patient')
+        .send(testPatient)
+        .set('Accept', 'application/json+fhir')
+        .set('content-type', 'application/json+fhir')
+        .set('x-provenance', '{ "resourceType": "Provenance", "target": [{"reference": "testRef"}]}')
+        .expect(400)
+        .then(async response => {
+          // Check the response
+          expect(response.body.issue[0].code).toEqual('BadRequest');
+          expect(response.body.issue[0].details.text).toEqual(
+            `The 'target' attribute should not be populated in the provenance header`
+          );
         });
     });
   });
   describe('update', () => {
+<<<<<<< HEAD
+=======
+    //*a put request*/
+
+    test('test update with populated provenance target', async () => {
+      await supertest(server.app)
+        .put('/4_0_1/Patient/testPatient')
+        .send(updatePatient)
+        .set('Accept', 'application/json+fhir')
+        .set('content-type', 'application/json+fhir')
+        .set('x-provenance', '{ "resourceType": "Provenance", "target": [{"reference": "testRef"}]}')
+        .expect(400)
+        .then(async response => {
+          // Check the response
+          expect(response.body.issue[0].code).toEqual('BadRequest');
+          expect(response.body.issue[0].details.text).toEqual(
+            `The 'target' attribute should not be populated in the provenance header`
+          );
+        });
+    });
+    test('test update with missing provenance header', async () => {
+      await supertest(server.app)
+        .put('/4_0_1/Patient/testPatient')
+        .send(updatePatient)
+        .set('Accept', 'application/json+fhir')
+        .set('content-type', 'application/json+fhir')
+        .expect(400)
+        .then(async response => {
+          // Check the response
+          expect(response.body.issue[0].code).toEqual('BadRequest');
+          expect(response.body.issue[0].details.text).toEqual(
+            `Ensure Provenance header is populated for this POST/PUT request`
+          );
+        });
+    });
+
+    test('test update with missing Provenance resourceType', async () => {
+      await supertest(server.app)
+        .put('/4_0_1/Patient/testPatient')
+        .send(updatePatient)
+        .set('Accept', 'application/json+fhir')
+        .set('content-type', 'application/json+fhir')
+        .set('x-provenance', '{}')
+        .expect(400)
+        .then(async response => {
+          // Check the response
+          expect(response.body.issue[0].code).toEqual('BadRequest');
+          expect(response.body.issue[0].details.text).toEqual(
+            `Expected resourceType 'Provenance' for Provenance header. Received undefined.`
+          );
+        });
+    });
+>>>>>>> 1cd1aa7 (added unit tests)
     test('test update with correctHeaders and the id is in database', async () => {
       await supertest(server.app)
         .put('/4_0_1/Patient/testPatient')
         .send(updatePatient)
         .set('Accept', 'application/json+fhir')
         .set('content-type', 'application/json+fhir')
+        .set('x-provenance', '{ "resourceType": "Provenance"}')
         .expect(200)
         .then(async response => {
           // Check the response
           expect(response.headers.location).toBeDefined();
+          expect(JSON.parse(response.headers['x-provenance']).target).toEqual([{ reference: 'Patient/testPatient' }]);
         });
     });
 

--- a/test/base.service.test.js
+++ b/test/base.service.test.js
@@ -132,8 +132,6 @@ describe('base.service', () => {
     });
   });
   describe('update', () => {
-<<<<<<< HEAD
-=======
     //*a put request*/
 
     test('test update with populated provenance target', async () => {
@@ -184,7 +182,6 @@ describe('base.service', () => {
           );
         });
     });
->>>>>>> 1cd1aa7 (added unit tests)
     test('test update with correctHeaders and the id is in database', async () => {
       await supertest(server.app)
         .put('/4_0_1/Patient/testPatient')
@@ -206,6 +203,7 @@ describe('base.service', () => {
         .send(updatePatient)
         .set('Accept', 'application/json+fhir')
         .set('content-type', 'application/json+fhir')
+        .set('x-provenance', '{ "resourceType": "Provenance"}')
         .expect(400)
         .then(async response => {
           expect(response.body.issue[0].code).toEqual('BadRequest');

--- a/test/bundle.service.test.js
+++ b/test/bundle.service.test.js
@@ -1,10 +1,19 @@
 const { uploadTransactionBundle } = require('../src/services/bundle.service');
+const testBundle = require('./fixtures/testBundle.json');
+const { client } = require('../src/util/mongo');
+const { cleanUpDb } = require('./populateTestData');
+const supertest = require('supertest');
+const { buildConfig } = require('../src/util/config');
+const { initialize } = require('../src/server/server');
+const config = buildConfig();
+const server = initialize(config);
 
 const NON_BUNDLE_REQ = {
   body: { resourceType: 'invalidType', type: 'transaction' },
   params: { base_version: '4_0_1' }
 };
 const NON_TXN_REQ = { body: { resourceType: 'Bundle', type: 'invalidType' }, params: { base_version: '4_0_1' } };
+
 describe('uploadTransactionBundle Server errors', () => {
   test('error thrown if resource type is not Bundle', async () => {
     try {
@@ -24,5 +33,28 @@ describe('uploadTransactionBundle Server errors', () => {
       expect(e.statusCode).toEqual(400);
       expect(e.issue[0].details.text).toEqual(`Expected 'type: transaction'. Received 'type: invalidType'.`);
     }
+  });
+});
+describe('Test transaction bundle upload', () => {
+  beforeAll(async () => {
+    await client.connect();
+  });
+
+  test('Transaction bundle upload populates provenance target', async () => {
+    await supertest(server.app)
+      .post('/4_0_1/')
+      .send(testBundle)
+      .set('Accept', 'application/json+fhir')
+      .set('content-type', 'application/json+fhir')
+      .set('x-provenance', '{ "resourceType": "Provenance"}')
+      .expect(200)
+      .then(async response => {
+        // Check the response
+        expect(JSON.parse(response.headers['x-provenance']).target).toBeDefined();
+      });
+  });
+
+  afterAll(async () => {
+    await cleanUpDb();
   });
 });

--- a/test/bundleUtils.test.js
+++ b/test/bundleUtils.test.js
@@ -69,6 +69,7 @@ describe('Testing dynamic querying for patient references using compartment defi
       .send(testBundle)
       .set('Accept', 'application/json+fhir')
       .set('content-type', 'application/json+fhir')
+      .set('x-provenance', '{ "resourceType": "Provenance"}')
       .expect(200);
     const patientBundle = await getPatientDataBundle('test-patient', testDataReq);
     const procedure = patientBundle.entry.filter(e => e.resource.resourceType === 'Procedure')[0];
@@ -82,6 +83,7 @@ describe('Testing dynamic querying for patient references using compartment defi
       .send(testNestedBundle)
       .set('Accept', 'application/json+fhir')
       .set('content-type', 'application/json+fhir')
+      .set('x-provenance', '{ "resourceType": "Provenance"}')
       .expect(200);
     const patientBundle = await getPatientDataBundle('test-patient', testDataReq);
     const procedure = patientBundle.entry.filter(e => e.resource.resourceType === 'Procedure')[0];

--- a/test/measure.service.test.js
+++ b/test/measure.service.test.js
@@ -28,6 +28,7 @@ describe('measure.service CRUD operations', () => {
       .send(testMeasure)
       .set('Accept', 'application/json+fhir')
       .set('content-type', 'application/json+fhir')
+      .set('x-provenance', '{ "resourceType": "Provenance"}')
       .expect(201)
       .then(response => {
         expect(response.headers.location).toBeDefined();
@@ -51,6 +52,7 @@ describe('measure.service CRUD operations', () => {
       .send(updateMeasure)
       .set('Accept', 'application/json+fhir')
       .set('content-type', 'application/json+fhir')
+      .set('x-provenance', '{ "resourceType": "Provenance"}')
       .expect(200)
       .then(async response => {
         // Check the response

--- a/test/measure.service.test.js
+++ b/test/measure.service.test.js
@@ -164,6 +164,7 @@ describe('testing custom measure operation', () => {
       .send(testParam)
       .set('Accept', 'application/json+fhir')
       .set('content-type', 'application/json+fhir')
+      .set('x-provenance', '{ "resourceType": "Provenance"}')
       .expect(200)
       .then(async response => {
         expect(response.body.entry[0].response.status).toEqual('201 Created');


### PR DESCRIPTION
# Summary
When a POST/PUT request is sent (assuming it contains the `Provenance` header), the `Provenance` `target` attribute is populated with the reference(s) to the ID(s) that the server is using for the resource(s) created via the POST/PUT request.

## New behavior
Now, POST/PUT requests are expected to contain a `Provenance` header, which is a JSON object that is clinically significant for authenticity and reliability. Right now, we are concerned that the Provenance header is present with the `Provenance` `resourceType`, that its target attribute is not initially specified, and that our POST/PUT requests create and populate the target attribute with references to the IDs that the server is using for a created resource.

The `target` attribute is populated for `baseCreate`, `baseUpdate`, and `uploadTransactionBundle` because they send POST/PUT requests. 

## Code changes
Functions were created in `base.service.js` to check that the included provenance header is valid and to populate the target attribute of the provenance header appropriately. The `baseUpdate`, `baseCreate`, and transaction bundle functions were updated to check for the provenance header and to populate it with the necessary references. In the case of the transaction bundle upload, all the creates/updates leave us with a bunch of `target` arrays, which we must combine together when populating the transaction bundle `target` with all the reference objects.

Some of the unit tests were updated so that the `x-provenance` header is present - otherwise those tests would now fail.

# Testing guidance
Run the unit tests and ensure that they pass. Try doing a standard transaction bundle upload with the EXM130 bundle and add the header `X-Provenance: { "resourceType": "Provenance”}`. After sending the request, check the response header in the Insomnia UI. It should have an X-Provenance header that is populated with the `resourceType` and a target array full of the references.
