### PR TITLE
Type check

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "db:reset": "npm run db:delete && npm run db:setup",
     "parse-references": "node src/scripts/parseCompartmentDefinition.js",
     "connectathon-upload": "node src/scripts/getConnectathonBundles.js",
-    "test": "jest --runInBand --forceExit",
+    "test": "jest --silent --runInBand --forceExit",
     "test:coverage": "jest --collectCoverage --silent --runInBand",
     "test:watch": "jest --watchAll --runInBand",
     "test:watch:coverage": "jest --watchAll --runInBand --collectCoverage"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "db:reset": "npm run db:delete && npm run db:setup",
     "parse-references": "node src/scripts/parseCompartmentDefinition.js",
     "connectathon-upload": "node src/scripts/getConnectathonBundles.js",
-    "test": "jest --silent --runInBand --forceExit",
+    "test": "jest --runInBand --forceExit",
     "test:coverage": "jest --collectCoverage --silent --runInBand",
     "test:watch": "jest --watchAll --runInBand",
     "test:watch:coverage": "jest --watchAll --runInBand --collectCoverage"

--- a/src/services/base.service.js
+++ b/src/services/base.service.js
@@ -218,7 +218,9 @@ const baseUpdate = async (args, { req }, resourceType) => {
   logger.info(`${resourceType} >>> update`);
   checkContentTypeHeader(req.headers);
   const data = req.body;
-  checkSupportedResource(data.resourceType);
+  if (data.resourceType !== undefined) {
+    checkSupportedResource(data.resourceType);
+  }
   //The user passes in an id in the request body and it doesn't match the id arg in the url
   //or user doesn't pass in body
   if (data.id !== args.id) {

--- a/src/services/base.service.js
+++ b/src/services/base.service.js
@@ -10,6 +10,7 @@ const {
   findResourcesWithAggregation
 } = require('../database/dbOperations');
 const { checkProvenanceHeader, populateProvenanceTarget } = require('../util/provenanceUtils');
+const { checkSupportedResource } = require('../util/baseUtils');
 
 const logger = loggers.get('default');
 
@@ -84,6 +85,7 @@ const baseCreate = async ({ req }, resourceType) => {
   logger.info(`${resourceType} >>> create`);
   checkContentTypeHeader(req.headers);
   const data = req.body;
+  checkSupportedResource(data.resourceType);
   //Create a new id regardless of whether one is passed
   data['id'] = uuidv4();
   if (req.headers['x-provenance']) {
@@ -216,7 +218,7 @@ const baseUpdate = async (args, { req }, resourceType) => {
   logger.info(`${resourceType} >>> update`);
   checkContentTypeHeader(req.headers);
   const data = req.body;
-
+  checkSupportedResource(data.resourceType);
   //The user passes in an id in the request body and it doesn't match the id arg in the url
   //or user doesn't pass in body
   if (data.id !== args.id) {

--- a/src/services/bundle.service.js
+++ b/src/services/bundle.service.js
@@ -71,8 +71,11 @@ async function handleSubmitDataBundles(transactionBundles, req) {
 
     if (auditID) {
       // save resources to the AuditEvent
+
       const entities = bundleResponse.entry
-        .filter(entry => entry.response.status === 200 || entry.response.staus === 201)
+        .filter(entry => {
+          return entry.response.status === '200 OK' || entry.response.status === '201 Created';
+        })
         .map(entry => {
           return { what: { reference: entry.response.location.replace(`${baseVersion}/`, '') } };
         });
@@ -137,7 +140,6 @@ async function uploadTransactionBundle(req, res) {
   const requestsArray = scrubbedEntries.map(async entry => {
     const { url, method } = entry.request;
     const destinationUrl = `${protocol}://${path.join(req.headers.host, baseUrl, baseVersion, url)}`;
-    console.log('reached');
     return axios[method.toLowerCase()](destinationUrl, entry.resource, {
       headers: entryHeaders
     }).catch(e => {

--- a/src/util/baseUtils.js
+++ b/src/util/baseUtils.js
@@ -1,0 +1,21 @@
+const { ServerError } = require('@projecttacoma/node-fhir-server-core');
+const supportedResources = require('../server/supportedResources');
+
+function checkSupportedResource(resourceType) {
+  if (!supportedResources.includes(resourceType)) {
+    throw new ServerError(null, {
+      statusCode: 400,
+      issue: [
+        {
+          severity: 'error',
+          code: 'BadRequest',
+          details: {
+            text: `resourceType: ${resourceType} is not a supported resourceType`
+          }
+        }
+      ]
+    });
+  }
+}
+
+module.exports = { checkSupportedResource };

--- a/test/services/base.service.test.js
+++ b/test/services/base.service.test.js
@@ -10,7 +10,7 @@ const { SINGLE_AGENT_PROVENANCE } = require('../fixtures/provenanceFixtures');
 
 const config = buildConfig();
 const server = initialize(config);
-const updatePatient = { id: 'testPatient', name: 'anUpdate' };
+const updatePatient = { resourceType: 'Patient', id: 'testPatient', name: 'anUpdate' };
 
 describe('base.service', () => {
   beforeEach(async () => {

--- a/test/util/baseUtils.test.js
+++ b/test/util/baseUtils.test.js
@@ -1,0 +1,10 @@
+const { checkSupportedResource } = require('../../src/util/baseUtils');
+
+describe('Testing base utility functions', () => {
+  test('returns true for supported resource', () => {
+    expect(checkSupportedResource('Patient')).toBeUndefined();
+  });
+  test('Throws error for unsupported resource', () => {
+    expect(() => checkSupportedResource('INVALID')).toThrow();
+  });
+});


### PR DESCRIPTION
# Summary
Added resource type checks for Create, Update, Transaction bundle upload and $submit-data

## New behavior
The test server will now throw 404 errors when the resource type included in the request body of a resource is not in our supported resources list

## Code changes
- Added a utility function to check the resourceType of a request body against our supported resources list
- Added code to run above function during Create, Update, Transaction bundle upload and $submit-data operations
- Updated Audit Event code to omit resources which failed to be Created/Updated during a transaction bundle upload or $submit data request
- Added testing for custom functions and updated existing testing to account for additions

# Testing guidance
- Try using the Create, Update, txn bundle upload, and $submit-data functionality using request bodies that contain invalid resource types and ensure that the error output is clear and appropriate
- Check that no other functionality is disturbed.
