### PR TITLE
Gaps post

### DIFF
--- a/src/services/base.service.js
+++ b/src/services/base.service.js
@@ -153,7 +153,6 @@ const baseSearch = async (args, { req }, resourceType, paramDefs) => {
   } else {
     searchParams = paramDefs;
   }
-
   // wipe out params since the 'base_version' here breaks the query building
   req.params = {};
 

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -24,7 +24,6 @@ const {
   findOneResourceWithQuery,
   findResourcesWithQuery
 } = require('../database/dbOperations');
-const { request } = require('express');
 
 const logger = loggers.get('default');
 

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -10,7 +10,8 @@ const { retrieveExportUrl } = require('../util/exportUtils');
 const {
   validateEvalMeasureParams,
   validateCareGapsParams,
-  validateDataRequirementsParams
+  validateDataRequirementsParams,
+  gatherParams
 } = require('../util/validationUtils');
 const {
   getMeasureBundleFromId,
@@ -23,6 +24,7 @@ const {
   findOneResourceWithQuery,
   findResourcesWithQuery
 } = require('../database/dbOperations');
+const { request } = require('express');
 
 const logger = loggers.get('default');
 
@@ -279,11 +281,21 @@ const evaluateMeasure = async (args, { req }) => {
 const careGaps = async (args, { req }) => {
   logger.info('Measure >>> $care-gaps');
 
-  validateCareGapsParams(req.query);
+  let query;
+  if (req.method === 'POST') {
+    query = gatherParams(req.query, req.body);
+  } else {
+    query = req.query;
+  }
+  validateCareGapsParams(query);
 
-  const { periodStart, periodEnd, subject } = req.query;
-  const searchTerm = retrieveSearchTerm(req);
-  req.query = searchTerm;
+  const { periodStart, periodEnd, subject } = query;
+  const searchTerm = retrieveSearchTerm(query);
+  if (req.method === 'POST') {
+    req.body = searchTerm;
+  } else {
+    req.query = searchTerm;
+  }
   //Use the base search function here to allow search by measureId, measureUrl, and measureIdentifier
   const measure = await search(args, { req });
   if (measure.total === 0) {
@@ -319,8 +331,8 @@ const careGaps = async (args, { req }) => {
  * @param {Object} req http request object
  * @returns {Object} an object containing the measure identifier with the appropriate key
  */
-const retrieveSearchTerm = req => {
-  const { measureId, measureIdentifier, measureUrl } = req.query;
+const retrieveSearchTerm = query => {
+  const { measureId, measureIdentifier, measureUrl } = query;
 
   if (measureId) {
     return { _id: measureId };

--- a/src/util/validationUtils.js
+++ b/src/util/validationUtils.js
@@ -169,9 +169,29 @@ const checkNoUnsupportedParams = (query, unsupportedParams, operationName) => {
   }
 };
 
+/**
+ * Pulls query parameters from both the body and creates a new parameters map
+ * @param {Object} query the query terms on the request URL
+ * @param {Object} body a FHIR Parameters object passed into the body of the request passed in
+ * @returns {Object} an object containing a combination of request parameters from both sources
+ */
+const gatherParams = (query, body) => {
+  const params = { ...query };
+
+  if (body.parameter) {
+    body.parameter.reduce((acc, e) => {
+      if (!e.resource) {
+        acc[e.name] = e.valueDate || e.valueString || e.valueId || e.valueCode;
+      }
+    }, params);
+  }
+  return params;
+};
+
 module.exports = {
   validateEvalMeasureParams,
   validateCareGapsParams,
   validateDataRequirementsParams,
-  checkRequiredParams
+  checkRequiredParams,
+  gatherParams
 };

--- a/src/util/validationUtils.js
+++ b/src/util/validationUtils.js
@@ -183,6 +183,7 @@ const gatherParams = (query, body) => {
       if (!e.resource) {
         acc[e.name] = e.valueDate || e.valueString || e.valueId || e.valueCode;
       }
+      return acc;
     }, params);
   }
   return params;

--- a/test/util/validationUtils.test.js
+++ b/test/util/validationUtils.test.js
@@ -1,9 +1,18 @@
 const {
   checkRequiredParams,
   validateEvalMeasureParams,
-  validateCareGapsParams
+  validateCareGapsParams,
+  gatherParams
 } = require('../../src/util/validationUtils');
 const queue = require('../../src/resources/importQueue');
+
+const VALID_QUERY = {
+  periodStart: '2019-01-01',
+  periodEnd: '2019-12-31',
+  status: 'open',
+  subject: 'testPatient',
+  measureId: 'testID'
+};
 
 describe('checkRequiredParams', () => {
   test('check checkRequiredParams throws error on missing params', () => {
@@ -144,15 +153,33 @@ describe('validateCareGapsParams', () => {
 
   test('validateCareGapsParams does not throw error with correct params', async () => {
     const VALID_REQ = {
+      query: VALID_QUERY
+    };
+    expect(validateCareGapsParams(VALID_REQ.query)).toBeUndefined();
+  });
+
+  test('gatherParams gathers params from query and body', () => {
+    const SPLIT_REQ = {
       query: {
         periodStart: '2019-01-01',
         periodEnd: '2019-12-31',
-        status: 'open',
-        subject: 'testPatient',
-        measureId: 'testID'
+        status: 'open'
+      },
+      body: {
+        resourceType: 'Parameters',
+        parameter: [
+          {
+            name: 'subject',
+            valueString: 'testPatient'
+          },
+          {
+            name: 'measureId',
+            valueId: 'testID'
+          }
+        ]
       }
     };
-    expect(validateCareGapsParams(VALID_REQ.query)).toBeUndefined();
+    expect(gatherParams(SPLIT_REQ.query, SPLIT_REQ.body)).toEqual(VALID_QUERY);
   });
 
   afterAll(async () => await queue.close());


### PR DESCRIPTION
# Summary
Fixed a bug that cause POST requests for $care-gaps operations to fail

## New behavior
- POST requests now work for $care-gaps operations
- Request parameters can now be submitted in the url query, request body or both for POST requests

## Code changes
- Added gatherParams function to validateUtils which gathers the params from both the request body and url query
- Added conditionals in careGaps function to allow the fhirQueryBuilder to properly parse the request query params
- Added testing

# Testing guidance
- Run `npm run db:reset`
- Run `npm run connectathon-upload`
- Run `npm run start`
- Send a `GET` request to `http://localhost:3000/4_0_1/Measure/$care-gaps?measureId=measure-EXM130-7.3.000&periodStart=2019-01-01&periodEnd=2019-12-31&subject=denom-EXM130&status=open` and ensure output matches the same request in main.
- Change the request to a `POST` and resend. Ensure output is the same.
- Add a FHIR parameters body to your `POST` request. Within the parameter array, add objects of the following form:
`{"name": "measureId", "valueString":"measure-EXM130-7.3.000"}` where name contains the parameter name and value[x] contains the parameter value, where x is the type of the parameter (eg. valueDate, valueId, valueString, valueCode)
Ensure that the output of these requests is the same.
- Try mixing parameters between the query and the body and ensure the requests come back the same.
