### PR TITLE
Import endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,9 @@ Check out the [Patient-everything operation spec](https://www.hl7.org/fhir/opera
 
 The server contains functionality for the FHIR Bulk Data Import operation using the [Ping and Pull Approach](https://github.com/smart-on-fhir/bulk-import/blob/master/import-pnp.md).
 
-To implement the bulk data import operation, first POST a valid transaction bundle. Then, POST a valid FHIR parameters object to `http://localhost:3000/4_0_1/Measure/$submit-data` or `http://localhost:3000/4_0_1/Measure/<your-measure-id>/$submit-data` with the `"prefer": "respond-async"` header populated. This will kick off the "ping and pull" bulk import.
+To implement a bulk data import operation of all the resources on a FHIR Bulk Data Export server, POST a valid FHIR parameters object to `http://localhost:3000/$import`. Use the parameter format below to specify a bulk export server.
+
+To implement the bulk data import operation from the data requirements for a specific measure, first POST a valid transaction bundle. Then, POST a valid FHIR parameters object to `http://localhost:3000/4_0_1/Measure/$submit-data` or `http://localhost:3000/4_0_1/Measure/<your-measure-id>/$submit-data` with the `"prefer": "respond-async"` header populated. This will kick off the "ping and pull" bulk import.
 
 For the bulk data import operation to be successful, the user must specify an export URL to a FHIR Bulk Data Export server in the request body of the FHIR parameters object. For example, in the `parameter` array of the FHIR parameters object, the user can include
 
@@ -173,6 +175,8 @@ For the bulk data import operation to be successful, the user must specify an ex
 ```
 
 with a valid kickoff endpoint URL for the `valueString`.
+
+The user can check the status of an $import or async $submit-data request by copying the content-location header in the response, and sending a GET request to `http://localhost:3000/<content-location-header>`.
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2680,7 +2680,7 @@
       "dev": true
     },
     "bulk-data-utilities": {
-      "version": "git+https://github.com/projecttacoma/bulk-data-utilities.git#fb04a13d49357b74e6e8fed55e97d44a4b490c2d",
+      "version": "git+https://github.com/projecttacoma/bulk-data-utilities.git#0c86db4a8ac1bad422574ee33b75ff0b16dfca08",
       "from": "git+https://github.com/projecttacoma/bulk-data-utilities.git",
       "requires": {
         "axios": "^0.21.2",
@@ -6640,9 +6640,9 @@
       "dev": true
     },
     "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "optional": true
     },
     "json-schema-traverse": {
@@ -6707,14 +6707,14 @@
       }
     },
     "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "optional": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
+        "json-schema": "0.4.0",
         "verror": "1.10.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "db:reset": "npm run db:delete && npm run db:setup",
     "parse-references": "node src/scripts/parseCompartmentDefinition.js",
     "connectathon-upload": "node src/scripts/getConnectathonBundles.js",
-    "test": "jest --silent --runInBand",
+    "test": "jest --silent --runInBand --forceExit",
     "test:coverage": "jest --collectCoverage --silent --runInBand",
     "test:watch": "jest --watchAll --runInBand",
     "test:watch:coverage": "jest --watchAll --runInBand --collectCoverage"

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -1,6 +1,7 @@
 const { Server } = require('@projecttacoma/node-fhir-server-core');
 const configTransaction = require('../services/bundle.controller');
 const configBulkStatus = require('../services/bulkstatus.controller');
+const configBulkImport = require('../services/import.controller');
 
 class DEQMServer extends Server {
   enableTransactionRoute() {
@@ -10,6 +11,10 @@ class DEQMServer extends Server {
   }
   enableBulkStatusRoute() {
     this.app.get('/:base_version/bulkstatus/:client_id', configBulkStatus.bulkstatus);
+    return this;
+  }
+  enableImportRoute() {
+    this.app.post('/:base_version/([$])import/', configBulkImport.bulkImport);
     return this;
   }
 }
@@ -23,6 +28,7 @@ function initialize(config, app) {
     .setPublicDirectory()
     .enableTransactionRoute()
     .enableBulkStatusRoute()
+    .enableImportRoute()
     .setProfileRoutes()
     .setErrorRoutes();
 }

--- a/src/services/bundle.service.js
+++ b/src/services/bundle.service.js
@@ -62,10 +62,11 @@ async function handleSubmitDataBundles(transactionBundles, req) {
     const auditEvent = createAuditEventFromProvenance(req.headers['x-provenance'], baseVersion);
     auditID = (await createResource(auditEvent, 'AuditEvent')).id;
   }
-
+  const tbTemplate = resolveSchema(baseVersion, 'bundle');
   // upload transaction bundles and add resources to auditevent from those successfully uploaded
   return transactionBundles.map(async tb => {
     // Check upload succeeds
+    tb = new tbTemplate(tb);
     req.body = tb.toJSON();
     const bundleResponse = await uploadTransactionBundle(req, req.res);
 
@@ -77,7 +78,6 @@ async function handleSubmitDataBundles(transactionBundles, req) {
       // use $each to push multiple
       await pushToResource(auditID, { entity: { $each: entities } }, 'AuditEvent');
     }
-
     return bundleResponse;
   });
 }

