### PR TITLE
Updated config and patient data logic for Patient/$everything

### DIFF
--- a/src/services/patient.service.js
+++ b/src/services/patient.service.js
@@ -1,8 +1,9 @@
 const { ServerError, loggers } = require('@projecttacoma/node-fhir-server-core');
 const { baseCreate, baseSearchById, baseRemove, baseUpdate, baseSearch } = require('./base.service');
-const { getPatientDataSearchSetBundle } = require('../util/bundleUtils');
+const { getPatientDataSearchSetBundle, getPatientData, mapArrayToSearchSetBundle } = require('../util/bundleUtils');
 const { findResourcesWithQuery } = require('../util/mongo.controller');
 const logger = loggers.get('default');
+const _ = require('lodash');
 
 /**
  * resulting function of sending a POST request to {BASE_URL}/4_0_1/Patient
@@ -74,12 +75,12 @@ const patientEverything = async (args, { req }) => {
   } else {
     // return information for all patients
     const patients = await findResourcesWithQuery({}, 'Patient');
-    let patientBundles = patients.map(async p => {
-      return getPatientDataSearchSetBundle(p.id, args, req);
+    let patientData = patients.map(async p => {
+      return getPatientData(p.id);
     });
 
-    patientBundles = await Promise.all(patientBundles);
-    return patientBundles;
+    patientData = await Promise.all(patientData);
+    return mapArrayToSearchSetBundle(_.flattenDeep(patientData), args, req);
   }
 };
 

--- a/src/util/bundleUtils.js
+++ b/src/util/bundleUtils.js
@@ -222,7 +222,7 @@ async function getPatientDataSearchSetBundle(patientId, args, req) {
  * @param {string} patientId patient ID of interest
  * @param {Array} dataRequirements data requirements obtained from fqm execution,
  * used when we are concerned with a specific measure. Otherwise undefined
- * @returns patient bundle
+ * @returns array of resources
  */
 async function getPatientData(patientId, dataRequirements) {
   const patient = await findResourceById(patientId, 'Patient');
@@ -320,6 +320,7 @@ module.exports = {
   replaceReferences,
   getPatientDataCollectionBundle,
   getPatientDataSearchSetBundle,
+  getPatientData,
   assembleCollectionBundleFromMeasure,
   getQueryFromReference
 };

--- a/src/util/config.js
+++ b/src/util/config.js
@@ -28,8 +28,20 @@ const buildConfig = () => {
             },
             {
               name: 'patientEverything',
+              route: '/$everything',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/operation-patient-everything.html'
+            },
+            {
+              name: 'patientEverything',
               route: '/:id/$everything',
               method: 'GET',
+              reference: 'https://www.hl7.org/fhir/operation-patient-everything.html'
+            },
+            {
+              name: 'patientEverything',
+              route: '/:id/$everything',
+              method: 'POST',
               reference: 'https://www.hl7.org/fhir/operation-patient-everything.html'
             }
           ]

--- a/test/patient.service.test.js
+++ b/test/patient.service.test.js
@@ -99,7 +99,6 @@ describe('testing custom measure operation', () => {
       .expect(200)
       .then(async response => {
         expect(response.body).toBeDefined();
-        expect(response.body.length).toEqual(2);
       });
   });
 


### PR DESCRIPTION
# Summary
The config was updated to support POST requests to Patient/$everything so that we can test the operation in the deqm test kit. Updates were made so that Patient/$everything returns a single bundle and not an array of bundles for each patient.

## New behavior
^
## Code changes
yes
# Testing guidance
Ensure that unit tests still pass and that calling `Patient/$everything` will give you a bundle, not an array of bundles.
