### PR TITLE
Update node-fhir-server-core to 2.2.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1718,9 +1718,9 @@
       "integrity": "sha512-Vvz3DcXZ2YRWwPbKeqAzeheykiWYcRO5WdXEz6iQKlPgFQHFB3rml7g3NcEkTrxlwwDb0C86Yg682PJDW1Q0GA=="
     },
     "@projecttacoma/node-fhir-server-core": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@projecttacoma/node-fhir-server-core/-/node-fhir-server-core-2.2.6.tgz",
-      "integrity": "sha512-I+NYRU1e3P4SkvRa0x6BDiQ4RRlDdK0sM2WwXchHtBoVBqRey5yM7gGpblG9ZougOrFMNfWqTj/LBHXekvkkMg==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@projecttacoma/node-fhir-server-core/-/node-fhir-server-core-2.2.7.tgz",
+      "integrity": "sha512-61D9MEiqXhi0oSaR5WRrj9SJ1HhODDagDoW01LnZbhtQJyY49/laCuudnab/TwUNWNL8z2QVGpFksKqoSAN5YA==",
       "requires": {
         "@asymmetrik/sof-scope-checker": "^1.0.7",
         "@hapi/bourne": "^1.3.2",
@@ -1735,12 +1735,12 @@
         "helmet": "^3.9.0",
         "jsonschema": "^1.2.2",
         "jsonwebtoken": "^8.1.0",
-        "jwk-to-pem": "^2.0.2",
-        "method-override": "^2.3.10",
-        "moment": "^2.19.4",
-        "moment-timezone": "^0.5.14",
-        "mongodb": "^3.0.0-rc0",
-        "passport": "^0.4.0",
+        "jwk-to-pem": "^2.0.5",
+        "method-override": "^3.0.0",
+        "moment": "^2.29.1",
+        "moment-timezone": "^0.5.33",
+        "mongodb": "^4.1.3",
+        "passport": "^0.5.0",
         "passport-http-bearer": "^1.0.1",
         "sanitize-html": "^2.5.1",
         "serve-favicon": "^2.5.0",
@@ -1752,9 +1752,9 @@
       },
       "dependencies": {
         "domhandler": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.2.tgz",
-          "integrity": "sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.0.tgz",
+          "integrity": "sha512-fC0aXNQXqKSFTr2wDNZDhsEYjCiYsDWl3D01kwt25hm1YIPyDGHvvi3rw+PLqHAl/m71MaiF7d5zvBr0p5UB2g==",
           "requires": {
             "domelementtype": "^2.2.0"
           }
@@ -1819,46 +1819,32 @@
             "entities": "^2.0.0"
           }
         },
-        "mongodb": {
-          "version": "3.7.3",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.3.tgz",
-          "integrity": "sha512-Psm+g3/wHXhjBEktkxXsFMZvd3nemI0r3IPsE0bU+4//PnvNWKkzhZcEsbPcYiWqe8XqXJJEg4Tgtr7Raw67Yw==",
-          "requires": {
-            "bl": "^2.2.1",
-            "bson": "^1.1.4",
-            "denque": "^1.4.1",
-            "optional-require": "^1.1.8",
-            "safe-buffer": "^5.1.2",
-            "saslprep": "^1.0.0"
-          }
-        },
         "picocolors": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
           "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
         },
         "postcss": {
-          "version": "8.3.11",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.11.tgz",
-          "integrity": "sha512-hCmlUAIlUiav8Xdqw3Io4LcpA1DOt7h3LSTAC4G6JGHFFaWzI6qvFt9oilvl8BmkbBRX1IhM90ZAmpk68zccQA==",
+          "version": "8.4.5",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.5.tgz",
+          "integrity": "sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==",
           "requires": {
             "nanoid": "^3.1.30",
             "picocolors": "^1.0.0",
-            "source-map-js": "^0.6.2"
+            "source-map-js": "^1.0.1"
           }
         },
         "sanitize-html": {
-          "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.5.2.tgz",
-          "integrity": "sha512-sJ1rO2YixFIqs2kIcEUb6PTrCjvz8DMq1XqWWuy0kjgjrn58GNLK1DKSIRybFZDO1WNgsEgD+WiEzTEYS8xEug==",
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.6.1.tgz",
+          "integrity": "sha512-DzjSz3H5qDntD7s1TcWCSoRPmNR8UmA+y+xZQOvWgjATe2Br9ZW73+vD3Pj6Snrg0RuEuJdXgrKvnYuiuixRkA==",
           "requires": {
             "deepmerge": "^4.2.2",
             "escape-string-regexp": "^4.0.0",
             "htmlparser2": "^6.0.0",
             "is-plain-object": "^5.0.0",
-            "klona": "^2.0.3",
             "parse-srcset": "^1.0.2",
-            "postcss": "^8.0.2"
+            "postcss": "^8.3.11"
           }
         },
         "validator": {
@@ -2218,9 +2204,9 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
     },
     "async": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.1.tgz",
-      "integrity": "sha512-XdD5lRO/87udXCMC9meWdYiR+Nq6ZjUfXidViUZGu2F1MO4T3XwZ1et0hb2++BgLfhyJwy44BGB/yx80ABx8hg=="
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.2.tgz",
+      "integrity": "sha512-H0E+qZaDEfx/FY4t7iLRv1W2fFI6+pyCeTw1uN20AQPiwqwM6ojPxHxdLv4z8hi2DtnW9BOckSspLucW7pIE5g=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -2464,15 +2450,6 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
     },
-    "bl": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
-      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
-      "requires": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
-      }
-    },
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
@@ -2663,11 +2640,6 @@
       "requires": {
         "node-int64": "^0.4.0"
       }
