### PR TITLE
Jsdoc types

### DIFF
--- a/src/controllers/bulkstatus.controller.js
+++ b/src/controllers/bulkstatus.controller.js
@@ -7,6 +7,6 @@ const service = require('../services/bulkstatus.service.js');
 module.exports.bulkstatus = (req, res, next) => {
   return service
     .checkBulkStatus(req, res)
-    .then(result => res.status(200).json(result))
+    .then(result => res.json(result))
     .catch(err => next(err));
 };

--- a/src/database/dbOperations.js
+++ b/src/database/dbOperations.js
@@ -89,7 +89,7 @@ const removeResource = async (id, resourceType) => {
 
 /**
  * Run an aggregation query on the database.
- * @param {Object[]} query Mongo aggregation pipeline array.
+ * @param {Array} query Mongo aggregation pipeline array.
  * @param {string} resourceType The resource type (collection) to aggregate on.
  * @returns Array promise of results.
  */

--- a/src/database/dbOperations.js
+++ b/src/database/dbOperations.js
@@ -5,7 +5,7 @@ const { db } = require('./connection.js');
  * creates a new document in the specified collection
  * @param {Object} data the data of the document to be created
  * @param {string} resourceType type of desired resource, signifies collection resource is stored in
- * @returns an object with the id of the created document
+ * @returns {Object} an object with the id of the created document
  */
 const createResource = async (data, resourceType) => {
   const collection = db.collection(resourceType);
@@ -17,7 +17,7 @@ const createResource = async (data, resourceType) => {
  * searches the database for the desired resource and returns the data
  * @param {string} id id of desired resource
  * @param {string} resourceType type of desired resource, signifies collection resource is stored in
- * @returns the data of the found document
+ * @returns {Object} the data of the found document
  */
 const findResourceById = async (id, resourceType) => {
   const collection = db.collection(resourceType);
@@ -28,13 +28,19 @@ const findResourceById = async (id, resourceType) => {
  * searches the database for the one resource based on a mongo query and returns the data
  * @param {Object} query the mongo query to use
  * @param {string} resourceType type of desired resource, signifies collection resource is stored in
- * @returns the data of the found document
+ * @returns {Object} the data of the found document
  */
 const findOneResourceWithQuery = async (query, resourceType) => {
   const collection = db.collection(resourceType);
   return collection.findOne(query);
 };
 
+/**
+ * searches the database for all resources based on the mongo query and returns the dat
+ * @param {Object} query
+ * @param {string} resourceType
+ * @returns {Array} an array of found objects which match the input query
+ */
 const findResourcesWithQuery = async (query, resourceType) => {
   const collection = db.collection(resourceType);
   return (await collection.find(query)).toArray();
@@ -45,7 +51,7 @@ const findResourcesWithQuery = async (query, resourceType) => {
  * @param {string} id id of resource to be updated
  * @param {Object} data the updated data to add to/edit in the document
  * @param {string} resourceType the collection the document is in
- * @returns the id of the updated/created document
+ * @returns {string} the id of the updated/created document
  */
 const updateResource = async (id, data, resourceType) => {
   const collection = db.collection(resourceType);
@@ -69,7 +75,7 @@ const updateResource = async (id, data, resourceType) => {
  * @param {string} id id of resource to be updated
  * @param {Object} data the new data to push in the document
  * @param {string} resourceType the collection the document is in
- * @returns the id of the updated/created document
+ * @returns {string} the id of the updated/created document
  */
 const pushToResource = async (id, data, resourceType) => {
   const collection = db.collection(resourceType);
@@ -80,7 +86,7 @@ const pushToResource = async (id, data, resourceType) => {
  * searches the database for the desired resource and removes it from the db
  * @param {string} id id of resource to be removed
  * @param {string} resourceType type of desired resource, signifies collection resource is stored in
- * @returns an object containing deletedCount: the number of documents deleted
+ * @returns {Object} an object containing deletedCount: the number of documents deleted
  */
 const removeResource = async (id, resourceType) => {
   const collection = db.collection(resourceType);
@@ -91,7 +97,7 @@ const removeResource = async (id, resourceType) => {
  * Run an aggregation query on the database.
  * @param {Array} query Mongo aggregation pipeline array.
  * @param {string} resourceType The resource type (collection) to aggregate on.
- * @returns Array promise of results.
+ * @returns {Array} Array promise of results.
  */
 const findResourcesWithAggregation = async (query, resourceType) => {
   const collection = db.collection(resourceType);
@@ -101,7 +107,7 @@ const findResourcesWithAggregation = async (query, resourceType) => {
 /**
  * Called as a result of bulkImport request. Adds a new clientId to db
  * which can be queried to get updates on the status of the bulk import
- * @returns the id of the inserted client
+ * @returns {string} the id of the inserted client
  */
 const addPendingBulkImportRequest = async () => {
   const collection = db.collection('bulkImportStatuses');
@@ -149,7 +155,7 @@ const failBulkImportRequest = async (clientId, error) => {
 /**
  * Wrapper for the findResourceById function that only searches bulkImportStatuses db
  * @param {string} clientId The id signifying the bulk status request
- * @returns The bulkstatus entry for the passed in clientId
+ * @returns {Object} The bulkstatus entry for the passed in clientId
  */
 const getBulkImportStatus = async clientId => {
   const status = await findResourceById(clientId, 'bulkImportStatuses');

--- a/src/database/dbOperations.js
+++ b/src/database/dbOperations.js
@@ -36,9 +36,9 @@ const findOneResourceWithQuery = async (query, resourceType) => {
 };
 
 /**
- * searches the database for all resources based on the mongo query and returns the dat
- * @param {Object} query
- * @param {string} resourceType
+ * searches the database for all resources based on the mongo query and returns the data
+ * @param {Object} query the mongo query to use
+ * @param {string} resourceType type of desired resource, signifies collection resource is stored in
  * @returns {Array} an array of found objects which match the input query
  */
 const findResourcesWithQuery = async (query, resourceType) => {

--- a/src/database/dbOperations.js
+++ b/src/database/dbOperations.js
@@ -3,8 +3,8 @@ const { db } = require('./connection.js');
 
 /**
  * creates a new document in the specified collection
- * @param {*} data the data of the document to be created
- * @param {*} resourceType type of desired resource, signifies collection resource is stored in
+ * @param {Object} data the data of the document to be created
+ * @param {string} resourceType type of desired resource, signifies collection resource is stored in
  * @returns an object with the id of the created document
  */
 const createResource = async (data, resourceType) => {
@@ -15,8 +15,8 @@ const createResource = async (data, resourceType) => {
 
 /**
  * searches the database for the desired resource and returns the data
- * @param {*} id id of desired resource
- * @param {*} resourceType type of desired resource, signifies collection resource is stored in
+ * @param {string} id id of desired resource
+ * @param {string} resourceType type of desired resource, signifies collection resource is stored in
  * @returns the data of the found document
  */
 const findResourceById = async (id, resourceType) => {
@@ -42,9 +42,9 @@ const findResourcesWithQuery = async (query, resourceType) => {
 
 /**
  * searches for a document and updates it if found, creates it if not
- * @param {*} id id of resource to be updated
- * @param {*} data the updated data to add to/edit in the document
- * @param {*} resourceType the collection the document is in
+ * @param {string} id id of resource to be updated
+ * @param {Object} data the updated data to add to/edit in the document
+ * @param {string} resourceType the collection the document is in
  * @returns the id of the updated/created document
  */
 const updateResource = async (id, data, resourceType) => {
@@ -78,8 +78,8 @@ const pushToResource = async (id, data, resourceType) => {
 
 /**
  * searches the database for the desired resource and removes it from the db
- * @param {*} id id of resource to be removed
- * @param {*} resourceType type of desired resource, signifies collection resource is stored in
+ * @param {string} id id of resource to be removed
+ * @param {string} resourceType type of desired resource, signifies collection resource is stored in
  * @returns an object containing deletedCount: the number of documents deleted
  */
 const removeResource = async (id, resourceType) => {
@@ -89,8 +89,8 @@ const removeResource = async (id, resourceType) => {
 
 /**
  * Run an aggregation query on the database.
- * @param {*[]} query Mongo aggregation pipeline array.
- * @param {*} resourceType The resource type (collection) to aggregate on.
+ * @param {Object[]} query Mongo aggregation pipeline array.
+ * @param {string} resourceType The resource type (collection) to aggregate on.
  * @returns Array promise of results.
  */
 const findResourcesWithAggregation = async (query, resourceType) => {
@@ -120,7 +120,7 @@ const addPendingBulkImportRequest = async () => {
 
 /**
  * Updates the bulk import status entry for a successful import
- * @param {*} clientId The ID for the bulkImportStatus entry
+ * @param {string} clientId The ID for the bulkImportStatus entry
  */
 const completeBulkImportRequest = async clientId => {
   const collection = db.collection('bulkImportStatuses');
@@ -132,7 +132,7 @@ const completeBulkImportRequest = async clientId => {
 
 /**
  * Updates the bulk import status entry for a successful import
- * @param {*} clientId The ID for the bulkImportStatus entry
+ * @param {string} clientId The ID for the bulkImportStatus entry
  */
 const failBulkImportRequest = async (clientId, error) => {
   const collection = db.collection('bulkImportStatuses');

--- a/src/scripts/createCollections.js
+++ b/src/scripts/createCollections.js
@@ -1,6 +1,9 @@
 const mongoUtil = require('../database/connection');
 const supportedResources = require('../server/supportedResources');
 
+/**
+ * Adds an empty collection to the mongo db for each supported resource
+ */
 async function main() {
   // Use connect method to connect to the server
   await mongoUtil.client.connect();

--- a/src/scripts/deleteCollections.js
+++ b/src/scripts/deleteCollections.js
@@ -1,5 +1,8 @@
 const mongoUtil = require('../database/connection');
 
+/**
+ * Deletes all collections stored in mongo
+ */
 async function main() {
   // Use connect method to connect to the server
   await mongoUtil.client.connect();

--- a/src/scripts/getConnectathonBundles.js
+++ b/src/scripts/getConnectathonBundles.js
@@ -13,7 +13,7 @@ const bundleFiles = [];
  * Retrieves EXM bundle files from the connectathon repo using a regular expression.
  * Uses recursion to parse through all available subdirectories.
  * @param {string} directory - directory path to start at
- * @returns array of string paths that represent the bundle files of interest
+ * @returns {Array} array of string paths that represent the bundle files of interest
  */
 const getBundleFiles = directory => {
   const fileNameRegExp = new RegExp(/(^EXM.*.json$)/);

--- a/src/scripts/parseCompartmentDefinition.js
+++ b/src/scripts/parseCompartmentDefinition.js
@@ -11,7 +11,7 @@ const { getSearchParameters } = require('@asymmetrik/node-fhir-server-core/dist/
 /**
  * Parse Patient compartment definition for search parameter keywords
  * @param {string} compartmentJson the string content of the patient compartment definition json file
- * @return object whose keys are resourceTypes and values are arrays of strings to use to reference a patient
+ * @return {Object} object whose keys are resourceTypes and values are arrays of strings to use to reference a patient
  */
 async function parse(compartmentJson) {
   const compartmentDefinition = await JSON.parse(compartmentJson);

--- a/src/scripts/parseModelInfo.js
+++ b/src/scripts/parseModelInfo.js
@@ -12,7 +12,7 @@ const IGNORED_REFS = ['where(resolve() is Patient)'];
 /**
  * Parse FHIR model info XML and output a map of resourceType => patient reference attributes
  * @param {string} xml the string content of the model info XML to parse
- * @return object whose keys are resourceTypes and values are arrays of strings to use to reference a patient
+ * @return {Object} object whose keys are resourceTypes and values are arrays of strings to use to reference a patient
  */
 async function parse(xml) {
   const { modelInfo } = await xml2js.parseStringPromise(xml);

--- a/src/services/base.service.js
+++ b/src/services/base.service.js
@@ -78,7 +78,7 @@ const qb = new QueryBuilder({
  * creates an object and generates an id for it regardless of the id passed in
  * @param {Object} req an object containing the request body
  * @param {string} resourceType string which signifies which collection to add the data to
- * @returns the id of the created object
+ * @returns {string} the id of the created object
  */
 const baseCreate = async ({ req }, resourceType) => {
   logger.info(`${resourceType} >>> create`);
@@ -99,7 +99,7 @@ const baseCreate = async ({ req }, resourceType) => {
  * @param {Object} args the args added to the end of the url, contains id of desired resource
  * @param {string} resourceType string which signifies which collection to search for
  * the data and which FHIR type to cast the result to
- * @returns the object with the desired id cast to the requested type
+ * @returns {Object} the object with the desired id cast to the requested type
  */
 const baseSearchById = async (args, resourceType) => {
   logger.info(`${resourceType} >>> read`);
@@ -129,7 +129,7 @@ const baseSearchById = async (args, resourceType) => {
  * @param {string} resourceType The resource type we are searching on.
  * @param {Object} paramDefs Optional parameter definitions for the specific resource types. Specific
  *                      resource services should call this and pass along supported params
- * @returns Search set result bundle
+ * @returns {Object} Search set result bundle
  */
 const baseSearch = async (args, { req }, resourceType, paramDefs) => {
   logger.info(`${resourceType} >>> search`);
@@ -210,7 +210,7 @@ const baseSearch = async (args, { req }, resourceType, paramDefs) => {
  * @param {Object} args the args added to the end of the url, contains id of desired resource
  * @param {Object} req an object containing the request body
  * @param {string} resourceType string which signifies which collection to add the data to
- * @returns the id of the updated/created document
+ * @returns {string} the id of the updated/created document
  */
 const baseUpdate = async (args, { req }, resourceType) => {
   logger.info(`${resourceType} >>> update`);
@@ -245,7 +245,7 @@ const baseUpdate = async (args, { req }, resourceType) => {
  * removes the document of the specified type with the specified id from the collection
  * @param {Object} args the args added to the end of the url, contains id of desired resource
  * @param {string} resourceType string which signifies which collection to add the data to
- * @returns an object containing deletedCount: the number of documents deleted
+ * @returns {Object} an object containing deletedCount: the number of documents deleted
  */
 const baseRemove = async (args, resourceType) => {
   logger.info(`${resourceType} >>> delete`);
@@ -280,7 +280,7 @@ const checkContentTypeHeader = requestHeaders => {
  * Build a basic service module for a given resource type. Supports basic CRUD operations.
  *
  * @param {string} resourceType Name of the resource to make a basic resource for.
- * @returns The resource service module.
+ * @returns {Object} The resource service module.
  */
 const buildServiceModule = resourceType => {
   return {

--- a/src/services/base.service.js
+++ b/src/services/base.service.js
@@ -76,8 +76,8 @@ const qb = new QueryBuilder({
 
 /**
  * creates an object and generates an id for it regardless of the id passed in
- * @param {*} req an object containing the request body
- * @param {*} resourceType string which signifies which collection to add the data to
+ * @param {Object} req an object containing the request body
+ * @param {string} resourceType string which signifies which collection to add the data to
  * @returns the id of the created object
  */
 const baseCreate = async ({ req }, resourceType) => {
@@ -96,8 +96,8 @@ const baseCreate = async ({ req }, resourceType) => {
 
 /**
  * Searches for the object of the requested type with the requested id
- * @param {*} args the args added to the end of the url, contains id of desired resource
- * @param {*} resourceType string which signifies which collection to search for
+ * @param {Object} args the args added to the end of the url, contains id of desired resource
+ * @param {string} resourceType string which signifies which collection to search for
  * the data and which FHIR type to cast the result to
  * @returns the object with the desired id cast to the requested type
  */
@@ -124,10 +124,10 @@ const baseSearchById = async (args, resourceType) => {
 
 /**
  * Searches using query parameters.
- * @param {*} args The args from the request.
- * @param {*} req The Express request object. This is used by the query builder.
- * @param {*} resourceType The resource type we are searching on.
- * @param {*} paramDefs Optional parameter definitions for the specific resource types. Specific
+ * @param {Object} args The args from the request.
+ * @param {Object} req The Express request object. This is used by the query builder.
+ * @param {string} resourceType The resource type we are searching on.
+ * @param {Object} paramDefs Optional parameter definitions for the specific resource types. Specific
  *                      resource services should call this and pass along supported params
  * @returns Search set result bundle
  */
@@ -207,9 +207,9 @@ const baseSearch = async (args, { req }, resourceType, paramDefs) => {
 /**
  * updates the document of the specified resource type with the passed in id or creates a new
  * document if no document with passed id is found
- * @param {*} args the args added to the end of the url, contains id of desired resource
- * @param {*} req an object containing the request body
- * @param {*} resourceType string which signifies which collection to add the data to
+ * @param {Object} args the args added to the end of the url, contains id of desired resource
+ * @param {Object} req an object containing the request body
+ * @param {string} resourceType string which signifies which collection to add the data to
  * @returns the id of the updated/created document
  */
 const baseUpdate = async (args, { req }, resourceType) => {
@@ -243,8 +243,8 @@ const baseUpdate = async (args, { req }, resourceType) => {
 
 /**
  * removes the document of the specified type with the specified id from the collection
- * @param {*} args the args added to the end of the url, contains id of desired resource
- * @param {*} resourceType string which signifies which collection to add the data to
+ * @param {Object} args the args added to the end of the url, contains id of desired resource
+ * @param {string} resourceType string which signifies which collection to add the data to
  * @returns an object containing deletedCount: the number of documents deleted
  */
 const baseRemove = async (args, resourceType) => {
@@ -254,7 +254,7 @@ const baseRemove = async (args, resourceType) => {
 
 /**
  * Checks if the content-type header is incorrect and throws and error with guidance if so
- * @param {*} requestHeaders the headers from the request body
+ * @param {Object} requestHeaders the headers from the request body
  */
 const checkContentTypeHeader = requestHeaders => {
   if (

--- a/src/services/bulkstatus.service.js
+++ b/src/services/bulkstatus.service.js
@@ -6,7 +6,7 @@ const { getBulkImportStatus } = require('../database/dbOperations');
  * formats the information held there to return to the user
  * @param {Object} req The express request object passed in by the user
  * @param {Object} res The express response object to be returned to the user
- * @returns
+ * @returns {Object} an object summarizing the status of the bulk data request
  */
 async function checkBulkStatus(req, res) {
   const clientId = req.params.client_id;

--- a/src/services/bulkstatus.service.js
+++ b/src/services/bulkstatus.service.js
@@ -1,6 +1,13 @@
 const { ServerError } = require('@projecttacoma/node-fhir-server-core');
 const { getBulkImportStatus } = require('../database/dbOperations');
 
+/**
+ * Searches for the bulkStatus entry with the passed in client id and interprets and
+ * formats the information held there to return to the user
+ * @param {Object} req The express request object passed in by the user
+ * @param {Object} res The express response object to be returned to the user
+ * @returns
+ */
 async function checkBulkStatus(req, res) {
   const clientId = req.params.client_id;
 
@@ -25,9 +32,6 @@ async function checkBulkStatus(req, res) {
     //TODO set these responses dynamically?
     res.set('X-Progress', 'Retrieving export files');
     res.set('Retry-After', 120);
-
-    //TODO: replace this once we have asymmetrik fork
-    res.status = () => res;
   } else if (bulkStatus.status === 'Completed') {
     res.status(200);
     res.set('Expires', 'EXAMPLE_EXPIRATION_DATE');

--- a/src/services/bundle.service.js
+++ b/src/services/bundle.service.js
@@ -11,10 +11,10 @@ const logger = loggers.get('default');
 
 /**
  * Creates transaction-response Bundle
- * @param {*} results - request results
- * @param {*} res - an object containing the response
- * @param {*} type - bundle type
- * @param { boolean } xprovenanceIncluded - X-Provenance header was included and
+ * @param {Object[]} results - request results
+ * @param {Object} res - an object containing the response
+ * @param {string} type - bundle type
+ * @param {boolean} xprovenanceIncluded - X-Provenance header was included and
  * should be accounted for
  * @returns transaction-response Bundle and updated txn bundle target (may be empty)
  */
@@ -50,7 +50,7 @@ const makeTransactionResponseBundle = (results, res, baseVersion, type, xprovena
 /**
  * Handles transaction bundles used for submit data.
  * Creates an audit event and uploads the transaction bundles.
- * @param {Array} transactionBundles - an array of transactionBundles to handle
+ * @param {Object[]} transactionBundles - an array of transactionBundles to handle
  * @param {Object} req - an object containing the request body
  * @returns array of transaction-response bundle
  */
@@ -84,8 +84,8 @@ async function handleSubmitDataBundles(transactionBundles, req) {
 
 /**
  * Supports Bundle upload to the server using transaction
- * @param {*} req - an object containing the request body
- * @param {*} res - an object containing the response
+ * @param {Object} req - an object containing the request body
+ * @param {Object} res - an object containing the response
  * @returns transaction-response bundle
  */
 async function uploadTransactionBundle(req, res) {

--- a/src/services/bundle.service.js
+++ b/src/services/bundle.service.js
@@ -11,7 +11,7 @@ const logger = loggers.get('default');
 
 /**
  * Creates transaction-response Bundle
- * @param {Array} results - ran array of equest result objects
+ * @param {Array} results - an array of equest result objects
  * @param {Object} res - an object containing the response
  * @param {string} type - bundle type
  * @param {boolean} xprovenanceIncluded - X-Provenance header was included and

--- a/src/services/bundle.service.js
+++ b/src/services/bundle.service.js
@@ -11,7 +11,7 @@ const logger = loggers.get('default');
 
 /**
  * Creates transaction-response Bundle
- * @param {Array} results - an array of equest result objects
+ * @param {Array} results - an array of request result objects
  * @param {Object} res - an object containing the response
  * @param {string} type - bundle type
  * @param {boolean} xprovenanceIncluded - X-Provenance header was included and

--- a/src/services/bundle.service.js
+++ b/src/services/bundle.service.js
@@ -16,7 +16,7 @@ const logger = loggers.get('default');
  * @param {string} type - bundle type
  * @param {boolean} xprovenanceIncluded - X-Provenance header was included and
  * should be accounted for
- * @returns transaction-response Bundle and updated txn bundle target (may be empty)
+ * @returns {Object} transaction-response Bundle and updated txn bundle target (may be empty)
  */
 const makeTransactionResponseBundle = (results, res, baseVersion, type, xprovenanceIncluded) => {
   const Bundle = resolveSchema(baseVersion, 'bundle');
@@ -52,7 +52,7 @@ const makeTransactionResponseBundle = (results, res, baseVersion, type, xprovena
  * Creates an audit event and uploads the transaction bundles.
  * @param {Array} transactionBundles - an array of transactionBundles to handle
  * @param {Object} req - an object containing the request body
- * @returns array of transaction-response bundle
+ * @returns {Array} array of transaction-response bundle
  */
 async function handleSubmitDataBundles(transactionBundles, req) {
   let auditID;
@@ -86,7 +86,7 @@ async function handleSubmitDataBundles(transactionBundles, req) {
  * Supports Bundle upload to the server using transaction
  * @param {Object} req - an object containing the request body
  * @param {Object} res - an object containing the response
- * @returns transaction-response bundle
+ * @returns {Object} transaction-response bundle
  */
 async function uploadTransactionBundle(req, res) {
   logger.info('Base >>> transaction');

--- a/src/services/bundle.service.js
+++ b/src/services/bundle.service.js
@@ -11,7 +11,7 @@ const logger = loggers.get('default');
 
 /**
  * Creates transaction-response Bundle
- * @param {Object[]} results - request results
+ * @param {Array} results - ran array of equest result objects
  * @param {Object} res - an object containing the response
  * @param {string} type - bundle type
  * @param {boolean} xprovenanceIncluded - X-Provenance header was included and
@@ -50,7 +50,7 @@ const makeTransactionResponseBundle = (results, res, baseVersion, type, xprovena
 /**
  * Handles transaction bundles used for submit data.
  * Creates an audit event and uploads the transaction bundles.
- * @param {Object[]} transactionBundles - an array of transactionBundles to handle
+ * @param {Array} transactionBundles - an array of transactionBundles to handle
  * @param {Object} req - an object containing the request body
  * @returns array of transaction-response bundle
  */

--- a/src/services/import.service.js
+++ b/src/services/import.service.js
@@ -24,7 +24,6 @@ async function bulkImport(req, res) {
   //When we move to a job queue, remove --forceExist from test script in package.json
   executePingAndPull(clientEntry, exportURL, req);
   res.status(202);
-  res.status = () => res;
   res.setHeader('Content-Location', `${req.params.base_version}/bulkstatus/${clientEntry}`);
 
   return;

--- a/src/services/import.service.js
+++ b/src/services/import.service.js
@@ -30,14 +30,14 @@ async function bulkImport(req, res) {
   return;
 }
 
-/*
+/**
  * Calls the bulk-data-utilities wrapper function to get data requirements for the passed in measure, convert those to
  * export requests from a bulk export server, then retrieve ndjson from that server and parse it into valid transaction bundles.
  * Finally, uploads the resulting transaction bundles to the server and updates the bulkstatus endpoint
- * @param {*} clientEntryId The unique identifier which corresponds to the bulkstatus content location for update
- * @param {*} exportUrl The url of the bulk export fhir server
- * @param {*} measureBundle The measure bundle for which to retrieve data requirements
- * @param {*} req The request object passed in by the user
+ * @param {string} clientEntryId The unique identifier which corresponds to the bulkstatus content location for update
+ * @param {string} exportUrl The url of the bulk export fhir server
+ * @param {Object} measureBundle The measure bundle for which to retrieve data requirements
+ * @param {Object} req The request object passed in by the user
  */
 
 const executePingAndPull = async (clientEntryId, exportUrl, req, measureBundle) => {

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -311,8 +311,8 @@ const careGaps = async (args, { req }) => {
 
 /**
  * Determines the type of identifier used by the client to identify the measure and returns it
- * @param {Object} req
- * @returns {Object} and object containing the measure identifier with the appropropriate key
+ * @param {Object} req http request object
+ * @returns {Object} an object containing the measure identifier with the appropriate key
  */
 const retrieveSearchTerm = req => {
   const { measureId, measureIdentifier, measureUrl } = req.query;

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -90,7 +90,7 @@ const search = async (args, { req }) => {
  * takes a measureReport and a set of required data with which to calculate the measure and
  * creates new documents for the measureReport and requirements in the appropriate collections.
  *
- * If 'prefer': 'respond-async' header is present, calls bulkImport.
+ * If 'prefer': 'respond-async' header is present, calls bulkImportFromRequirements.
  * @param {Object} args the args object passed in by the user
  * @param {Object} req the request object passed in by the user
  * @returns a transaction-response bundle
@@ -200,7 +200,6 @@ const bulkImportFromRequirements = async (args, { req }) => {
   // After updating to job queue, remove --forceExit in test script in package.json
   executePingAndPull(clientEntry, exportURL, req, measureBundle);
   res.status(202);
-  res.status = () => res;
   res.setHeader('Content-Location', `${args.base_version}/bulkstatus/${clientEntry}`);
 
   return;

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -27,8 +27,8 @@ const logger = loggers.get('default');
 /**
  * resulting function of sending a POST request to {BASE_URL}/4_0_1/Measure
  * creates a new measure in the database
- * @param {*} _ unused arg
- * @param {*} data the measure data passed in with the request
+ * @param {undefined} _ unused arg
+ * @param {Object} data the measure data passed in with the request
  * @returns an object with the created measure's id
  */
 const create = async (_, data) => {
@@ -38,7 +38,7 @@ const create = async (_, data) => {
 /**
  * result of sending a GET request to {BASE_URL}/4_0_1/Measure/{id}
  * searches for the measure with the passed in id
- * @param {*} args passed in arguments including the id of the sought after measure
+ * @param {Object} args passed in arguments including the id of the sought after measure
  * @returns
  */
 const searchById = async args => {
@@ -48,8 +48,8 @@ const searchById = async args => {
 /**
  * result of sending a PUT request to {BASE_URL}/4_0_1/Measure/{id}
  * updates the measure with the passed in id using the passed in data
- * @param {*} args passed in arguments including the id of the sought after measure
- * @param {*} data a map of the attributes to change and their new values
+ * @param {Object} args passed in arguments including the id of the sought after measure
+ * @param {Object} data a map of the attributes to change and their new values
  * @returns
  */
 const update = async (args, data) => {
@@ -59,7 +59,7 @@ const update = async (args, data) => {
 /**
  * result of sending a DELETE request to {BASE_URL}/4_0_1/Measure/{id}
  * removes the measure with the passed in id from the database
- * @param {*} args passed in arguments including the id of the sought after measure
+ * @param {Object} args passed in arguments including the id of the sought after measure
  * @returns
  */
 const remove = async args => {
@@ -91,8 +91,8 @@ const search = async (args, { req }) => {
  * creates new documents for the measureReport and requirements in the appropriate collections.
  *
  * If 'prefer': 'respond-async' header is present, calls bulkImport.
- * @param {*} args the args object passed in by the user
- * @param {*} req the request object passed in by the user
+ * @param {Object} args the args object passed in by the user
+ * @param {Object} req the request object passed in by the user
  * @returns a transaction-response bundle
  */
 const submitData = async (args, { req }) => {
@@ -166,8 +166,8 @@ const submitData = async (args, { req }) => {
  * Retrieves measure bundle from the measure ID and
  * maps data requirements into an export request, which is
  * returned to the intiial import client.
- * @param {*} args the args object passed in by the user
- * @param {*} req the request object passed in by the user
+ * @param {Object} args the args object passed in by the user
+ * @param {Object} req the request object passed in by the user
  */
 const bulkImportFromRequirements = async (args, { req }) => {
   logger.info('Measure >>> $bulk-import');

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -87,7 +87,7 @@ const search = async (args, { req }) => {
 };
 
 /**
- * takes a measureReport and a set of required data with which to calculate the measure and
+ * Takes a measureReport and a set of required data as part of the request. Calculates the measure and
  * creates new documents for the measureReport and requirements in the appropriate collections.
  *
  * If 'prefer': 'respond-async' header is present, calls bulkImportFromRequirements.

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -88,7 +88,7 @@ const search = async (args, { req }) => {
 
 /**
  * Takes a measureReport and a set of required data as part of the request. Calculates the measure and
- * creates new documents for the measureReport and requirements in the appropriate collections.
+ * creates new documents for the measureReport and required data in the appropriate collections.
  *
  * If 'prefer': 'respond-async' header is present, calls bulkImportFromRequirements.
  * @param {Object} args the args object passed in by the user
@@ -165,7 +165,7 @@ const submitData = async (args, { req }) => {
 /**
  * Retrieves measure bundle from the measure ID and
  * maps data requirements into an export request, which is
- * returned to the intiial import client.
+ * returned to the initial import client.
  * @param {Object} args the args object passed in by the user
  * @param {Object} req the request object passed in by the user
  */

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -29,7 +29,7 @@ const logger = loggers.get('default');
  * creates a new measure in the database
  * @param {undefined} _ unused arg
  * @param {Object} data the measure data passed in with the request
- * @returns an object with the created measure's id
+ * @returns {Object} an object with the created measure's id
  */
 const create = async (_, data) => {
   return baseCreate(data, 'Measure');
@@ -39,7 +39,7 @@ const create = async (_, data) => {
  * result of sending a GET request to {BASE_URL}/4_0_1/Measure/{id}
  * searches for the measure with the passed in id
  * @param {Object} args passed in arguments including the id of the sought after measure
- * @returns
+ * @returns {Object} the FHIR resource with the specified id
  */
 const searchById = async args => {
   return baseSearchById(args, 'Measure');
@@ -50,7 +50,7 @@ const searchById = async args => {
  * updates the measure with the passed in id using the passed in data
  * @param {Object} args passed in arguments including the id of the sought after measure
  * @param {Object} data a map of the attributes to change and their new values
- * @returns
+ * @returns {string} the id of the updated/created resource
  */
 const update = async (args, data) => {
   return baseUpdate(args, data, 'Measure');
@@ -60,7 +60,7 @@ const update = async (args, data) => {
  * result of sending a DELETE request to {BASE_URL}/4_0_1/Measure/{id}
  * removes the measure with the passed in id from the database
  * @param {Object} args passed in arguments including the id of the sought after measure
- * @returns
+ * @returns {Object} an object containing deletedCount: the number of documents deleted
  */
 const remove = async args => {
   return baseRemove(args, 'Measure');
@@ -79,7 +79,7 @@ const SEARCH_PARAM_DEFS = {
  * queries for all measures matching the criteria, only name and version for now
  * @param {Object} args passed in arguments including the search parameters for the Measure
  * @param {Object} req http request object
- * @returns
+ * @returns {Object} Search set result bundle
  */
 const search = async (args, { req }) => {
   logger.info('Measure >>> search');
@@ -93,7 +93,7 @@ const search = async (args, { req }) => {
  * If 'prefer': 'respond-async' header is present, calls bulkImportFromRequirements.
  * @param {Object} args the args object passed in by the user
  * @param {Object} req the request object passed in by the user
- * @returns a transaction-response bundle
+ * @returns {Object} a transaction-response bundle
  */
 const submitData = async (args, { req }) => {
   logger.info('Measure >>> $submit-data');
@@ -208,7 +208,7 @@ const bulkImportFromRequirements = async (args, { req }) => {
 /**
  * Get all data requirements for a given measure as a FHIR Library
  * @param {Object} args the args object passed in by the user, includes measure id
- * @returns FHIR Library with all data requirements
+ * @returns {Object} FHIR Library with all data requirements
  */
 const dataRequirements = async (args, { req }) => {
   logger.info('Measure >>> $data-requirements');
@@ -227,7 +227,7 @@ const dataRequirements = async (args, { req }) => {
  * Execute the measure for a given Patient
  * @param {Object} args the args object passed in by the user, includes measure id
  * @param {Object} req http request object
- * @returns FHIR MeasureReport with population results
+ * @returns {Object} FHIR MeasureReport with population results
  */
 const evaluateMeasure = async (args, { req }) => {
   logger.info('Measure >>> $evaluate-measure');
@@ -269,7 +269,7 @@ const evaluateMeasure = async (args, { req }) => {
  * Calculate the gaps in care for a given Patient
  * @param {Object} args the args object passed in by the user, includes measure id
  * @param {Object} req http request object
- * @returns FHIR MeasureReport with population results
+ * @returns {Object} FHIR MeasureReport with population results
  */
 const careGaps = async (args, { req }) => {
   logger.info('Measure >>> $care-gaps');
@@ -309,6 +309,11 @@ const careGaps = async (args, { req }) => {
   return results;
 };
 
+/**
+ * Determines the type of identifier used by the client to identify the measure and returns it
+ * @param {Object} req
+ * @returns {Object} and object containing the measure identifier with the appropropriate key
+ */
 const retrieveSearchTerm = req => {
   const { measureId, measureIdentifier, measureUrl } = req.query;
 

--- a/src/services/patient.service.js
+++ b/src/services/patient.service.js
@@ -20,7 +20,7 @@ const create = async (_, data) => {
  * result of sending a GET request to {BASE_URL}/4_0_1/Patient/{id}
  * searches for the patient with the passed in id
  * @param {Object} args passed in arguments including the id of the sought after patient
- * @returns
+ * @returns {Object} the object with the desired id cast to Patient
  */
 const searchById = async args => {
   return baseSearchById(args, 'Patient');
@@ -31,7 +31,7 @@ const searchById = async args => {
  * updates the patient with the passed in id using the passed in data
  * @param {Object} args passed in arguments including the id of the sought after patient
  * @param {Object} data a map of the attributes to change and their new values
- * @returns
+ * @returns {string} the id of the created/updated patient
  */
 const update = async (args, data) => {
   return baseUpdate(args, data, 'Patient');
@@ -41,7 +41,7 @@ const update = async (args, data) => {
  * result of sending a DELETE request to {BASE_URL}/4_0_1/Patient/{id}
  * removes the measure with the passed in id from the database
  * @param {Object} args passed in arguments including the id of the sought after patient
- * @returns
+ * @returns {Object} an object containing the number of items deleted
  */
 const remove = async args => {
   return baseRemove(args, 'Patient');
@@ -52,7 +52,7 @@ const remove = async args => {
  * queries for all measures matching the criteria, only name and version for now
  * @param {Object} args passed in arguments including the search parameters for the Patient
  * @param {Object} req http request object
- * @returns
+ * @returns {Object} Search set result bundle
  */
 const search = async (args, { req }) => {
   logger.info('Patient >>> search');
@@ -65,6 +65,7 @@ const search = async (args, { req }) => {
  * patients in db (if no id is specified)
  * @param {Object} args passed in arguments
  * @param {Object} req http request object
+ * @returns {Object} a FHIR searchset bundle containing the properly formatted resources
  */
 const patientEverything = async (args, { req }) => {
   validatePatientEverythingParams(req);

--- a/src/services/patient.service.js
+++ b/src/services/patient.service.js
@@ -8,8 +8,8 @@ const logger = loggers.get('default');
 /**
  * resulting function of sending a POST request to {BASE_URL}/4_0_1/Patient
  * creates a new patient in the database
- * @param {*} _ unused arg
- * @param {*} data the measure data passed in with the request
+ * @param {undefined} _ unused arg
+ * @param {Object} data the measure data passed in with the request
  * @returns an object with the created measure's id
  */
 const create = async (_, data) => {
@@ -19,7 +19,7 @@ const create = async (_, data) => {
 /**
  * result of sending a GET request to {BASE_URL}/4_0_1/Patient/{id}
  * searches for the patient with the passed in id
- * @param {*} args passed in arguments including the id of the sought after patient
+ * @param {Object} args passed in arguments including the id of the sought after patient
  * @returns
  */
 const searchById = async args => {
@@ -29,8 +29,8 @@ const searchById = async args => {
 /**
  * result of sending a PUT request to {BASE_URL}/4_0_1/Patient/{id}
  * updates the patient with the passed in id using the passed in data
- * @param {*} args passed in arguments including the id of the sought after patient
- * @param {*} data a map of the attributes to change and their new values
+ * @param {Object} args passed in arguments including the id of the sought after patient
+ * @param {Object} data a map of the attributes to change and their new values
  * @returns
  */
 const update = async (args, data) => {
@@ -40,7 +40,7 @@ const update = async (args, data) => {
 /**
  * result of sending a DELETE request to {BASE_URL}/4_0_1/Patient/{id}
  * removes the measure with the passed in id from the database
- * @param {*} args passed in arguments including the id of the sought after patient
+ * @param {Object} args passed in arguments including the id of the sought after patient
  * @returns
  */
 const remove = async args => {
@@ -87,7 +87,7 @@ const patientEverything = async (args, { req }) => {
 /**
  * Checks if unsupported parameters are provided in the http request.
  * If any unsupported parameters are present, a ServerError is thrown.
- * @param {*} req http request object
+ * @param {Object} req http request object
  */
 const validatePatientEverythingParams = req => {
   // These params are not supported. We should throw an error if we receive them

--- a/src/util/bundleUtils.js
+++ b/src/util/bundleUtils.js
@@ -145,7 +145,7 @@ async function assembleCollectionBundleFromMeasure(measure) {
 /**
  * Go through the relatedArtifact ValueSets and query for them from the database
  * @param {Object} lib FHIR library to grab ValueSets for
- * @returns {Array} list of ValueSet resources required by the library
+ * @returns {Array} array of ValueSet resources required by the library
  */
 async function getDependentValueSets(lib) {
   if (hasNoDependencies(lib)) {

--- a/src/util/bundleUtils.js
+++ b/src/util/bundleUtils.js
@@ -9,7 +9,7 @@ const patientRefs = require('../compartment-definition/patient-references');
 
 /**
  * Converts an array of FHIR resources to a fhir searchset bundle
- * @param {Array} resources and array of FHIR resources
+ * @param {Array} resources an array of FHIR resources
  * @param {Object} args the arguments passed in through the client's request
  * @param {Object} req the request passed in by the client
  * @returns {Object} a FHIR searchset bundle containing the properly formatted resources

--- a/src/util/bundleUtils.js
+++ b/src/util/bundleUtils.js
@@ -12,7 +12,7 @@ const patientRefs = require('../compartment-definition/patient-references');
  * @param {Array} resources and array of FHIR resources
  * @param {Object} args the arguments passed in through the client's request
  * @param {Object} req the request passed in by the client
- * @returns a FHIR searchset bundle containing the properly formatted resources
+ * @returns {Object} a FHIR searchset bundle containing the properly formatted resources
  */
 function mapArrayToSearchSetBundle(resources, args, req) {
   const Bundle = resolveSchema(args.base_version, 'bundle');
@@ -49,7 +49,7 @@ function mapResourcesToCollectionBundle(resources) {
 /**
  * Utility function for checking if a given string is a canonical URL
  * @param {string} s the string to check
- * @returns true if the string is a url, false otherwise
+ * @returns {boolean} true if the string is a url, false otherwise
  */
 function isCanonicalUrl(s) {
   const urlRegex = /(ftp|http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-/]))?/;
@@ -59,7 +59,7 @@ function isCanonicalUrl(s) {
 /**
  * Utility function for checking if a library has any dependencies
  * @param {Object} lib FHIR Library resource to check dependencies of
- * @returns true if there are any other Library/ValueSet resources that this library depends on, false otherwise
+ * @returns {boolean} true if there are any other Library/ValueSet resources that this library depends on, false otherwise
  */
 function hasNoDependencies(lib) {
   return !lib.relatedArtifact || (Array.isArray(lib.relatedArtifact) && lib.relatedArtifact.length === 0);
@@ -68,7 +68,7 @@ function hasNoDependencies(lib) {
 /**
  * Assemble a mongo query based on a reference to another resource
  * @param {string} reference either a canonical or resourceType/id reference
- * @returns mongo query to pass in to mongo controller to search for the referenced resource
+ * @returns {Object} mongo query to pass in to mongo controller to search for the referenced resource
  */
 function getQueryFromReference(reference) {
   // References could be canonical or resourceType/id
@@ -88,7 +88,7 @@ function getQueryFromReference(reference) {
 /**
  * Assemble a measure bundle with necessary FHIR Library resources
  * @param {string} measureId id of the measure to assemble bundle for
- * @returns FHIR Bundle of Measure resource and all dependent FHIR Library resources
+ * @returns {Object} FHIR Bundle of Measure resource and all dependent FHIR Library resources
  */
 async function getMeasureBundleFromId(measureId) {
   const measure = await findResourceById(measureId, 'Measure');
@@ -113,7 +113,7 @@ async function getMeasureBundleFromId(measureId) {
  * Takes in a measure resource, finds all dependent library resources and bundles them
  * together with the measure in a collection bundle
  * @param {Object} measure a fhir measure resource
- * @returns FHIR Bundle of Measure resource and all dependent FHIR Library resources
+ * @returns {Object} FHIR Bundle of Measure resource and all dependent FHIR Library resources
  */
 async function assembleCollectionBundleFromMeasure(measure) {
   const [mainLibraryRef] = measure.library;
@@ -145,7 +145,7 @@ async function assembleCollectionBundleFromMeasure(measure) {
 /**
  * Go through the relatedArtifact ValueSets and query for them from the database
  * @param {Object} lib FHIR library to grab ValueSets for
- * @returns list of ValueSet resources required by the library
+ * @returns {Array} list of ValueSet resources required by the library
  */
 async function getDependentValueSets(lib) {
   if (hasNoDependencies(lib)) {
@@ -167,7 +167,7 @@ async function getDependentValueSets(lib) {
 /**
  * Iterate through relatedArtifact of library and return list of all dependent libraries used
  * @param {Object} lib FHIR library resources to traverse dependencies from
- * @returns array of all libraries
+ * @returns {Array} array of all libraries
  */
 async function getAllDependentLibraries(lib) {
   // Kick off function with current library and any ValueSets it uses
@@ -203,7 +203,7 @@ async function getAllDependentLibraries(lib) {
  * requirements and map the resources to a collection bundle.
  * @param {string} patientId patient ID of interest
  * @param {Array} dataRequirements data requirements array obtained from fqm execution
- * @returns patient bundle as a collection bundle
+ * @returns {Object} patient bundle as a collection bundle
  */
 async function getPatientDataCollectionBundle(patientId, dataRequirements) {
   const data = await getPatientData(patientId, dataRequirements);
@@ -217,7 +217,7 @@ async function getPatientDataCollectionBundle(patientId, dataRequirements) {
  * @param {string} patientId patient ID of interest
  * @param {Object} args passed in arguments
  * @param {Object} req http request body
- * @returns patient bundle as a searchset bundle
+ * @returns {Object} patient bundle as a searchset bundle
  */
 async function getPatientDataSearchSetBundle(patientId, args, req) {
   const data = await getPatientData(patientId);
@@ -229,7 +229,7 @@ async function getPatientDataSearchSetBundle(patientId, args, req) {
  * @param {string} patientId patient ID of interest
  * @param {Array} dataRequirements data requirements array obtained from fqm execution,
  * used when we are concerned with a specific measure. Otherwise undefined
- * @returns array of resources
+ * @returns {Array} array of resources
  */
 async function getPatientData(patientId, dataRequirements) {
   const patient = await findResourceById(patientId, 'Patient');
@@ -276,7 +276,7 @@ async function getPatientData(patientId, dataRequirements) {
  * Modify the request type to PUT after forcing the IDs. This will not affect return results, just internal representation
  *
  * @param {Array} entries array of bundle entries
- * @returns new array of entries with replaced references
+ * @returns {Array} new array of entries with replaced references
  */
 function replaceReferences(entries) {
   // Add metadata for old IDs and newly created ones of POST entries

--- a/src/util/bundleUtils.js
+++ b/src/util/bundleUtils.js
@@ -227,7 +227,7 @@ async function getPatientDataSearchSetBundle(patientId, args, req) {
 /**
  * Assemble the patient bundle to be used in our operations from fqm execution
  * @param {string} patientId patient ID of interest
- * @param {Array } dataRequirements data requirements array obtained from fqm execution,
+ * @param {Array} dataRequirements data requirements array obtained from fqm execution,
  * used when we are concerned with a specific measure. Otherwise undefined
  * @returns array of resources
  */

--- a/src/util/bundleUtils.js
+++ b/src/util/bundleUtils.js
@@ -7,6 +7,13 @@ const supportedResources = require('../server/supportedResources');
 // lookup from patient compartment-definition
 const patientRefs = require('../compartment-definition/patient-references');
 
+/**
+ * Converts an array of FHIR resources to a fhir searchset bundle
+ * @param {Array} resources and array of FHIR resources
+ * @param {Object} args the arguments passed in through the client's request
+ * @param {Object} req the request passed in by the client
+ * @returns a FHIR searchset bundle containing the properly formatted resources
+ */
 function mapArrayToSearchSetBundle(resources, args, req) {
   const Bundle = resolveSchema(args.base_version, 'bundle');
 
@@ -26,7 +33,7 @@ function mapArrayToSearchSetBundle(resources, args, req) {
 
 /**
  * Transform array of arbitrary resources into collection bundle
- * @param {Array} resources the list of resources to map
+ * @param {Array} resources an array of FHIR resources to map
  * @returns {Object} FHIR collection bundle of all resources
  */
 function mapResourcesToCollectionBundle(resources) {
@@ -105,7 +112,7 @@ async function getMeasureBundleFromId(measureId) {
 /**
  * Takes in a measure resource, finds all dependent library resources and bundles them
  * together with the measure in a collection bundle
- * @param {*} measure a fhir measure resource
+ * @param {Object} measure a fhir measure resource
  * @returns FHIR Bundle of Measure resource and all dependent FHIR Library resources
  */
 async function assembleCollectionBundleFromMeasure(measure) {
@@ -195,7 +202,7 @@ async function getAllDependentLibraries(lib) {
  * Wrapper function to get patient data for a given patient id and its data
  * requirements and map the resources to a collection bundle.
  * @param {string} patientId patient ID of interest
- * @param {Array} dataRequirements data requirements obtained from fqm execution
+ * @param {Array} dataRequirements data requirements array obtained from fqm execution
  * @returns patient bundle as a collection bundle
  */
 async function getPatientDataCollectionBundle(patientId, dataRequirements) {
@@ -220,7 +227,7 @@ async function getPatientDataSearchSetBundle(patientId, args, req) {
 /**
  * Assemble the patient bundle to be used in our operations from fqm execution
  * @param {string} patientId patient ID of interest
- * @param {Array} dataRequirements data requirements obtained from fqm execution,
+ * @param {Array } dataRequirements data requirements array obtained from fqm execution,
  * used when we are concerned with a specific measure. Otherwise undefined
  * @returns array of resources
  */

--- a/src/util/measureOperationsUtils.js
+++ b/src/util/measureOperationsUtils.js
@@ -79,7 +79,7 @@ function validateEvalMeasureParams(req) {
 /**
  * Uses request body parameter to search for the export server URL. Validates that
  * only one URL is present.
- * @param {*} parameters - request body parameter
+ * @param {Object} parameters - request body parameter
  * @returns export server URL string
  */
 const retrieveExportURL = parameters => {
@@ -132,7 +132,7 @@ const retrieveExportURL = parameters => {
 
 /**
  * Checks that all required parameters for care-gaps are present. Throws an error if not.
- * @param {*} req the request passed in by the client
+ * @param {Object} req the request passed in by the client
  * @returns void but throws a detailed error if it finds an issue
  */
 const validateCareGapsParams = req => {
@@ -196,7 +196,7 @@ const validateCareGapsParams = req => {
 
 /**
  * Checks that the parameters passed in for $data-requirements are valid
- * @param {*} req the request passed in by the user
+ * @param {Object} req the request passed in by the user
  * @returns void but throws a detailed error if necessary
  */
 const validateDataRequirementsParams = req => {
@@ -206,9 +206,9 @@ const validateDataRequirementsParams = req => {
 
 /**
  * Dynamic function for checking the presence of required params for all validation functions
- * @param {*} query the query passed in through the client's request
- * @param {*} requiredParams  an array of strings detailing which params are required
- * @param {*} functionName the name of the function we are checking for more detailed error message
+ * @param {Object} query the query passed in through the client's request
+ * @param {Array} requiredParams  an array of strings detailing which params are required
+ * @param {string} functionName the name of the function we are checking for more detailed error message
  * @returns void, but throws a detailed error when necessary
  */
 const checkRequiredParams = ({ query }, requiredParams, functionName) => {

--- a/src/util/provenanceUtils.js
+++ b/src/util/provenanceUtils.js
@@ -5,7 +5,7 @@ const { v4: uuidv4 } = require('uuid');
  * Creates a raw JSON AuditEvent resource from the X-Provenance headers of a submission request
  * @param {string} provenance the provenance headers in string form from the request
  * @param {Object} version base_version from parameter
- * @returns A JSON object representing an AuditEvent to be stored in the system
+ * @returns {Object} A JSON object representing an AuditEvent to be stored in the system
  */
 const createAuditEventFromProvenance = (provenance, version) => {
   provenance = JSON.parse(provenance);
@@ -69,7 +69,7 @@ const createAuditEventFromProvenance = (provenance, version) => {
  * In the event of an agent acting on behalf of another agent, this function
  * wraps the reference to the delegating agent properly for storage in an AuditEvent resource
  * @param {Object} reference a fhir reference object to the delegating agent
- * @returns a delegating agent to be added to an AuditEvent
+ * @returns {Object} a delegating agent to be added to an AuditEvent
  */
 const buildDelegator = reference => {
   return {

--- a/src/util/provenanceUtils.js
+++ b/src/util/provenanceUtils.js
@@ -146,9 +146,9 @@ const checkProvenanceHeader = requestHeaders => {
  * to the ID that the server uses for a resource that was created via POST/PUT
  *
  * will probably need to change for multiple references
- * @param {*} requestHeaders the headers from the request body
- * @param {*} res the response body
- * @param {*} target array of reference objects for provenance header
+ * @param {Object} requestHeaders the headers from the request body
+ * @param {Object} res the response body
+ * @param {Array} target array of reference objects for provenance header
  */
 const populateProvenanceTarget = (requestHeaders, res, target) => {
   const provenanceRequest = JSON.parse(requestHeaders['x-provenance']);


### PR DESCRIPTION
# Summary
Added JSDoc types and improved comments. Also removed the `res.status = () => res` workaround added back when we were using Asymmetrik

## New behavior
Hopefully none

## Code changes
Aside from updating comments, simply removing the above-mentioned workaround.

# Testing guidance

- Give it an `npm run test` and check the $import functionality to ensure that nothing has changed.
- Look through each file in the test server and make sure all appropriate functions have JSDocs and all JSDocs have correct argument typing
