### PR TITLE
update package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2690,7 +2690,7 @@
       "dev": true
     },
     "bulk-data-utilities": {
-      "version": "git+https://github.com/projecttacoma/bulk-data-utilities.git#0c86db4a8ac1bad422574ee33b75ff0b16dfca08",
+      "version": "git+https://github.com/projecttacoma/bulk-data-utilities.git#b17a8948cc263233b397ebff844f9f0ac7a983ef",
       "from": "git+https://github.com/projecttacoma/bulk-data-utilities.git",
       "requires": {
         "axios": "^0.21.2",


### PR DESCRIPTION
# Summary
Changes were made to the bulk-data-utilities repo. This PR updates package-lock to refer to the correct commit hash.

## New behavior

## Code changes

# Testing guidance
Check that the upgraded commit hash is correct