### PR TITLE
Audit references

### DIFF
--- a/src/services/bundle.service.js
+++ b/src/services/bundle.service.js
@@ -50,12 +50,12 @@ const makeTransactionResponseBundle = (results, res, baseVersion, type, xprovena
 /**
  * Handles transaction bundles used for submit data.
  * Creates an audit event and uploads the transaction bundles.
- * @param {*} transactionBundles - an array of transactionBundles to handle
- * @param {*} req - an object containing the request body
+ * @param {Array} transactionBundles - an array of transactionBundles to handle
+ * @param {Object} req - an object containing the request body
  * @returns array of transaction-response bundle
  */
 async function handleSubmitDataBundles(transactionBundles, req) {
-  var auditID;
+  let auditID;
   const { base_version: baseVersion } = req.params;
   if (req.headers['x-provenance']) {
     checkProvenanceHeader(req.headers);

--- a/src/services/bundle.service.js
+++ b/src/services/bundle.service.js
@@ -72,7 +72,7 @@ async function handleSubmitDataBundles(transactionBundles, req) {
     if (auditID) {
       // save resources to the AuditEvent
       const entities = bundleResponse.entry.map(entry => {
-        return { what: { reference: entry.response.location.replace(`${baseVersion}/`, '') } }; // TODO: remove '4_0_1'
+        return { what: { reference: entry.response.location.replace(`${baseVersion}/`, '') } };
       });
       // use $each to push multiple
       await pushToResource(auditID, { entity: { $each: entities } }, 'AuditEvent');

--- a/src/services/bundle.service.js
+++ b/src/services/bundle.service.js
@@ -57,8 +57,8 @@ const makeTransactionResponseBundle = (results, res, baseVersion, type, xprovena
 // TODO: does this need to be async?
 async function handleSubmitDataBundles(transactionBundles, req){
   var auditID;
+  const { base_version: baseVersion } = req.params;
   if (req.headers['x-provenance']) {
-    const { base_version: baseVersion } = req.params;
     // create AuditEvent
     // const { base_version: baseVersion } = req.params;
     // const AuditEvent = resolveSchema(baseVersion, 'AuditEvent');
@@ -77,7 +77,7 @@ async function handleSubmitDataBundles(transactionBundles, req){
   }
 
   // upload transaction bundles and add resources to auditevent from those successfully uploaded
-  const temp = transactionBundles.map(async tb => {
+  return transactionBundles.map(async tb => {
 
     // Check upload succeeds
     //TODO: does this need to be toJSON or not? (might depend on what's calling it and need to be fixed on the calling side)
@@ -88,7 +88,7 @@ async function handleSubmitDataBundles(transactionBundles, req){
       // save resources to the AuditEvent
       
       const entities = bundleResponse.entry.map(entry => {
-        return {what: {reference: entry.response.location} } // TODO: remove '4_0_1'
+        return {what: {reference: entry.response.location.replace(`${baseVersion}/`,'')} } // TODO: remove '4_0_1'
       });
       // use $each to push multiple
       await pushToResource(auditID, {entity:{ $each: entities }}, 'AuditEvent')
@@ -97,7 +97,6 @@ async function handleSubmitDataBundles(transactionBundles, req){
 
     return bundleResponse;
   });
-  return temp;
 }
 
 /**

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -159,7 +159,7 @@ const submitData = async (args, { req }) => {
 
     tb.addEntryFromResource(param.resource, 'POST');
   });
-  const output = await handleSubmitDataBundles([tb],req);
+  const output = await handleSubmitDataBundles([tb], req);
   // expect exactly one output because uses exactly one transaction bundle
   return output[0];
 };
@@ -226,7 +226,7 @@ const executePingAndPull = async (clientEntryId, exportUrl, measureBundle, req) 
     ).catch(async e => {
       await failBulkImportRequest(clientEntryId, e);
     });
-    const pendingTransactionBundles = handleSubmitDataBundles(transactionBundles, req)
+    const pendingTransactionBundles = handleSubmitDataBundles(transactionBundles, req);
     await Promise.all(pendingTransactionBundles);
     await completeBulkImportRequest(clientEntryId);
   } catch (e) {

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -3,7 +3,7 @@ const { BulkImportWrappers } = require('bulk-data-utilities');
 const { Calculator } = require('fqm-execution');
 const { baseCreate, baseSearchById, baseRemove, baseUpdate, baseSearch } = require('./base.service');
 const { createTransactionBundleClass } = require('../resources/transactionBundle');
-const { uploadTransactionBundle } = require('./bundle.service');
+const { handleSubmitDataBundles } = require('./bundle.service');
 const {
   retrieveExportURL,
   validateEvalMeasureParams,
@@ -21,10 +21,8 @@ const {
   addPendingBulkImportRequest,
   failBulkImportRequest,
   completeBulkImportRequest,
-  findResourcesWithQuery,
-  createResource
+  findResourcesWithQuery
 } = require('../util/mongo.controller');
-const { createAuditEventFromProvenance } = require('../util/provenanceUtils');
 
 const logger = loggers.get('default');
 
@@ -161,13 +159,9 @@ const submitData = async (args, { req }) => {
 
     tb.addEntryFromResource(param.resource, 'POST');
   });
-  req.body = tb.toJSON();
-  const output = await uploadTransactionBundle(req, req.res);
-  if (req.headers['x-provenance']) {
-    const auditEvent = createAuditEventFromProvenance(req.headers['x-provenance'], args);
-    await createResource(auditEvent, 'AuditEvent');
-  }
-  return output;
+  const output = await handleSubmitDataBundles([tb],req);
+  // expect exactly one output because uses exactly one transaction bundle
+  return output[0];
 };
 
 /**
@@ -217,7 +211,7 @@ const bulkImport = async (args, { req }) => {
 /**
  * Calls the bulk-data-utilities wrapper function to get data requirements for the passed in measure, convert those to
  * export requests from a bulk export server, then retrieve ndjson from that server and parse it into valid transaction bundles.
- * Finally, uploads the resulting transaction bundles to the server and updateed the bulkstatus endpoint
+ * Finally, uploads the resulting transaction bundles to the server and updates the bulkstatus endpoint
  * @param {*} clientEntryId The unique identifier which corresponds to the bulkstatus content location for update
  * @param {*} exportUrl The url of the bulk export fhir server
  * @param {*} measureBundle The measure bundle for which to retrieve data requirements
@@ -232,9 +226,7 @@ const executePingAndPull = async (clientEntryId, exportUrl, measureBundle, req) 
     ).catch(async e => {
       await failBulkImportRequest(clientEntryId, e);
     });
-    const pendingTransactionBundles = transactionBundles.map(async tb => {
-      return uploadTransactionBundle({ ...req, body: tb }, req.res);
-    });
+    const pendingTransactionBundles = handleSubmitDataBundles(transactionBundles, req)
     await Promise.all(pendingTransactionBundles);
     await completeBulkImportRequest(clientEntryId);
   } catch (e) {

--- a/src/util/bundleUtils.js
+++ b/src/util/bundleUtils.js
@@ -269,7 +269,7 @@ async function getPatientData(patientId, dataRequirements) {
  * Modify the request type to PUT after forcing the IDs. This will not affect return results, just internal representation
  *
  * @param {Array} entries array of bundle entries
- * @returns new array of entries with replaced reverences
+ * @returns new array of entries with replaced references
  */
 function replaceReferences(entries) {
   // Add metadata for old IDs and newly created ones of POST entries

--- a/src/util/mongo.controller.js
+++ b/src/util/mongo.controller.js
@@ -69,7 +69,7 @@ const updateResource = async (id, data, resourceType) => {
  * @param {*} resourceType the collection the document is in
  * @returns the id of the updated/created document
  */
- const pushToResource = async (id, data, resourceType) => {
+const pushToResource = async (id, data, resourceType) => {
   const collection = db.collection(resourceType);
 
   // TODO: multiple requires an $each i.e. data = { scores: { $each: [ 90, 92, 85 ] } }

--- a/src/util/mongo.controller.js
+++ b/src/util/mongo.controller.js
@@ -64,9 +64,9 @@ const updateResource = async (id, data, resourceType) => {
 
 /**
  * searches for a document and updates it by pushing to existing if found, creates it if not
- * @param {*} id id of resource to be updated
- * @param {*} data the new data to push in the document
- * @param {*} resourceType the collection the document is in
+ * @param {string} id id of resource to be updated
+ * @param {Object} data the new data to push in the document
+ * @param {string} resourceType the collection the document is in
  * @returns the id of the updated/created document
  */
 const pushToResource = async (id, data, resourceType) => {

--- a/src/util/mongo.controller.js
+++ b/src/util/mongo.controller.js
@@ -72,8 +72,6 @@ const updateResource = async (id, data, resourceType) => {
 const pushToResource = async (id, data, resourceType) => {
   const collection = db.collection(resourceType);
 
-  // TODO: multiple requires an $each i.e. data = { scores: { $each: [ 90, 92, 85 ] } }
-  // should $each be passed in as data, or is that bad modularization?
   const results = await collection.findOneAndUpdate({ id: id }, { $push: data });
 
   // If the document cannot be created with the passed id, Mongo will throw an error

--- a/src/util/mongo.controller.js
+++ b/src/util/mongo.controller.js
@@ -63,7 +63,8 @@ const updateResource = async (id, data, resourceType) => {
 };
 
 /**
- * searches for a document and updates it by pushing to existing if found, creates it if not
+ * searches for a document and updates it by pushing to existing
+ * should not be called for document that doesn't exist or for data that doesn't already exist
  * @param {string} id id of resource to be updated
  * @param {Object} data the new data to push in the document
  * @param {string} resourceType the collection the document is in
@@ -71,18 +72,7 @@ const updateResource = async (id, data, resourceType) => {
  */
 const pushToResource = async (id, data, resourceType) => {
   const collection = db.collection(resourceType);
-
-  const results = await collection.findOneAndUpdate({ id: id }, { $push: data });
-
-  // If the document cannot be created with the passed id, Mongo will throw an error
-  // before here, so should be ok to just return the passed id
-  if (results.value === null) {
-    // null value indicates a newly created document
-    return { id: id, created: true };
-  }
-
-  // value being present indicates an update, so set created flag to false
-  return { id: results.value.id, created: false };
+  await collection.findOneAndUpdate({ id: id }, { $push: data });
 };
 
 /**

--- a/src/util/provenanceUtils.js
+++ b/src/util/provenanceUtils.js
@@ -61,6 +61,7 @@ const createAuditEventFromProvenance = (provenance, version) => {
   });
   audit.source = { observer: source };
   audit['id'] = uuidv4();
+  audit.entity = [];
   const AuditEvent = resolveSchema(version, 'auditevent');
   return new AuditEvent(audit).toJSON();
 };

--- a/src/util/provenanceUtils.js
+++ b/src/util/provenanceUtils.js
@@ -36,7 +36,7 @@ const createAuditEventFromProvenance = (provenance, version) => {
   }
   let source = {};
   audit.agent = [];
-  provenance?.agent?.forEach(agent => {
+  provenance.agent.forEach(agent => {
     agent['requestor'] = true;
 
     // TODO: should these be safe-accessed?

--- a/src/util/provenanceUtils.js
+++ b/src/util/provenanceUtils.js
@@ -4,10 +4,10 @@ const { v4: uuidv4 } = require('uuid');
 /**
  * Creates a raw JSON AuditEvent resource from the X-Provenance headers of a submission request
  * @param {string} provenance the provenance headers in string form from the request
- * @param {Object} args the object containing the base_version parameter
+ * @param {Object} version base_version from parameter
  * @returns A JSON object representing an AuditEvent to be stored in the system
  */
-const createAuditEventFromProvenance = (provenance, args) => {
+const createAuditEventFromProvenance = (provenance, version) => {
   provenance = JSON.parse(provenance);
   const audit = {};
   audit.type = {
@@ -36,9 +36,10 @@ const createAuditEventFromProvenance = (provenance, args) => {
   }
   let source = {};
   audit.agent = [];
-  provenance.agent.forEach(agent => {
+  provenance?.agent?.forEach(agent => {
     agent['requestor'] = true;
 
+    // TODO: should these be safe-accessed?
     if (agent.role.coding.some(role => role.code === 'AGNT')) {
       agent['requestor'] = false;
       source = agent.who;
@@ -60,7 +61,7 @@ const createAuditEventFromProvenance = (provenance, args) => {
   });
   audit.source = { observer: source };
   audit['id'] = uuidv4();
-  const AuditEvent = resolveSchema(args.base_version, 'auditevent');
+  const AuditEvent = resolveSchema(version, 'auditevent');
   return new AuditEvent(audit).toJSON();
 };
 

--- a/src/util/provenanceUtils.js
+++ b/src/util/provenanceUtils.js
@@ -39,12 +39,11 @@ const createAuditEventFromProvenance = (provenance, version) => {
   provenance.agent.forEach(agent => {
     agent['requestor'] = true;
 
-    // TODO: should these be safe-accessed?
-    if (agent.role.coding.some(role => role.code === 'AGNT')) {
+    if (agent.role?.coding?.some(role => role.code === 'AGNT')) {
       agent['requestor'] = false;
       source = agent.who;
     }
-    if (agent.role.coding.some(role => role.code === 'ASSIGNED')) {
+    if (agent.role?.coding?.some(role => role.code === 'ASSIGNED')) {
       source = agent.who;
     }
 

--- a/test/bundle.service.test.js
+++ b/test/bundle.service.test.js
@@ -73,10 +73,9 @@ describe('Test handle submit data bundle', () => {
       .set('Accept', 'application/json+fhir')
       .set('content-type', 'application/json+fhir')
       .set('x-provenance', JSON.stringify(SINGLE_AGENT_PROVENANCE))
-      .expect(500)
+      .expect(200)
       .then(async response => {
         // Check the response
-        expect(response.body).toEqual("");
         expect(JSON.parse(response.headers['x-provenance']).target).toBeDefined();
       });
     // Check for AuditEvent with resources
@@ -89,6 +88,9 @@ describe('Test handle submit data bundle', () => {
           expect(response.body.type).toEqual('searchset');
           expect(response.body.total).toEqual(1);
           expect(response.body.entry[0].resource.resourceType).toEqual('AuditEvent');
+          const entities = response.body.entry[0].resource.entity;
+          expect(entities.some(ent => ent.what.reference.startsWith("MeasureReport"))).toBe(true);
+          expect(entities.some(ent => ent.what.reference.startsWith("Encounter"))).toBe(true);
         });
   });
 

--- a/test/bundle.service.test.js
+++ b/test/bundle.service.test.js
@@ -80,18 +80,18 @@ describe('Test handle submit data bundle', () => {
       });
     // Check for AuditEvent with resources
     await supertest(server.app)
-        .get('/4_0_1/AuditEvent')
-        .set('Accept', 'application/json+fhir')
-        .expect(200)
-        .then(async response => {
-          expect(response.body.resourceType).toEqual('Bundle');
-          expect(response.body.type).toEqual('searchset');
-          expect(response.body.total).toEqual(1);
-          expect(response.body.entry[0].resource.resourceType).toEqual('AuditEvent');
-          const entities = response.body.entry[0].resource.entity;
-          expect(entities.some(ent => ent.what.reference.startsWith("MeasureReport"))).toBe(true);
-          expect(entities.some(ent => ent.what.reference.startsWith("Encounter"))).toBe(true);
-        });
+      .get('/4_0_1/AuditEvent')
+      .set('Accept', 'application/json+fhir')
+      .expect(200)
+      .then(async response => {
+        expect(response.body.resourceType).toEqual('Bundle');
+        expect(response.body.type).toEqual('searchset');
+        expect(response.body.total).toEqual(1);
+        expect(response.body.entry[0].resource.resourceType).toEqual('AuditEvent');
+        const entities = response.body.entry[0].resource.entity;
+        expect(entities.some(ent => ent.what.reference.startsWith('MeasureReport'))).toBe(true);
+        expect(entities.some(ent => ent.what.reference.startsWith('Encounter'))).toBe(true);
+      });
   });
 
   afterAll(async () => {

--- a/test/bundle.service.test.js
+++ b/test/bundle.service.test.js
@@ -1,5 +1,6 @@
 const { uploadTransactionBundle } = require('../src/services/bundle.service');
 const testBundle = require('./fixtures/testBundle.json');
+const testParamResource = require('./fixtures/parametersObjs/paramNoExportResource.json');
 const { client } = require('../src/util/mongo');
 const { cleanUpDb } = require('./populateTestData');
 const supertest = require('supertest');
@@ -53,6 +54,42 @@ describe('Test transaction bundle upload', () => {
         // Check the response
         expect(JSON.parse(response.headers['x-provenance']).target).toBeDefined();
       });
+  });
+
+  afterAll(async () => {
+    await cleanUpDb();
+  });
+});
+
+describe('Test handle submit data bundle', () => {
+  beforeAll(async () => {
+    await client.connect();
+  });
+
+  test('Submit data bundle with resources creates AuditEvent with resources', async () => {
+    await supertest(server.app)
+      .post('/4_0_1/Measure/$submit-data')
+      .send(testParamResource)
+      .set('Accept', 'application/json+fhir')
+      .set('content-type', 'application/json+fhir')
+      .set('x-provenance', JSON.stringify(SINGLE_AGENT_PROVENANCE))
+      .expect(500)
+      .then(async response => {
+        // Check the response
+        expect(response.body).toEqual("");
+        expect(JSON.parse(response.headers['x-provenance']).target).toBeDefined();
+      });
+    // Check for AuditEvent with resources
+    await supertest(server.app)
+        .get('/4_0_1/AuditEvent')
+        .set('Accept', 'application/json+fhir')
+        .expect(200)
+        .then(async response => {
+          expect(response.body.resourceType).toEqual('Bundle');
+          expect(response.body.type).toEqual('searchset');
+          expect(response.body.total).toEqual(1);
+          expect(response.body.entry[0].resource.resourceType).toEqual('AuditEvent');
+        });
   });
 
   afterAll(async () => {

--- a/test/fixtures/parametersObjs/paramNoExportResource.json
+++ b/test/fixtures/parametersObjs/paramNoExportResource.json
@@ -1,0 +1,21 @@
+{
+  "resourceType": "Parameters",
+  "parameter": [
+    {
+      "name": "measureReport",
+      "resource": {
+        "resourceType": "MeasureReport",
+        "id": "measurereport-testMeasure",
+        "measure": "Measure/testMeasure"
+      }
+    },
+    {
+      "name": "resource",
+      "resource": {
+        "resourceType": "Encounter",
+        "id": "test-encounter",
+        "status": "finished"
+      }
+    }
+  ]
+}

--- a/test/fixtures/testProvenanceUtils.js
+++ b/test/fixtures/testProvenanceUtils.js
@@ -218,6 +218,7 @@ const ON_BEHALF_OF_PROVENANCE = {
 const SINGLE_AGENT_AUDIT = {
   resourceType: 'AuditEvent',
   id: 'TEST_ID',
+  entity: [],
   type: {
     system: 'http://dicom.nema.org/resources/ontology/DCM',
     code: '110100',
@@ -270,6 +271,7 @@ const SINGLE_AGENT_AUDIT = {
 const AMENDING_AUDIT = {
   resourceType: 'AuditEvent',
   id: 'TEST_ID',
+  entity: [],
   type: {
     system: 'http://dicom.nema.org/resources/ontology/DCM',
     code: '110100',
@@ -338,6 +340,7 @@ const AMENDING_AUDIT = {
 const ON_BEHALF_OF_AUDIT = {
   resourceType: 'AuditEvent',
   id: 'TEST_ID',
+  entity: [],
   type: {
     system: 'http://dicom.nema.org/resources/ontology/DCM',
     code: '110100',

--- a/test/measure.service.test.js
+++ b/test/measure.service.test.js
@@ -3,6 +3,7 @@ const testMeasure = require('./fixtures/testMeasure.json');
 const testLibrary = require('./fixtures/testLibrary.json');
 const testPatient = require('./fixtures/testPatient.json');
 const testParam = require('./fixtures/parametersObjs/paramNoExport.json');
+const testParamResource = require('./fixtures/parametersObjs/paramNoExportResource.json');
 const testParamTwoExports = require('./fixtures/parametersObjs/paramTwoExports.json');
 const testParamNoValString = require('./fixtures/parametersObjs/paramNoValueString.json');
 const testParamInvalidResourceType = require('./fixtures/parametersObjs/paramInvalidType.json');
@@ -109,6 +110,31 @@ describe('bulkImport with exportURL', () => {
   });
 });
 
+describe('testing submit data with a resource', () => {
+  beforeAll(async () => {
+    await testSetup(testMeasure, testPatient, testLibrary);
+  });
+  test('$submit-data uploads txn bundle for valid parameters request with resource', async () => {
+    // uuidv4.mockImplementationOnce(() => `testid`);
+    // uuidv4.mockImplementationOnce(() => `encounterid`);
+    await supertest(server.app)
+      .post('/4_0_1/Measure/$submit-data')
+      .send(testParamResource)
+      .set('Accept', 'application/json+fhir')
+      .set('content-type', 'application/json+fhir')
+      .set('x-provenance', JSON.stringify(SINGLE_AGENT_PROVENANCE))
+      .expect(200)
+      .then(async response => {
+        expect(response.body.entry[0].response.status).toEqual('201 Created');
+        expect(response.body.resourceType).toEqual('Bundle');
+        expect(response.body.type).toEqual('transaction-response');
+      });
+  });
+  afterAll(async () => {
+    await cleanUpDb();
+  });
+});
+
 describe('testing custom measure operation', () => {
   beforeAll(async () => {
     await testSetup(testMeasure, testPatient, testLibrary);
@@ -173,6 +199,7 @@ describe('testing custom measure operation', () => {
         expect(response.body.type).toEqual('transaction-response');
       });
   });
+
   test('$evaluate-measure returns 200 when subject is omitted and reportType is set to population', async () => {
     const { Calculator } = require('fqm-execution');
     const mrSpy = jest.spyOn(Calculator, 'calculateMeasureReports').mockImplementation(() => {

--- a/test/measure.service.test.js
+++ b/test/measure.service.test.js
@@ -110,31 +110,6 @@ describe('bulkImport with exportURL', () => {
   });
 });
 
-describe('testing submit data with a resource', () => {
-  beforeAll(async () => {
-    await testSetup(testMeasure, testPatient, testLibrary);
-  });
-  test('$submit-data uploads txn bundle for valid parameters request with resource', async () => {
-    // uuidv4.mockImplementationOnce(() => `testid`);
-    // uuidv4.mockImplementationOnce(() => `encounterid`);
-    await supertest(server.app)
-      .post('/4_0_1/Measure/$submit-data')
-      .send(testParamResource)
-      .set('Accept', 'application/json+fhir')
-      .set('content-type', 'application/json+fhir')
-      .set('x-provenance', JSON.stringify(SINGLE_AGENT_PROVENANCE))
-      .expect(200)
-      .then(async response => {
-        expect(response.body.entry[0].response.status).toEqual('201 Created');
-        expect(response.body.resourceType).toEqual('Bundle');
-        expect(response.body.type).toEqual('transaction-response');
-      });
-  });
-  afterAll(async () => {
-    await cleanUpDb();
-  });
-});
-
 describe('testing custom measure operation', () => {
   beforeAll(async () => {
     await testSetup(testMeasure, testPatient, testLibrary);
@@ -189,6 +164,21 @@ describe('testing custom measure operation', () => {
     await supertest(server.app)
       .post('/4_0_1/Measure/$submit-data')
       .send(testParam)
+      .set('Accept', 'application/json+fhir')
+      .set('content-type', 'application/json+fhir')
+      .set('x-provenance', JSON.stringify(SINGLE_AGENT_PROVENANCE))
+      .expect(200)
+      .then(async response => {
+        expect(response.body.entry[0].response.status).toEqual('201 Created');
+        expect(response.body.resourceType).toEqual('Bundle');
+        expect(response.body.type).toEqual('transaction-response');
+      });
+  });
+
+  test('$submit-data uploads txn bundle for valid parameters request with resource', async () => {
+    await supertest(server.app)
+      .post('/4_0_1/Measure/$submit-data')
+      .send(testParamResource)
       .set('Accept', 'application/json+fhir')
       .set('content-type', 'application/json+fhir')
       .set('x-provenance', JSON.stringify(SINGLE_AGENT_PROVENANCE))

--- a/test/provenanceUtils.test.js
+++ b/test/provenanceUtils.test.js
@@ -32,16 +32,16 @@ describe('provenanceUtils tests', () => {
   test('createAuditEventFromProvenance works with single agent acting by itself', () => {
     let expected = resolveSchema('4_0_1', 'auditevent');
     expected = new expected(SINGLE_AGENT_AUDIT);
-    expect(createAuditEventFromProvenance(JSON.stringify(SINGLE_AGENT_PROVENANCE), args)).toEqual(expected.toJSON());
+    expect(createAuditEventFromProvenance(JSON.stringify(SINGLE_AGENT_PROVENANCE), args.base_version)).toEqual(expected.toJSON());
   });
   test('createAuditEventFromProvenance works with single agent acting on behalf of another', () => {
     let expected = resolveSchema('4_0_1', 'auditevent');
     expected = new expected(ON_BEHALF_OF_AUDIT);
-    expect(createAuditEventFromProvenance(JSON.stringify(ON_BEHALF_OF_PROVENANCE), args)).toEqual(expected.toJSON());
+    expect(createAuditEventFromProvenance(JSON.stringify(ON_BEHALF_OF_PROVENANCE), args.base_version)).toEqual(expected.toJSON());
   });
   test('createAuditEventFromProvenance works with single agent updating a resource', () => {
     let expected = resolveSchema('4_0_1', 'auditevent');
     expected = new expected(AMENDING_AUDIT);
-    expect(createAuditEventFromProvenance(JSON.stringify(AMENDING_PROVENANCE), args)).toEqual(expected.toJSON());
+    expect(createAuditEventFromProvenance(JSON.stringify(AMENDING_PROVENANCE), args.base_version)).toEqual(expected.toJSON());
   });
 });

--- a/test/provenanceUtils.test.js
+++ b/test/provenanceUtils.test.js
@@ -32,16 +32,22 @@ describe('provenanceUtils tests', () => {
   test('createAuditEventFromProvenance works with single agent acting by itself', () => {
     let expected = resolveSchema('4_0_1', 'auditevent');
     expected = new expected(SINGLE_AGENT_AUDIT);
-    expect(createAuditEventFromProvenance(JSON.stringify(SINGLE_AGENT_PROVENANCE), args.base_version)).toEqual(expected.toJSON());
+    expect(createAuditEventFromProvenance(JSON.stringify(SINGLE_AGENT_PROVENANCE), args.base_version)).toEqual(
+      expected.toJSON()
+    );
   });
   test('createAuditEventFromProvenance works with single agent acting on behalf of another', () => {
     let expected = resolveSchema('4_0_1', 'auditevent');
     expected = new expected(ON_BEHALF_OF_AUDIT);
-    expect(createAuditEventFromProvenance(JSON.stringify(ON_BEHALF_OF_PROVENANCE), args.base_version)).toEqual(expected.toJSON());
+    expect(createAuditEventFromProvenance(JSON.stringify(ON_BEHALF_OF_PROVENANCE), args.base_version)).toEqual(
+      expected.toJSON()
+    );
   });
   test('createAuditEventFromProvenance works with single agent updating a resource', () => {
     let expected = resolveSchema('4_0_1', 'auditevent');
     expected = new expected(AMENDING_AUDIT);
-    expect(createAuditEventFromProvenance(JSON.stringify(AMENDING_PROVENANCE), args.base_version)).toEqual(expected.toJSON());
+    expect(createAuditEventFromProvenance(JSON.stringify(AMENDING_PROVENANCE), args.base_version)).toEqual(
+      expected.toJSON()
+    );
   });
 });


### PR DESCRIPTION
# Summary
Changes the creation of AuditEvents a bit from Nat's code since these were developed at the same time a little differently, but otherwise uses Nat's X-provenance mapping to create AuditEvents and adds references to the uploaded resources. Adds some tests to exercise resources in the request body and check for AuditEvent added.

## New behavior
References to the submitted resources (with appropriate resource location) are added to the audit event.

## Code changes
Creates a new pushToResource function for adding to arrays on a mongo resource.
Uses new `handleSubmitDataBundles` function to do appropriate bundle handling for submit data including creating the audit event.
Makes changes in places where `uploadTransactionBundle` to use `handleSubmitDataBundles` more generically instead.

# Testing guidance
Make sure mongo is running. Run tests with `npm run test`. Submit test requests with resources in the body and X-Provenance headers to http://localhost:3000/4_0_0/Measure/$submit-data
An example of parameters with resources can be found here: https://github.com/projecttacoma/deqm-test-server/blob/audit_references/test/fixtures/parametersObjs/paramNoExportResource.json
An example of xprovenance for the header can be found here: https://github.com/projecttacoma/deqm-test-server/blob/cd73371ea381b71edae05f4fd4c39105d5622c4d/test/fixtures/testProvenanceUtils.js#L22
Feel free to play around with the data to break.
Use robo 3t or a get request to http://localhost:3000/4_0_0/AuditEvent to look at the created AuditEvents and ensure that they have the correct references to the submitted resources
This should also work for a bulk submit data.
