### PR TITLE
Bulk-Data-Utilities Error handling

### DIFF
--- a/src/server/importWorker.js
+++ b/src/server/importWorker.js
@@ -40,13 +40,7 @@ importQueue.process(async job => {
 
 const executePingAndPull = async (clientEntryId, exportUrl, { headers, baseUrl, params, protocol }, measureBundle) => {
   try {
-    const transactionBundles = await BulkImportWrappers.executeBulkImport(
-      exportUrl,
-      clientEntryId,
-      measureBundle
-    ).catch(async e => {
-      await failBulkImportRequest(clientEntryId, e);
-    });
+    const transactionBundles = await BulkImportWrappers.executeBulkImport(exportUrl, clientEntryId, measureBundle);
     const baseVersion = params.base_version;
     const pendingTransactionBundles = transactionBundles.map(async tb => {
       const tbTemplate = resolveSchema(baseVersion, 'bundle');


### PR DESCRIPTION
# Summary
Small patch to differently catch errors thrown by bulk-data-utilities. To be reviewed in tandem with [Bulk-Data-Utilities #14](https://github.com/projecttacoma/bulk-data-utilities/pull/14)

## New behavior
When an error is thrown during a bulk import in bulk-data-utilities, it will now be correctly caught and stored in mongo for retrieval at the bulkStatus endpoint

## Code changes
Removed a .catch from our executePingAndPull function which was messing with our error handling

# Testing guidance
- Pull down the bulk-data-utilities `error-handling` branch
- Run `npm build` in bulk-data-utilities repo
- Run `npm link _{PathToBulkDataUtilities}_`
- Run `npm run start` (note: do not start up the bulk export server)
- Send a bulk import request using the instructions [here](https://github.com/projecttacoma/deqm-test-server/pull/54) (note: You can and should skip the step of changing the export url line in bulk-data-utilities)
- You should now see a descriptive error about the connection refusing when sending a request to the bulkstatus endpoint
- Now, start up the bulk-export-server, upload the connectathon bundles using `npm run connectathon-upload` and send another bulkImport request
- You should now see a descriptive error documenting the known reference failure in the connectathon-bundles