### PR TITLE
Add POST support for ops and fix evaluate-measure return

### DIFF
--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -293,7 +293,7 @@ const evaluateMeasure = async (args, { req }) => {
     measurementPeriodEnd: periodEnd,
     reportType: reportType
   });
-  return results;
+  return results[0];
 };
 
 /**

--- a/src/util/config.js
+++ b/src/util/config.js
@@ -83,9 +83,21 @@ const buildConfig = () => {
               reference: 'https://www.hl7.org/fhir/measure-operation-evaluate-measure.html'
             },
             {
+              name: 'evaluateMeasure',
+              route: '/:id/$evaluate-measure',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/measure-operation-evaluate-measure.html'
+            },
+            {
               name: 'careGaps',
               route: '/$care-gaps',
               method: 'GET',
+              reference: 'https://build.fhir.org/ig/HL7/davinci-deqm/OperationDefinition-care-gaps.html'
+            },
+            {
+              name: 'careGaps',
+              route: '/$care-gaps',
+              method: 'POST',
               reference: 'https://build.fhir.org/ig/HL7/davinci-deqm/OperationDefinition-care-gaps.html'
             }
           ]


### PR DESCRIPTION
# Summary

This PR was work done to make the demo work. The deqm-test-kit uses POST requests for all operations, and I added support for POST requests in the config for eval measure and care-gaps.

This PR also fixes an issue where an individual MeasureReport was being returned as a 1-element array from $evaluate-measure. The default return from fqm-e is an array of measure reports for each patient bundle provided, but in this case we are always providing only 1 patient bundle. Therefore, we should only be accessing one measure report for the return result.

## New behavior

* Can send care-gaps and evaluate-measure requests via POST
* $evaluate-measure for an individual no longer responds with an array

## Code changes

* Access first array elem for eval measure
* Add post request config for eval measure and care gaps

# Testing guidance

Test operations with get and post. Test that individual measure report returns one MR, not an array of 1 MR