--- a/src/services/import.controller.js
+++ b/src/services/import.controller.js
@@ -1,0 +1,12 @@
+const service = require('./import.service');
+
+/**
+ * @name exports
+ * @summary import controller
+ */
+module.exports.bulkImport = (req, res, next) => {
+  return service
+    .bulkImport(req, res)
+    .then(result => res.status(200).json(result))
+    .catch(err => next(err));
+};

--- a/src/services/import.service.js
+++ b/src/services/import.service.js
@@ -12,11 +12,11 @@ const logger = loggers.get('default');
 
 async function bulkImport(req, res) {
   logger.info('Measure >>> $bulk-import');
-  // id of inserted client
+  // ID assigned to the requesting client
   const clientEntry = await addPendingBulkImportRequest();
   const parameters = req.body.parameter;
   const exportURL = retrieveExportURL(parameters);
-
+  //When we move to a job queue, remove --forceExist from test script in package.json
   executePingAndPull(clientEntry, exportURL, req);
   res.status(202);
   res.status = () => res;

--- a/src/services/import.service.js
+++ b/src/services/import.service.js
@@ -10,6 +10,12 @@ const { handleSubmitDataBundles } = require('./bundle.service');
 
 const logger = loggers.get('default');
 
+/**
+ * Executes an import of all the resources on the passed in server.
+ * @param {Object} req The request object passed in by the client
+ * @param {Object} res The response object returned to the client by the server
+ * @returns void
+ */
 async function bulkImport(req, res) {
   logger.info('Measure >>> $bulk-import');
   // ID assigned to the requesting client

--- a/src/services/import.service.js
+++ b/src/services/import.service.js
@@ -43,14 +43,15 @@ async function bulkImport(req, res) {
 const executePingAndPull = async (clientEntryId, exportUrl, req, measureBundle) => {
   try {
     const transactionBundles = await BulkImportWrappers.executeBulkImport(
-      measureBundle,
       exportUrl,
-      clientEntryId
+      clientEntryId,
+      measureBundle
     ).catch(async e => {
       await failBulkImportRequest(clientEntryId, e);
     });
-    const pendingTransactionBundles = handleSubmitDataBundles(transactionBundles, req);
+    const pendingTransactionBundles = await handleSubmitDataBundles(transactionBundles, req);
     await Promise.all(pendingTransactionBundles);
+
     await completeBulkImportRequest(clientEntryId);
   } catch (e) {
     await failBulkImportRequest(clientEntryId, e);

--- a/src/services/import.service.js
+++ b/src/services/import.service.js
@@ -1,0 +1,54 @@
+const { BulkImportWrappers } = require('bulk-data-utilities');
+const {
+  failBulkImportRequest,
+  completeBulkImportRequest,
+  addPendingBulkImportRequest
+} = require('../util/mongo.controller');
+const { retrieveExportURL } = require('../util/measureOperationsUtils');
+const { loggers } = require('@projecttacoma/node-fhir-server-core');
+const { handleSubmitDataBundles } = require('./bundle.service');
+
+const logger = loggers.get('default');
+
+async function bulkImport(req, res) {
+  logger.info('Measure >>> $bulk-import');
+  // id of inserted client
+  const clientEntry = await addPendingBulkImportRequest();
+  const parameters = req.body.parameter;
+  const exportURL = retrieveExportURL(parameters);
+
+  executePingAndPull(clientEntry, exportURL, req);
+  res.status(202);
+  res.status = () => res;
+  res.setHeader('Content-Location', `${req.params.base_version}/bulkstatus/${clientEntry}`);
+
+  return;
+}
+
+/*
+ * Calls the bulk-data-utilities wrapper function to get data requirements for the passed in measure, convert those to
+ * export requests from a bulk export server, then retrieve ndjson from that server and parse it into valid transaction bundles.
+ * Finally, uploads the resulting transaction bundles to the server and updates the bulkstatus endpoint
+ * @param {*} clientEntryId The unique identifier which corresponds to the bulkstatus content location for update
+ * @param {*} exportUrl The url of the bulk export fhir server
+ * @param {*} measureBundle The measure bundle for which to retrieve data requirements
+ * @param {*} req The request object passed in by the user
+ */
+const executePingAndPull = async (clientEntryId, exportUrl, measureBundle, req) => {
+  try {
+    const transactionBundles = await BulkImportWrappers.executeBulkImport(
+      measureBundle,
+      exportUrl,
+      clientEntryId
+    ).catch(async e => {
+      await failBulkImportRequest(clientEntryId, e);
+    });
+    const pendingTransactionBundles = handleSubmitDataBundles(transactionBundles, req);
+    await Promise.all(pendingTransactionBundles);
+    await completeBulkImportRequest(clientEntryId);
+  } catch (e) {
+    await failBulkImportRequest(clientEntryId, e);
+  }
+};
+
+module.exports = { bulkImport, executePingAndPull };

--- a/src/services/import.service.js
+++ b/src/services/import.service.js
@@ -14,7 +14,6 @@ const logger = loggers.get('default');
  * Executes an import of all the resources on the passed in server.
  * @param {Object} req The request object passed in by the client
  * @param {Object} res The response object returned to the client by the server
- * @returns void
  */
 async function bulkImport(req, res) {
   logger.info('Measure >>> $bulk-import');
@@ -40,7 +39,8 @@ async function bulkImport(req, res) {
  * @param {*} measureBundle The measure bundle for which to retrieve data requirements
  * @param {*} req The request object passed in by the user
  */
-const executePingAndPull = async (clientEntryId, exportUrl, measureBundle, req) => {
+
+const executePingAndPull = async (clientEntryId, exportUrl, req, measureBundle) => {
   try {
     const transactionBundles = await BulkImportWrappers.executeBulkImport(
       measureBundle,

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -1,9 +1,10 @@
 const { ServerError, loggers } = require('@projecttacoma/node-fhir-server-core');
-const { BulkImportWrappers } = require('bulk-data-utilities');
 const { Calculator } = require('fqm-execution');
 const { baseCreate, baseSearchById, baseRemove, baseUpdate, baseSearch } = require('./base.service');
 const { createTransactionBundleClass } = require('../resources/transactionBundle');
+const { executePingAndPull } = require('./import.service');
 const { handleSubmitDataBundles } = require('./bundle.service');
+
 const {
   retrieveExportURL,
   validateEvalMeasureParams,
@@ -19,8 +20,6 @@ const {
 const {
   findOneResourceWithQuery,
   addPendingBulkImportRequest,
-  failBulkImportRequest,
-  completeBulkImportRequest,
   findResourcesWithQuery
 } = require('../util/mongo.controller');
 
@@ -149,7 +148,7 @@ const submitData = async (args, { req }) => {
 
   // check if we want to do a bulk import
   if (req.headers['prefer'] === 'respond-async') {
-    return await bulkImport(args, { req });
+    return await bulkImportFromRequirements(args, { req });
   }
 
   const { base_version: baseVersion } = req.params;
@@ -165,14 +164,13 @@ const submitData = async (args, { req }) => {
 };
 
 /**
- * "TO-DO: add bulk import funtionality" (sic)
  * Retrieves measure bundle from the measure ID and
  * maps data requirements into an export request, which is
  * returned to the intiial import client.
  * @param {*} args the args object passed in by the user
  * @param {*} req the request object passed in by the user
  */
-const bulkImport = async (args, { req }) => {
+const bulkImportFromRequirements = async (args, { req }) => {
   logger.info('Measure >>> $bulk-import');
   // id of inserted client
   const clientEntry = await addPendingBulkImportRequest();
@@ -206,32 +204,6 @@ const bulkImport = async (args, { req }) => {
   res.setHeader('Content-Location', `${args.base_version}/bulkstatus/${clientEntry}`);
 
   return;
-};
-
-/**
- * Calls the bulk-data-utilities wrapper function to get data requirements for the passed in measure, convert those to
- * export requests from a bulk export server, then retrieve ndjson from that server and parse it into valid transaction bundles.
- * Finally, uploads the resulting transaction bundles to the server and updates the bulkstatus endpoint
- * @param {*} clientEntryId The unique identifier which corresponds to the bulkstatus content location for update
- * @param {*} exportUrl The url of the bulk export fhir server
- * @param {*} measureBundle The measure bundle for which to retrieve data requirements
- * @param {*} req The request object passed in by the user
- */
-const executePingAndPull = async (clientEntryId, exportUrl, measureBundle, req) => {
-  try {
-    const transactionBundles = await BulkImportWrappers.executeBulkImport(
-      measureBundle,
-      exportUrl,
-      clientEntryId
-    ).catch(async e => {
-      await failBulkImportRequest(clientEntryId, e);
-    });
-    const pendingTransactionBundles = handleSubmitDataBundles(transactionBundles, req);
-    await Promise.all(pendingTransactionBundles);
-    await completeBulkImportRequest(clientEntryId);
-  } catch (e) {
-    await failBulkImportRequest(clientEntryId, e);
-  }
 };
 
 /**

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -199,7 +199,7 @@ const bulkImportFromRequirements = async (args, { req }) => {
   const exportURL = retrieveExportURL(parameters);
 
   // After updating to job queue, remove --forceExit in test script in package.json
-  executePingAndPull(clientEntry, exportURL, measureBundle, req);
+  executePingAndPull(clientEntry, exportURL, req, measureBundle);
   res.status(202);
   res.status = () => res;
   res.setHeader('Content-Location', `${args.base_version}/bulkstatus/${clientEntry}`);

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -198,6 +198,7 @@ const bulkImportFromRequirements = async (args, { req }) => {
   // retrieve data requirements
   const exportURL = retrieveExportURL(parameters);
 
+  // After updating to job queue, remove --forceExit in test script in package.json
   executePingAndPull(clientEntry, exportURL, measureBundle, req);
   res.status(202);
   res.status = () => res;

--- a/src/util/measureOperationsUtils.js
+++ b/src/util/measureOperationsUtils.js
@@ -84,7 +84,6 @@ function validateEvalMeasureParams(req) {
  */
 const retrieveExportURL = parameters => {
   const exportURLArray = parameters.filter(param => param.name === 'exportURL');
-
   if (exportURLArray.length === 0) {
     throw new ServerError(null, {
       statusCode: 400,

--- a/test/import.service.test.js
+++ b/test/import.service.test.js
@@ -16,6 +16,12 @@ describe('Testing $import with no specified measure bundle', () => {
   beforeEach(async () => {
     await client.connect();
   });
+
+  /*
+   * Skipped purposely for now
+   * TODO: Once job queue is implemented, unskip this!
+   */
+
   test.skip('Returns 202 on Valid Request', async () => {
     await supertest(server.app)
       .post('/4_0_1/$import')

--- a/test/import.service.test.js
+++ b/test/import.service.test.js
@@ -1,0 +1,3 @@
+describe('Testing Bulk Import with no Specified Measure Bundle', () => {
+  test('Returns 200');
+});

--- a/test/import.service.test.js
+++ b/test/import.service.test.js
@@ -16,7 +16,7 @@ describe('Testing $import with no specified measure bundle', () => {
   beforeEach(async () => {
     await client.connect();
   });
-  test('Returns 202 on Valid Request', async () => {
+  test.skip('Returns 202 on Valid Request', async () => {
     await supertest(server.app)
       .post('/4_0_1/$import')
       .send(validParam)

--- a/test/import.service.test.js
+++ b/test/import.service.test.js
@@ -1,3 +1,41 @@
-describe('Testing Bulk Import with no Specified Measure Bundle', () => {
-  test('Returns 200');
+const supertest = require('supertest');
+const { buildConfig } = require('../src/util/config');
+const { initialize } = require('../src/server/server');
+const validParam = require('./fixtures/parametersObjs/paramWithExport');
+const paramNoExport = require('./fixtures/parametersObjs/paramNoExport.json');
+const { SINGLE_AGENT_PROVENANCE } = require('./fixtures/testProvenanceUtils');
+const { client } = require('../src/util/mongo');
+const { cleanUpDb } = require('./populateTestData');
+
+const config = buildConfig();
+const server = initialize(config);
+
+describe('Testing $import with no specified measure bundle', () => {
+  beforeEach(async () => {
+    await client.connect();
+  });
+  test('Returns 202 on Valid Request', async () => {
+    await supertest(server.app)
+      .post('/4_0_1/$import')
+      .send(validParam)
+      .set('Accept', 'application/json+fhir')
+      .set('content-type', 'application/json+fhir')
+      .set('x-provenance', JSON.stringify(SINGLE_AGENT_PROVENANCE))
+      .expect(202)
+      .then(response => {
+        expect(response.headers['content-location']).toBeDefined();
+      });
+  });
+  test('Returns 400 on missing exportURL', async () => {
+    await supertest(server.app)
+      .post('/4_0_1/$import')
+      .send(paramNoExport)
+      .set('Accept', 'application/json+fhir')
+      .set('content-type', 'application/json+fhir')
+      .set('x-provenance', JSON.stringify(SINGLE_AGENT_PROVENANCE))
+      .expect(400);
+  });
+  afterEach(async () => {
+    await cleanUpDb();
+  });
 });

--- a/test/import.service.test.js
+++ b/test/import.service.test.js
@@ -3,6 +3,8 @@ const { buildConfig } = require('../src/util/config');
 const { initialize } = require('../src/server/server');
 const validParam = require('./fixtures/parametersObjs/paramWithExport');
 const paramNoExport = require('./fixtures/parametersObjs/paramNoExport.json');
+const testParamTwoExports = require('./fixtures/parametersObjs/paramTwoExports.json');
+const testParamNoValString = require('./fixtures/parametersObjs/paramNoValueString.json');
 const { SINGLE_AGENT_PROVENANCE } = require('./fixtures/testProvenanceUtils');
 const { client } = require('../src/util/mongo');
 const { cleanUpDb } = require('./populateTestData');
@@ -33,6 +35,25 @@ describe('Testing $import with no specified measure bundle', () => {
       .set('Accept', 'application/json+fhir')
       .set('content-type', 'application/json+fhir')
       .set('x-provenance', JSON.stringify(SINGLE_AGENT_PROVENANCE))
+      .expect(400);
+  });
+  test('FHIR Parameters object has two export URLs', async () => {
+    await supertest(server.app)
+      .post('/4_0_1/$import')
+      .send(testParamTwoExports)
+      .set('Accept', 'application/json+fhir')
+      .set('content-type', 'application/json+fhir')
+      .set('prefer', 'respond-async')
+      .expect(400);
+  });
+
+  test('FHIR Parameters object is missing valueString for export URL', async () => {
+    await supertest(server.app)
+      .post('/4_0_1/$import')
+      .send(testParamNoValString)
+      .set('Accept', 'application/json+fhir')
+      .set('content-type', 'application/json+fhir')
+      .set('prefer', 'respond-async')
       .expect(400);
   });
   afterEach(async () => {


### PR DESCRIPTION
# Summary
Exposed a `$import` endpoint for carrying out non-measure-specific bulk import

## New behavior
We can now send generic bulk import requests to the `$import` endpoint. These requests will export all the resources on  bulk export server referenced by the passed-in url

## Code changes
- Added src/services/import.service.js
- Added src/services/import.controller.js
- Exposed new `$import` endpoint
- Reconfigured existing `$import` code to work with updated bulk-data-utilities functions
- Moved existing `$import`-related functions to src/import.service.js
- Added unit tests

# Testing guidance
- Run all unit tests
- Testing this code is a little involved due to reference errors in both our bulk-export-server and the smarthealthIT server
- Open your local copy of bulk-export-server and change the `PORT` variable in .env to `8080`
- Boot up the bulk-export-server with `npm run start`
- Open your local copy of bulk-data-utilities and change the url in the `retrieveAllBulkData` function on line 149 of src/RequirementsQuery from ``const url = `${exportURL}/$export`;`` to ``const url = `${exportURL}/$export?_type=Patient`;``
- Back in DEQM-test-server, run `npm link {LOCAL_PATH_TO_BULK_DATA_UTILITIES_REPO}`
- Now, boot up the test server with `npm run start`
- Send a `POST` request to `http://localhost:3000/4_0_1/$import` with the following body `{
  "resourceType": "Parameters",
  "parameter": [
		{
     "name": "exportURL",
     "valueString": "http://localhost:8080"
}]}`
- You should receive a `202:Accepted` status with a `content-location` header
- Send a `GET` request to `localhost:3000{INSERT CONENT LOCATION HEADER HERE}`
- If you receive `202:Accepted`, repeat the request
- You should eventually expect to receive `200` code with an OperationOutcome returned with one url representing the ndjson file of patients exported from the server
