### PR TITLE
made x-provenance optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2680,10 +2680,10 @@
       "dev": true
     },
     "bulk-data-utilities": {
-      "version": "git+https://github.com/projecttacoma/bulk-data-utilities.git#fb04a13d49357b74e6e8fed55e97d44a4b490c2d",
+      "version": "git+https://github.com/projecttacoma/bulk-data-utilities.git#32be10a86f6fc7386b26ae93df4a16d2944936d4",
       "from": "git+https://github.com/projecttacoma/bulk-data-utilities.git",
       "requires": {
-        "axios": "^0.21.2",
+        "axios": "^0.21.1",
         "fqm-execution": "^0.8.0",
         "path": "^0.12.7",
         "sqlite": "^4.0.23",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2187,9 +2187,9 @@
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
       "optional": true,
       "requires": {
         "safer-buffer": "~2.1.0"
@@ -2680,10 +2680,10 @@
       "dev": true
     },
     "bulk-data-utilities": {
-      "version": "git+https://github.com/projecttacoma/bulk-data-utilities.git#32be10a86f6fc7386b26ae93df4a16d2944936d4",
+      "version": "git+https://github.com/projecttacoma/bulk-data-utilities.git#fb04a13d49357b74e6e8fed55e97d44a4b490c2d",
       "from": "git+https://github.com/projecttacoma/bulk-data-utilities.git",
       "requires": {
-        "axios": "^0.21.1",
+        "axios": "^0.21.2",
         "fqm-execution": "^0.8.0",
         "path": "^0.12.7",
         "sqlite": "^4.0.23",

--- a/src/services/base.service.js
+++ b/src/services/base.service.js
@@ -233,7 +233,7 @@ const baseUpdate = async (args, { req }, resourceType) => {
       ]
     });
   }
-  if (Object.keys(req.headers).includes('x-provenance')) {
+  if (req.headers['x-provenance']) {
     checkProvenanceHeader(req.headers);
     const res = req.res;
     populateProvenanceTarget(req.headers, res, [{ reference: `${resourceType}/${args.id}` }]);

--- a/src/services/base.service.js
+++ b/src/services/base.service.js
@@ -83,13 +83,14 @@ const qb = new QueryBuilder({
 const baseCreate = async ({ req }, resourceType) => {
   logger.info(`${resourceType} >>> create`);
   checkContentTypeHeader(req.headers);
-  checkProvenanceHeader(req.headers);
-  const res = req.res;
   const data = req.body;
   //Create a new id regardless of whether one is passed
   data['id'] = uuidv4();
-  populateProvenanceTarget(req.headers, res, [{ reference: `${resourceType}/${data.id}` }]);
-
+  if (Object.keys(req.headers).includes('x-provenance')) {
+    checkProvenanceHeader(req.headers);
+    const res = req.res;
+    populateProvenanceTarget(req.headers, res, [{ reference: `${resourceType}/${data.id}` }]);
+  }
   return createResource(data, resourceType);
 };
 
@@ -214,9 +215,8 @@ const baseSearch = async (args, { req }, resourceType, paramDefs) => {
 const baseUpdate = async (args, { req }, resourceType) => {
   logger.info(`${resourceType} >>> update`);
   checkContentTypeHeader(req.headers);
-  checkProvenanceHeader(req.headers);
   const data = req.body;
-  const res = req.res;
+
   //The user passes in an id in the request body and it doesn't match the id arg in the url
   //or user doesn't pass in body
   if (data.id !== args.id) {
@@ -233,7 +233,11 @@ const baseUpdate = async (args, { req }, resourceType) => {
       ]
     });
   }
-  populateProvenanceTarget(req.headers, res, [{ reference: `${resourceType}/${args.id}` }]);
+  if (Object.keys(req.headers).includes('x-provenance')) {
+    checkProvenanceHeader(req.headers);
+    const res = req.res;
+    populateProvenanceTarget(req.headers, res, [{ reference: `${resourceType}/${args.id}` }]);
+  }
   return updateResource(args.id, data, resourceType);
 };
 
@@ -279,20 +283,6 @@ const checkContentTypeHeader = requestHeaders => {
  * @param {*} requestHeaders the headers from the request body
  */
 const checkProvenanceHeader = requestHeaders => {
-  if (!Object.keys(requestHeaders).includes('x-provenance')) {
-    throw new ServerError(null, {
-      statusCode: 400,
-      issue: [
-        {
-          severity: 'error',
-          code: 'BadRequest',
-          details: {
-            text: `Ensure Provenance header is populated for this POST/PUT request`
-          }
-        }
-      ]
-    });
-  }
   const provenanceRequest = JSON.parse(requestHeaders['x-provenance']);
   if (provenanceRequest.resourceType !== 'Provenance') {
     throw new ServerError(null, {

--- a/src/services/base.service.js
+++ b/src/services/base.service.js
@@ -86,7 +86,7 @@ const baseCreate = async ({ req }, resourceType) => {
   const data = req.body;
   //Create a new id regardless of whether one is passed
   data['id'] = uuidv4();
-  if (Object.keys(req.headers).includes('x-provenance')) {
+  if (req.headers['x-provenance']) {
     checkProvenanceHeader(req.headers);
     const res = req.res;
     populateProvenanceTarget(req.headers, res, [{ reference: `${resourceType}/${data.id}` }]);

--- a/src/services/bundle.service.js
+++ b/src/services/bundle.service.js
@@ -14,11 +14,10 @@ const logger = loggers.get('default');
  * @param {*} type - bundle type
  * @param { boolean } xprovenanceIncluded - X-Provenance header was included and
  * should be accounted for
- * @returns transaction-response Bundle and (optionally) updated txn bundle target
+ * @returns transaction-response Bundle and updated txn bundle target (may be empty)
  */
 const makeTransactionResponseBundle = (results, res, baseVersion, type, xprovenanceIncluded) => {
   const Bundle = resolveSchema(baseVersion, 'bundle');
-  console.log(xprovenanceIncluded);
   const bundle = new Bundle({ type: type, id: uuidv4() });
   bundle.link = {
     url: `${res.req.protocol}://${path.join(res.req.get('host'), res.req.baseUrl)}`,

--- a/src/services/bundle.service.js
+++ b/src/services/bundle.service.js
@@ -84,7 +84,7 @@ async function uploadTransactionBundle(req, res) {
     });
   }
   let xprovenanceIncluded;
-  if (Object.keys(req.headers).includes('x-provenance')) {
+  if (req.headers['x-provenance']) {
     checkProvenanceHeader(req.headers);
     xprovenanceIncluded = true;
   }

--- a/test/base.service.test.js
+++ b/test/base.service.test.js
@@ -10,7 +10,7 @@ const config = buildConfig();
 const server = initialize(config);
 const updatePatient = { id: 'testPatient', name: 'anUpdate' };
 describe('base.service', () => {
-  beforeAll(async () => {
+  beforeEach(async () => {
     await testSetup(testMeasure, testPatient, testLibrary);
   });
   describe('searchById', () => {
@@ -81,19 +81,16 @@ describe('base.service', () => {
         });
     });
 
-    test('test create with missing provenance header', async () => {
+    test('test create with without provenance header', async () => {
       await supertest(server.app)
         .post('/4_0_1/Patient')
         .send(testPatient)
         .set('Accept', 'application/json+fhir')
         .set('content-type', 'application/json+fhir')
-        .expect(400)
+        .expect(201)
         .then(async response => {
           // Check the response
-          expect(response.body.issue[0].code).toEqual('BadRequest');
-          expect(response.body.issue[0].details.text).toEqual(
-            `Ensure Provenance header is populated for this POST/PUT request`
-          );
+          expect(response.headers.location).toBeDefined();
         });
     });
 
@@ -150,19 +147,16 @@ describe('base.service', () => {
           );
         });
     });
-    test('test update with missing provenance header', async () => {
+    test('test update without provenance header', async () => {
       await supertest(server.app)
         .put('/4_0_1/Patient/testPatient')
         .send(updatePatient)
         .set('Accept', 'application/json+fhir')
         .set('content-type', 'application/json+fhir')
-        .expect(400)
+        .expect(200)
         .then(async response => {
           // Check the response
-          expect(response.body.issue[0].code).toEqual('BadRequest');
-          expect(response.body.issue[0].details.text).toEqual(
-            `Ensure Provenance header is populated for this POST/PUT request`
-          );
+          expect(response.headers.location).toBeDefined();
         });
     });
 
@@ -221,7 +215,7 @@ describe('base.service', () => {
     });
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await cleanUpDb();
   });
 });

--- a/test/bundle.service.test.js
+++ b/test/bundle.service.test.js
@@ -50,7 +50,6 @@ describe.only('Test transaction bundle upload', () => {
       .expect(200)
       .then(async response => {
         // Check the response
-        console.log(response.headers['x-provenance']);
         expect(JSON.parse(response.headers['x-provenance']).target).toBeDefined();
       });
   });

--- a/test/bundle.service.test.js
+++ b/test/bundle.service.test.js
@@ -35,7 +35,7 @@ describe('uploadTransactionBundle Server errors', () => {
     }
   });
 });
-describe('Test transaction bundle upload', () => {
+describe.only('Test transaction bundle upload', () => {
   beforeAll(async () => {
     await client.connect();
   });
@@ -46,10 +46,11 @@ describe('Test transaction bundle upload', () => {
       .send(testBundle)
       .set('Accept', 'application/json+fhir')
       .set('content-type', 'application/json+fhir')
-      .set('x-provenance', '{ "resourceType": "Provenance"}')
+      .set('x-provenance', '{"resourceType": "Provenance"}')
       .expect(200)
       .then(async response => {
         // Check the response
+        console.log(response.headers['x-provenance']);
         expect(JSON.parse(response.headers['x-provenance']).target).toBeDefined();
       });
   });

--- a/test/bundle.service.test.js
+++ b/test/bundle.service.test.js
@@ -35,7 +35,7 @@ describe('uploadTransactionBundle Server errors', () => {
     }
   });
 });
-describe.only('Test transaction bundle upload', () => {
+describe('Test transaction bundle upload', () => {
   beforeAll(async () => {
     await client.connect();
   });


### PR DESCRIPTION
# Summary
Updated code so that the X-Provenance header is optional.

## New behavior
It makes more sense right now for the X-Provenance header to be optional for POST/PUT requests until we test X-Provenance more. 

See [the original PR](https://github.com/projecttacoma/deqm-test-server/pull/46) to learn more about X-Provenance.

## Code changes
Changes were made to the base create, base update, and transaction bundle upload to make the X-Provenance header optional. The validation handling and unit tests were updated to reflect these changes.

# Testing guidance
Ensure that the unit tests run. Run the same tests outlined in [the original PR](https://github.com/projecttacoma/deqm-test-server/pull/46) to make sure that functionality is good both with and without the header.