-    },
-    "bson": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
-      "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg=="
     },
     "buffer": {
       "version": "5.7.1",
@@ -2926,9 +2898,9 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-string": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.6.0.tgz",
-      "integrity": "sha512-c/hGS+kRWJutUBEngKKmk4iH3sD59MBkoxVapS/0wgpCz2u7XsNloxknyvBhzwEs1IbV36D9PwqLPJ2DTu3vMA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.0.tgz",
+      "integrity": "sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==",
       "requires": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -3322,11 +3294,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
-    },
-    "denque": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
-      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw=="
     },
     "depd": {
       "version": "1.1.2",
@@ -6927,11 +6894,6 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
-    "klona": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.5.tgz",
-      "integrity": "sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ=="
-    },
     "kuler": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
@@ -7141,20 +7103,20 @@
       "dev": true
     },
     "method-override": {
-      "version": "2.3.10",
-      "resolved": "https://registry.npmjs.org/method-override/-/method-override-2.3.10.tgz",
-      "integrity": "sha1-49r41d7hDdLc59SuiNYrvud0drQ=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/method-override/-/method-override-3.0.0.tgz",
+      "integrity": "sha512-IJ2NNN/mSl9w3kzWB92rcdHpz+HjkxhDJWNDBqSlas+zQdP8wBiJzITPg08M/k2uVvMow7Sk41atndNtt/PHSA==",
       "requires": {
-        "debug": "2.6.9",
+        "debug": "3.1.0",
         "methods": "~1.1.2",
         "parseurl": "~1.3.2",
         "vary": "~1.1.2"
       },
       "dependencies": {
         "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "requires": {
             "ms": "2.0.0"
           }
@@ -7663,14 +7625,6 @@
         "mimic-fn": "^2.1.0"
       }
     },
-    "optional-require": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.1.8.tgz",
-      "integrity": "sha512-jq83qaUb0wNg9Krv1c5OQ+58EK+vHde6aBPzLvPPqJm89UQWsvSuFy9X/OSNJnFeSOKo7btE0n8Nl2+nE+z5nA==",
-      "requires": {
-        "require-at": "^1.0.6"
-      }
-    },
     "optionator": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
@@ -7775,9 +7729,9 @@
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
     "passport": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/passport/-/passport-0.4.1.tgz",
-      "integrity": "sha512-IxXgZZs8d7uFSt3eqNjM9NQ3g3uQCW5avD8mRNoXV99Yig50vjuaez6dQK2qC0kVWPRTujxY0dWgGfT09adjYg==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.5.2.tgz",
+      "integrity": "sha512-w9n/Ot5I7orGD4y+7V3EFJCQEznE5RxHamUxcqLT2QoJY0f2JdN8GyHonYFvN0Vz+L6lUJfVhrk2aZz2LbuREw==",
       "requires": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1"
@@ -8226,11 +8180,6 @@
         }
       }
     },
-    "require-at": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/require-at/-/require-at-1.0.6.tgz",
-      "integrity": "sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g=="
-    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -8586,9 +8535,9 @@
       }
     },
     "snyk": {
-      "version": "1.746.0",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.746.0.tgz",
-      "integrity": "sha512-RQlpKam8h/Gerx4PLex7oN2SWE60VosbqsYZZP6kEy9xj+B1z10FR3lJ+UpGuxqBn7zXwXavm3QEizH9tvxTfw=="
+      "version": "1.812.0",
+      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.812.0.tgz",
+      "integrity": "sha512-qNwExVlsQt2io8sDdaj/h/3Q31EqlhABLMO/N8aKKnkiLFv69H37J3Ci6gjByIca4YXzg1kHM++MaC9xKXOyqg=="
     },
     "source-map": {
       "version": "0.6.1",
@@ -8596,9 +8545,9 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-js": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
-      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.1.tgz",
+      "integrity": "sha512-4+TN2b3tqOCd/kaGRJ/sTYA0tR0mdXx26ipdolxcwtJVqEnqNYvlCAt1q3ypy4QMlYus+Zh34RNtYLoq2oQ4IA=="
     },
     "source-map-support": {
       "version": "0.5.20",
@@ -9560,12 +9509,25 @@
       }
     },
     "winston-transport": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.0.tgz",
-      "integrity": "sha512-Lc7/p3GtqtqPBYYtS6KCN3c77/2QCev51DvcJKbkFPQNoj1sinkGwLGFDxkXY9J6p9+EPnYs+D90uwbnaiURTw==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.1.tgz",
+      "integrity": "sha512-ciZRlU4CSjHqHe8RQG1iPxKMRVwv6ZJ0RC7DxStKWd0KjpAhPDy5gVYSCpIUq+5CUsP+IyNOTZy1X0tO2QZqjg==",
       "requires": {
-        "readable-stream": "^2.3.7",
+        "logform": "^2.2.0",
+        "readable-stream": "^3.4.0",
         "triple-beam": "^1.2.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "wkx": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@asymmetrik/fhir-qb": "^0.12.5",
     "@asymmetrik/fhir-qb-mongo": "^0.12.3",
-    "@projecttacoma/node-fhir-server-core": "^2.2.6 ",
+    "@projecttacoma/node-fhir-server-core": "^2.2.7",
     "axios": "^0.21.4",
     "bee-queue": "^1.4.0",
     "bulk-data-utilities": "git+https://github.com/projecttacoma/bulk-data-utilities.git",


### PR DESCRIPTION
no new behavior, just updating the dependency to the new rebased copy of fhir-server-core (published as a patch version)

Just test all functionality and make sure nothing broke.