### PR TITLE
Update env to reflect new variables

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
-HOST = localhost
-PORT = 3000
+SERVER_HOST = localhost
+SERVER_PORT = 3000
 DB_HOST = localhost
 DB_PORT = 27017
 DB_NAME = deqm-test-server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,8 @@ services:
       context: .
       dockerfile: Dockerfile
     environment:
-      HOST: fhir
-      PORT: 3000
+      SERVER_HOST: localhost
+      SERVER_PORT: 3000
       DB_HOST: mongo
       DB_PORT: 27017
       DB_NAME: deqm-test-server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,9 +9,13 @@ services:
       context: .
       dockerfile: Dockerfile
     environment:
+      HOST: fhir
+      PORT: 3000
       DB_HOST: mongo
       DB_PORT: 27017
       DB_NAME: deqm-test-server
+      IMPORT_WORKERS: 2
+      NDJSON_WORKERS: 2
       REDIS_HOST: redis
       REDIS_PORT: 6379
     ports:

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ for (let i = 0; i < process.env.NDJSON_WORKERS; i++) {
   });
 }
 
-const port = process.env.PORT || 3000;
+const port = process.env.SERVER_PORT || 3000;
 
 server.listen(port, async () => {
   logger.info(`Starting the FHIR Server at localhost:${port}`);

--- a/src/services/bulkstatus.service.js
+++ b/src/services/bulkstatus.service.js
@@ -104,7 +104,7 @@ async function checkBulkStatus(req, res) {
       outcome: [
         {
           type: 'OperationOutcome',
-          url: `http://${process.env.HOST}:${process.env.PORT}/${req.params.base_version}/file/${clientId}/OperationOutcome.ndjson`
+          url: `http://${process.env.SERVER_HOST}:${process.env.SERVER_PORT}/${req.params.base_version}/file/${clientId}/OperationOutcome.ndjson`
         }
       ],
       extension: { 'https://example.com/extra-property': true }

--- a/src/services/import.service.js
+++ b/src/services/import.service.js
@@ -27,7 +27,7 @@ async function bulkImport(req, res) {
   res.status(202);
   res.setHeader(
     'Content-Location',
-    `http://${process.env.HOST}:${process.env.PORT}/${req.params.base_version}/bulkstatus/${clientEntry}`
+    `http://${process.env.SERVER_HOST}:${process.env.SERVER_PORT}/${req.params.base_version}/bulkstatus/${clientEntry}`
   );
   return;
 }

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -207,7 +207,7 @@ const bulkImportFromRequirements = async (args, { req }) => {
   res.status(202);
   res.setHeader(
     'Content-Location',
-    `http://${process.env.HOST}:${process.env.PORT}/${req.params.base_version}/bulkstatus/${clientEntry}`
+    `http://${process.env.SERVER_HOST}:${process.env.SERVER_PORT}/${req.params.base_version}/bulkstatus/${clientEntry}`
   );
 };
 

--- a/test/services/bulkstatus.service.test.js
+++ b/test/services/bulkstatus.service.test.js
@@ -23,7 +23,7 @@ describe('checkBulkStatus logic', () => {
     expect(response.body).toBeDefined();
     expect(response.body.outcome[0].type).toEqual('OperationOutcome');
     await supertest(server.app)
-      .get(response.body.outcome[0].url.replace(`http://${process.env.HOST}:${process.env.PORT}`, '')) //TODO: may need to break apart base_url to get slug
+      .get(response.body.outcome[0].url.replace(`http://${process.env.SERVER_HOST}:${process.env.SERVER_PORT}`, '')) //TODO: may need to break apart base_url to get slug
       .expect(200);
   });
   test('check 500 and error returned for failed request with known error', async () => {


### PR DESCRIPTION
noticed the docker compose environment hasn't been updated since we added some more variables to `.env` so I went ahead and did them such that `docker-compose up --build` still behaves properly for all functionality in the test server.

Assigned @natjoe4 by random draw