### PR TITLE
Support for Patient/$everything

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,15 @@ Check out the [$data-requirements operation spec](https://www.hl7.org/fhir/measu
 
 This operation takes a Measure Report and a set of required data with which to calculate the measure, and the server adds new documents to the database for each contained FHIR object. To use, send a valid FHIR parameters object in a POST request to `http://localhost:3000/4_0_1/Measure/$submit-data` or `http://localhost:3000/4_0_1/Measure/<your-measure-id>/$submit-data`.
 
-Check out the [$submit-data operation spec](https://www.hl7.org/fhir/measure-operation-submit-data.html) for more infomration.
+Check out the [$submit-data operation spec](https://www.hl7.org/fhir/measure-operation-submit-data.html) for more information.
+
+#### `Patient/$everything`
+
+This operation returns a searchset bundle containing all the information related to a patient. If no patient ID is specified, bundle will contain information for all patients.
+
+To use, first POST a bundle into your database, then send a GET request to `http://localhost:3000/4_0_1/Patient/<your-patient-id>/$everything` or `http://localhost:3000/4_0_1/Patient/$everything`.
+
+Check out the [Patient-everything operation spec](https://www.hl7.org/fhir/operation-patient-everything.html) for more information.
 
 ### Bulk Data Access
 

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -12,7 +12,7 @@ const {
 } = require('../util/measureOperationsUtils');
 const {
   getMeasureBundleFromId,
-  getPatientDataBundle,
+  getPatientDataCollectionBundle,
   assembleCollectionBundleFromMeasure,
   getQueryFromReference
 } = require('../util/bundleUtils');
@@ -272,7 +272,7 @@ const evaluateMeasure = async (args, { req }) => {
   if (req.query.reportType === 'population') {
     const patients = await findResourcesWithQuery({}, 'Patient');
     let patientBundles = patients.map(async p => {
-      return getPatientDataBundle(p.id, dataReq.results.dataRequirement);
+      return getPatientDataCollectionBundle(p.id, dataReq.results.dataRequirement);
     });
 
     patientBundles = await Promise.all(patientBundles);
@@ -286,7 +286,7 @@ const evaluateMeasure = async (args, { req }) => {
   }
 
   const { periodStart, periodEnd, reportType = 'individual', subject } = req.query;
-  const patientBundle = await getPatientDataBundle(subject, dataReq.results.dataRequirement);
+  const patientBundle = await getPatientDataCollectionBundle(subject, dataReq.results.dataRequirement);
 
   const { results } = await Calculator.calculateMeasureReports(measureBundle, [patientBundle], {
     measurementPeriodStart: periodStart,
@@ -331,7 +331,7 @@ const careGaps = async (args, { req }) => {
 
   const dataReq = Calculator.calculateDataRequirements(measureBundle);
 
-  const patientBundle = await getPatientDataBundle(subject, dataReq.results.dataRequirement);
+  const patientBundle = await getPatientDataCollectionBundle(subject, dataReq.results.dataRequirement);
 
   const { results } = await Calculator.calculateGapsInCare(measureBundle, [patientBundle], {
     measurementPeriodStart: periodStart,

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -27,7 +27,7 @@ const {
 const logger = loggers.get('default');
 
 /**
- * resulting function of sending a POST request to {BASE_URL}/4_0_0/Measure
+ * resulting function of sending a POST request to {BASE_URL}/4_0_1/Measure
  * creates a new measure in the database
  * @param {*} _ unused arg
  * @param {*} data the measure data passed in with the request
@@ -38,7 +38,7 @@ const create = async (_, data) => {
 };
 
 /**
- * result of sending a GET request to {BASE_URL}/4_0_0/Measure/{id}
+ * result of sending a GET request to {BASE_URL}/4_0_1/Measure/{id}
  * searches for the measure with the passed in id
  * @param {*} args passed in arguments including the id of the sought after measure
  * @returns
@@ -48,7 +48,7 @@ const searchById = async args => {
 };
 
 /**
- * result of sending a PUT request to {BASE_URL}/4_0_0/Measure/{id}
+ * result of sending a PUT request to {BASE_URL}/4_0_1/Measure/{id}
  * updates the measure with the passed in id using the passed in data
  * @param {*} args passed in arguments including the id of the sought after measure
  * @param {*} data a map of the attributes to change and their new values
@@ -59,7 +59,7 @@ const update = async (args, data) => {
 };
 
 /**
- * result of sending a DELETE request to {BASE_URL}/4_0_0/Measure/{id}
+ * result of sending a DELETE request to {BASE_URL}/4_0_1/Measure/{id}
  * removes the measure with the passed in id from the database
  * @param {*} args passed in arguments including the id of the sought after measure
  * @returns
@@ -77,7 +77,7 @@ const SEARCH_PARAM_DEFS = {
 };
 
 /**
- * result of sending a GET request to {BASE_URL}/4_0_0/Measure
+ * result of sending a GET request to {BASE_URL}/4_0_1/Measure
  * queries for all measures matching the criteria, only name and version for now
  * @param {Object} args passed in arguments including the search parameters for the Measure
  * @param {Object} req http request object

--- a/src/services/patient.service.js
+++ b/src/services/patient.service.js
@@ -83,6 +83,11 @@ const patientEverything = async (args, { req }) => {
   }
 };
 
+/**
+ * Checks if unsupported parameters are provided in the http request.
+ * If any unsupported parameters are present, a ServerError is thrown.
+ * @param {*} req http request object
+ */
 const validatePatientEverythingParams = req => {
   // These params are not supported. We should throw an error if we receive them
   const UNSUPPORTED_PARAMS = ['start', 'end', '_since', '_type', '_count'];

--- a/src/services/patient.service.js
+++ b/src/services/patient.service.js
@@ -79,7 +79,6 @@ const patientEverything = async (args, { req }) => {
     });
 
     patientBundles = await Promise.all(patientBundles);
-    // want to create into a searchset bundle?
     return patientBundles;
   }
 };

--- a/src/services/patient.service.js
+++ b/src/services/patient.service.js
@@ -1,0 +1,93 @@
+const { loggers } = require('@projecttacoma/node-fhir-server-core');
+const { baseCreate, baseSearchById, baseRemove, baseUpdate, baseSearch } = require('./base.service');
+const { getPatientDataBundle } = require('../util/bundleUtils');
+const { findResourcesWithQuery } = require('../util/mongo.controller');
+const logger = loggers.get('default');
+
+/**
+ * resulting function of sending a POST request to {BASE_URL}/4_0_1/Patient
+ * creates a new patient in the database
+ * @param {*} _ unused arg
+ * @param {*} data the measure data passed in with the request
+ * @returns an object with the created measure's id
+ */
+const create = async (_, data) => {
+  return baseCreate(data, 'Patient');
+};
+
+/**
+ * result of sending a GET request to {BASE_URL}/4_0_1/Patient/{id}
+ * searches for the patient with the passed in id
+ * @param {*} args passed in arguments including the id of the sought after patient
+ * @returns
+ */
+const searchById = async args => {
+  return baseSearchById(args, 'Patient');
+};
+
+/**
+ * result of sending a PUT request to {BASE_URL}/4_0_1/Patient/{id}
+ * updates the patient with the passed in id using the passed in data
+ * @param {*} args passed in arguments including the id of the sought after patient
+ * @param {*} data a map of the attributes to change and their new values
+ * @returns
+ */
+const update = async (args, data) => {
+  return baseUpdate(args, data, 'Patient');
+};
+
+/**
+ * result of sending a DELETE request to {BASE_URL}/4_0_1/Patient/{id}
+ * removes the measure with the passed in id from the database
+ * @param {*} args passed in arguments including the id of the sought after patient
+ * @returns
+ */
+const remove = async args => {
+  return baseRemove(args, 'Patient');
+};
+
+/**
+ * result of sending a GET request to {BASE_URL}/4_0_1/Patient
+ * queries for all measures matching the criteria, only name and version for now
+ * @param {Object} args passed in arguments including the search parameters for the Patient
+ * @param {Object} req http request object
+ * @returns
+ */
+const search = async (args, { req }) => {
+  logger.info('Patient >>> search');
+  return baseSearch(args, { req }, 'Patient');
+};
+
+/**
+ * Result of sending a GET request to {BASE_URL}/4_0_1/Patient/$everything
+ * Returns all information related to patient specified, or all
+ * patients in db (if no id is specified)
+ * @param {Object} args passed in arguments
+ * @param {Object} req http request object
+ */
+const patientEverything = async (args, { req }) => {
+  if (req.params.id) {
+    // return information for specified patient
+    const patientBundle = await getPatientDataBundle(req.params.id);
+    return patientBundle;
+  } else {
+    // return information for all patients
+    const patients = await findResourcesWithQuery({}, 'Patient');
+    let patientBundles = patients.map(async p => {
+      return getPatientDataBundle(p.id);
+    });
+
+    patientBundles = await Promise.all(patientBundles);
+    // want to create into a searchset bundle?
+    return patientBundles;
+  }
+};
+
+module.exports = {
+  create,
+  searchById,
+  remove,
+  update,
+  search,
+  patientEverything
+};

--- a/src/util/bundleUtils.js
+++ b/src/util/bundleUtils.js
@@ -226,6 +226,20 @@ async function getPatientDataSearchSetBundle(patientId, args, req) {
  */
 async function getPatientData(patientId, dataRequirements) {
   const patient = await findResourceById(patientId, 'Patient');
+  if (!patient) {
+    throw new ServerError(null, {
+      statusCode: 404,
+      issue: [
+        {
+          severity: 'error',
+          code: 'ResourceNotFound',
+          details: {
+            text: `Patient with id ${patientId} does not exist in the server`
+          }
+        }
+      ]
+    });
+  }
   let requiredTypes;
   if (dataRequirements) {
     requiredTypes = _.uniq(dataRequirements.map(dr => dr.type));
@@ -243,7 +257,6 @@ async function getPatientData(patientId, dataRequirements) {
     return findResourcesWithQuery({ $or: allQueries }, type);
   });
   const data = await Promise.all(queries);
-
   data.push(patient);
 
   return data;

--- a/src/util/bundleUtils.js
+++ b/src/util/bundleUtils.js
@@ -189,6 +189,17 @@ async function getAllDependentLibraries(lib) {
   return results;
 }
 
+async function getPatientDataCollectionBundle(patientId, dataRequirements) {
+  const data = await getPatientData(patientId, dataRequirements);
+  return mapResourcesToCollectionBundle(_.flattenDeep(data));
+}
+
+async function getPatientDataSearchSetBundle(patientId, args, req) {
+  const data = await getPatientData(patientId);
+  console.log(_.flattenDeep(data));
+  return mapArrayToSearchSetBundle(_.flattenDeep(data), 'Patient', args, req);
+}
+
 /**
  * Assemble the patient bundle to be used in our operations from fqm execution
  * @param {string} patientId patient ID of interest
@@ -196,7 +207,7 @@ async function getAllDependentLibraries(lib) {
  * used when we are concerned with a specific measure. Otherwise undefined
  * @returns patient bundle
  */
-async function getPatientDataBundle(patientId, dataRequirements) {
+async function getPatientData(patientId, dataRequirements) {
   const patient = await findResourceById(patientId, 'Patient');
   let requiredTypes;
   if (dataRequirements) {
@@ -218,7 +229,7 @@ async function getPatientDataBundle(patientId, dataRequirements) {
 
   data.push(patient);
 
-  return mapResourcesToCollectionBundle(_.flattenDeep(data));
+  return data;
 }
 
 /**
@@ -277,7 +288,8 @@ module.exports = {
   mapArrayToSearchSetBundle,
   getMeasureBundleFromId,
   replaceReferences,
-  getPatientDataBundle,
+  getPatientDataCollectionBundle,
+  getPatientDataSearchSetBundle,
   assembleCollectionBundleFromMeasure,
   getQueryFromReference
 };

--- a/src/util/config.js
+++ b/src/util/config.js
@@ -15,6 +15,26 @@ const buildConfig = () => {
   };
   supportedResources.forEach(resourceType => {
     switch (resourceType) {
+      case 'Patient':
+        config.profiles['Patient'] = {
+          service: path.resolve('src', 'services', 'patient.service.js'),
+          versions: [VERSIONS['4_0_1']],
+          operation: [
+            {
+              name: 'patientEverything',
+              route: '/$everything',
+              method: 'GET',
+              reference: 'https://www.hl7.org/fhir/operation-patient-everything.html'
+            },
+            {
+              name: 'patientEverything',
+              route: '/:id/$everything',
+              method: 'GET',
+              reference: 'https://www.hl7.org/fhir/operation-patient-everything.html'
+            }
+          ]
+        };
+        break;
       case 'Measure':
         config.profiles['Measure'] = {
           service: path.resolve('src', 'services', 'measure.service.js'),

--- a/test/bundleUtils.test.js
+++ b/test/bundleUtils.test.js
@@ -1,4 +1,4 @@
-const { replaceReferences, getPatientDataBundle, getQueryFromReference } = require('../src/util/bundleUtils');
+const { replaceReferences, getPatientDataCollectionBundle, getQueryFromReference } = require('../src/util/bundleUtils');
 const supertest = require('supertest');
 const { buildConfig } = require('../src/util/config');
 const { initialize } = require('../src/server/server');
@@ -71,7 +71,7 @@ describe('Testing dynamic querying for patient references using compartment defi
       .set('content-type', 'application/json+fhir')
       .set('x-provenance', '{ "resourceType": "Provenance"}')
       .expect(200);
-    const patientBundle = await getPatientDataBundle('test-patient', testDataReq);
+    const patientBundle = await getPatientDataCollectionBundle('test-patient', testDataReq);
     const procedure = patientBundle.entry.filter(e => e.resource.resourceType === 'Procedure')[0];
     const reference = procedure.resource.subject;
     expect(reference).toEqual({ reference: 'Patient/test-patient' });
@@ -85,7 +85,7 @@ describe('Testing dynamic querying for patient references using compartment defi
       .set('content-type', 'application/json+fhir')
       .set('x-provenance', '{ "resourceType": "Provenance"}')
       .expect(200);
-    const patientBundle = await getPatientDataBundle('test-patient', testDataReq);
+    const patientBundle = await getPatientDataCollectionBundle('test-patient', testDataReq);
     const procedure = patientBundle.entry.filter(e => e.resource.resourceType === 'Procedure')[0];
     const reference = procedure.resource.performer.actor;
     expect(reference).toEqual({ reference: 'Patient/test-patient' });

--- a/test/fixtures/testPatient2.json
+++ b/test/fixtures/testPatient2.json
@@ -1,0 +1,4 @@
+{
+  "resourceType": "Patient",
+  "id": "testPatient2"
+}

--- a/test/patient.service.test.js
+++ b/test/patient.service.test.js
@@ -1,0 +1,109 @@
+require('../src/util/dbconfig');
+const testMeasure = require('./fixtures/testMeasure.json');
+const testLibrary = require('./fixtures/testLibrary.json');
+const testPatient = require('./fixtures/testPatient.json');
+const testPatient2 = require('./fixtures/testPatient2.json');
+const { testSetup, cleanUpDb, createTestResource } = require('./populateTestData');
+const supertest = require('supertest');
+const { buildConfig } = require('../src/util/config');
+const { initialize } = require('../src/server/server');
+const { client } = require('../src/util/mongo');
+
+const config = buildConfig();
+const server = initialize(config);
+const updatePatient = { id: 'testPatient', name: 'anUpdate' };
+describe('measure.service CRUD operations', () => {
+  beforeAll(async () => {
+    await testSetup(testMeasure, testPatient, testLibrary);
+  });
+
+  test('test create with correct headers', async () => {
+    await supertest(server.app)
+      .post('/4_0_1/Patient')
+      .send(testPatient)
+      .set('Accept', 'application/json+fhir')
+      .set('content-type', 'application/json+fhir')
+      .set('x-provenance', '{ "resourceType": "Provenance"}')
+      .expect(201)
+      .then(response => {
+        expect(response.headers.location).toBeDefined();
+      });
+  });
+
+  test('test searchById with correctHeaders and the id should be in database', async () => {
+    await supertest(server.app)
+      .get('/4_0_1/Patient/testPatient')
+      .set('Accept', 'application/json+fhir')
+      .set('content-type', 'application/json+fhir')
+      .expect(200)
+      .then(async response => {
+        expect(response.body.id).toEqual(testPatient.id);
+      });
+  });
+
+  test('test update with correctHeaders and the id is in database', async () => {
+    await supertest(server.app)
+      .put('/4_0_1/Patient/testPatient')
+      .send(updatePatient)
+      .set('Accept', 'application/json+fhir')
+      .set('content-type', 'application/json+fhir')
+      .set('x-provenance', '{ "resourceType": "Provenance"}')
+      .expect(200)
+      .then(async response => {
+        // Check the response
+        expect(response.headers.location).toBeDefined();
+      });
+  });
+
+  test('removing the patient from the database when the patient is indeed present', async () => {
+    await supertest(server.app).delete('/4_0_1/Measure/testPatient').expect(204);
+  });
+
+  afterAll(async () => {
+    await cleanUpDb();
+  });
+});
+
+describe('testing custom measure operation', () => {
+  beforeAll(async () => {
+    await client.connect();
+    await createTestResource(testPatient2, 'Patient');
+    await testSetup(testMeasure, testPatient, testLibrary);
+  });
+
+  test('$everything returns 500 for non-implemented params', async () => {
+    await supertest(server.app)
+      .get('/4_0_1/Patient/$everything?start=STARTDATE')
+      .expect(501)
+      .then(async response => {
+        expect(response.body.issue[0].code).toEqual('NotImplemented');
+        expect(response.body.issue[0].details.text).toEqual(
+          '$everything functionality has not yet been implemented for requests with parameters: start'
+        );
+      });
+  });
+
+  test('$everything returns patient info for single patient', async () => {
+    await supertest(server.app)
+      .get('/4_0_1/Patient/testPatient/$everything')
+      .expect(200)
+      .then(async response => {
+        expect(response.body).toBeDefined();
+        expect(response.body.type).toEqual('searchset');
+      });
+  });
+
+  test('$everything returns patient info for multiple patients', async () => {
+    await supertest(server.app)
+      .get('/4_0_1/Patient/$everything')
+      .expect(200)
+      .then(async response => {
+        expect(response.body).toBeDefined();
+        expect(response.body.length).toEqual(2);
+      });
+  });
+
+  afterAll(async () => {
+    await cleanUpDb();
+  });
+});

--- a/test/populateTestData.js
+++ b/test/populateTestData.js
@@ -25,4 +25,4 @@ const bulkStatusSetup = async () => {
   });
   await Promise.all(promises);
 };
-module.exports = { testSetup, cleanUpDb, bulkStatusSetup };
+module.exports = { testSetup, cleanUpDb, bulkStatusSetup, createTestResource };


### PR DESCRIPTION
# Summary
This PR adds support for the `Patient/$everything` operation in the test server.

## New behavior
This new operation will return all the information related to one of more patients, with a response that is a `searchset` bundle. The operation can be used by sending a `GET` request to `[base]/Patient/$everything` or `[base]/Patient/[id]/$everything`. 

## Code changes
`patient.service.js` was created to cover basic CRUD operations and the `$everything` operation. Parameter validation was added to throw errors if any non-implemented parameters are provided in the request. Note that there are no required parameters for this operation.

`config.js` was updated to support the `$everything` route.

In `bundleutils.js`, the `getPatientDataBundle()` function was changed since we want to use it for the `$everything` operation as well as with measure operations like `$evaluate-measure`. However, the measure operations map to a collection bundle, whereas `$everything` maps to a searchset bundle. Two wrapper functions were created to account for the different bundle type scenarios.

Unit testing was added.
 

# Testing guidance
Ensure that the unit tests pass and provide adequate coverage of the added functionality. Then, POST a bundle containing a patient resource and resources related to the patient. Try sending a GET request and check that the correct response is returned. For example, I POSTed the EXM 130 bundle and then sent requests to
* `http://localhost:3000/4_0_1/Patient/$everything`
* `http://localhost:3000/4_0_1/Patient/numer-EXM130/$everything`
* `http://localhost:3000/4_0_1/Patient/$everything?start=2019-01-01` (will throw ServerError)
