### PR TITLE
OperationOutcome file for individual resource errors during bulk import

### DIFF
--- a/src/database/dbOperations.js
+++ b/src/database/dbOperations.js
@@ -166,7 +166,7 @@ const failBulkImportRequest = async (clientId, error) => {
  */
 const pushBulkFailedOutcomes = async (clientId, failedOutcomes) => {
   const collection = db.collection('bulkImportStatuses');
-  await collection.findOneAndUpdate({ id: clientId }, { $push: failedOutcomes });
+  await collection.findOneAndUpdate({ id: clientId }, { $push: { failedOutcomes: { $each: failedOutcomes } } });
 };
 
 /**

--- a/src/database/dbOperations.js
+++ b/src/database/dbOperations.js
@@ -123,7 +123,8 @@ const addPendingBulkImportRequest = async () => {
     exportedFileCount: -1,
     totalFileCount: -1,
     exportedResourceCount: -1,
-    totalResourceCount: -1
+    totalResourceCount: -1,
+    failedOutcomes: []
   };
   await collection.insertOne(bulkImportClient);
   return clientId;
@@ -155,6 +156,17 @@ const failBulkImportRequest = async (clientId, error) => {
     }
   };
   await collection.findOneAndUpdate({ id: clientId }, { $set: update });
+};
+
+/**
+ * Pushes an array of error messages to a bulkstatus entry to late be converted to
+ * OperationOutcomes and made accessible via ndjson file to requestor
+ * @param {String} clientId The id associated with the bulkImport request
+ * @param {Array} failedOutcomes An array of strings with messages detailing why the resource failed import
+ */
+const pushBulkFailedOutcomes = async (clientId, failedOutcomes) => {
+  const collection = db.collection('bulkImportStatuses');
+  await collection.findOneAndUpdate({ id: clientId }, { $push: failedOutcomes });
 };
 
 /**
@@ -227,6 +239,7 @@ module.exports = {
   createResource,
   decrementBulkFileCount,
   failBulkImportRequest,
+  pushBulkFailedOutcomes,
   findOneResourceWithQuery,
   findResourceById,
   findResourcesWithAggregation,

--- a/src/database/dbOperations.js
+++ b/src/database/dbOperations.js
@@ -159,7 +159,7 @@ const failBulkImportRequest = async (clientId, error) => {
 };
 
 /**
- * Pushes an array of error messages to a bulkstatus entry to late be converted to
+ * Pushes an array of error messages to a bulkstatus entry to later be converted to
  * OperationOutcomes and made accessible via ndjson file to requestor
  * @param {String} clientId The id associated with the bulkImport request
  * @param {Array} failedOutcomes An array of strings with messages detailing why the resource failed import

--- a/src/server/importWorker.js
+++ b/src/server/importWorker.js
@@ -45,7 +45,9 @@ const executePingAndPull = async (clientEntryId, exportUrl, measureBundle) => {
   try {
     // Default to not use typeFilters for measure specific import
     const output = await BulkImportWrappers.executeBulkImport(exportUrl, measureBundle, false);
-
+    if (output.length === 0) {
+      throw new Error('Export server failed to export any resources');
+    }
     // Calculate number of resources to export, if available. Otherwise, set to -1.
     const resourceCount = output.reduce((resources, fileInfo) => {
       if (resources === -1 || fileInfo.count === undefined) {

--- a/src/server/ndjsonWorker.js
+++ b/src/server/ndjsonWorker.js
@@ -49,6 +49,8 @@ ndjsonWorker.process(async job => {
         checkSupportedResource(data.resourceType);
         return updateResource(data.id, data, data.resourceType);
       } catch (e) {
+        // Here, the location of the error message varies between standard error and ServerError
+        // The former path finds the message for a ServerError, the latter for a standard error
         throw new Error(
           `${data.resourceType}/${data.id} failed import with the following message: ${
             e.issue?.[0]?.details?.text ?? e.message
@@ -63,7 +65,7 @@ ndjsonWorker.process(async job => {
   const outcomeData = [];
 
   failedOutcomes.forEach(out => {
-    outcomeData.push(out?.reason?.issue?.[0]?.details?.text ?? out.reason.message);
+    outcomeData.push(out.reason.message);
   });
   await pushBulkFailedOutcomes(clientId, outcomeData);
 

--- a/src/server/ndjsonWorker.js
+++ b/src/server/ndjsonWorker.js
@@ -39,9 +39,22 @@ ndjsonWorker.process(async job => {
     .trim()
     .split(/\n/)
     .map(async resourceStr => {
-      const data = JSON.parse(resourceStr);
-      checkSupportedResource(data.resourceType);
-      return updateResource(data.id, data, data.resourceType);
+      let data;
+      try {
+        data = JSON.parse(resourceStr);
+      } catch (e) {
+        throw new Error(`Error parsing JSON: ${resourceStr}`);
+      }
+      try {
+        checkSupportedResource(data.resourceType);
+        return updateResource(data.id, data, data.resourceType);
+      } catch (e) {
+        throw new Error(
+          `${data.resourceType}/${data.id} failed import with the following message: ${
+            e.issue?.[0]?.details?.text ?? e.message
+          }`
+        );
+      }
     });
 
   const outcomes = await Promise.allSettled(insertions);

--- a/src/server/ndjsonWorker.js
+++ b/src/server/ndjsonWorker.js
@@ -39,7 +39,6 @@ ndjsonWorker.process(async job => {
     .trim()
     .split(/\n/)
     .map(async resourceStr => {
-      resourceStr = resourceStr.slice(-25);
       const data = JSON.parse(resourceStr);
       checkSupportedResource(data.resourceType);
       return updateResource(data.id, data, data.resourceType);

--- a/src/services/bulkstatus.service.js
+++ b/src/services/bulkstatus.service.js
@@ -98,7 +98,7 @@ async function checkBulkStatus(req, res) {
     const OperationOutcome = resolveSchema(req.params.base_version, 'operationoutcome');
     writeToFile(JSON.parse(JSON.stringify(new OperationOutcome(outcome).toJSON())), 'OperationOutcome', clientId);
 
-    return {
+    const response = {
       transactionTime: '2021-01-01T00:00:00Z',
       requiresAccessToken: true,
       outcome: [
@@ -109,6 +109,28 @@ async function checkBulkStatus(req, res) {
       ],
       extension: { 'https://example.com/extra-property': true }
     };
+
+    if (bulkStatus.failedOutcomes.length > 0) {
+      bulkStatus.failedOutcomes.forEach(fail => {
+        const failOutcome = {};
+        failOutcome.id = uuidv4();
+        failOutcome.issue = [
+          {
+            severity: 'error',
+            code: 'BadRequest',
+            details: {
+              text: fail
+            }
+          }
+        ];
+        writeToFile(JSON.parse(JSON.stringify(new OperationOutcome(failOutcome).toJSON())), 'Errors', clientId);
+      });
+      response.outcome.push({
+        type: 'OperationOutcome',
+        url: `http://${process.env.HOST}:${process.env.PORT}/${req.params.base_version}/file/${clientId}/Errors.ndjson`
+      });
+    }
+    return response;
   } else {
     const outcome = {};
     outcome.id = uuidv4();

--- a/src/services/bulkstatus.service.js
+++ b/src/services/bulkstatus.service.js
@@ -127,7 +127,7 @@ async function checkBulkStatus(req, res) {
       });
       response.outcome.push({
         type: 'OperationOutcome',
-        url: `http://${process.env.HOST}:${process.env.PORT}/${req.params.base_version}/file/${clientId}/Errors.ndjson`
+        url: `http://${process.env.SERVER_HOST}:${process.env.SERVER_PORT}/${req.params.base_version}/file/${clientId}/Errors.ndjson`
       });
     }
     return response;

--- a/test/database/dbOperations.test.js
+++ b/test/database/dbOperations.test.js
@@ -3,7 +3,8 @@ const {
   initializeBulkFileCount,
   decrementBulkFileCount,
   failBulkImportRequest,
-  findResourceById
+  findResourceById,
+  pushBulkFailedOutcomes
 } = require('../../src/database/dbOperations');
 
 describe('check bulk file count logic', () => {
@@ -72,6 +73,13 @@ describe('check bulk import status logic', () => {
     expect(result.status).toEqual('Failed');
     expect(result.error.code).toEqual(500);
     expect(result.error.message).toEqual(TEST_ERROR.message);
+  });
+  test('push to failed outcomes adds correctly to failed outcome array', async () => {
+    const CLIENT_ID = 'PENDING_REQUEST';
+    const exampleOutcomes = ['test1', 'test2'];
+    await pushBulkFailedOutcomes(CLIENT_ID, exampleOutcomes);
+    const result = await findResourceById(CLIENT_ID, 'bulkImportStatuses');
+    expect(result.failedOutcomes).toEqual(['test1', 'test2']);
   });
 
   afterAll(cleanUpTest);

--- a/test/fixtures/testBulkStatus.json
+++ b/test/fixtures/testBulkStatus.json
@@ -7,7 +7,8 @@
     "exportedFileCount": 10,
     "totalResourceCount": -1,
     "exportedResourceCount": -1,
-    "error": { "code": null, "message": null }
+    "error": { "code": null, "message": null },
+    "failedOutcomes": []
   },
   {
     "id": "PENDING_REQUEST_WITH_RESOURCE_COUNT",
@@ -16,7 +17,8 @@
     "exportedFileCount": 10,
     "totalResourceCount": 500,
     "exportedResourceCount": 200,
-    "error": { "code": null, "message": null }
+    "error": { "code": null, "message": null },
+    "failedOutcomes": []
   },
   {
     "id": "ALMOST_COMPLETE_PENDING_REQUEST",
@@ -25,13 +27,20 @@
     "exportedFileCount": 1,
     "totalResourceCount": 500,
     "exportedResourceCount": 10,
-    "error": { "code": null, "message": null }
+    "error": { "code": null, "message": null },
+    "failedOutcomes": []
   },
-  { "id": "COMPLETED_REQUEST", "status": "Completed", "error": { "code": null, "message": null } },
+  {
+    "id": "COMPLETED_REQUEST",
+    "status": "Completed",
+    "error": { "code": null, "message": null },
+    "failedOutcomes": []
+  },
   {
     "id": "KNOWN_ERROR_REQUEST",
     "status": "Error",
-    "error": { "code": "ErrorCode", "message": "Known Error Occurred!" }
+    "error": { "code": "ErrorCode", "message": "Known Error Occurred!" },
+    "failedOutcomes": []
   },
-  { "id": "UNKNOWN_ERROR_REQUEST", "status": "Error", "error": { "code": null, "message": null } }
+  { "id": "UNKNOWN_ERROR_REQUEST", "status": "Error", "error": { "code": null, "message": null }, "failedOutcomes": [] }
 ]

--- a/test/fixtures/testBulkStatus.json
+++ b/test/fixtures/testBulkStatus.json
@@ -37,6 +37,12 @@
     "failedOutcomes": []
   },
   {
+    "id": "COMPLETED_REQUEST_WITH_RESOURCE_ERRORS",
+    "status": "Completed",
+    "error": { "code": null, "message": null },
+    "failedOutcomes": ["Test error message"]
+  },
+  {
     "id": "KNOWN_ERROR_REQUEST",
     "status": "Error",
     "error": { "code": "ErrorCode", "message": "Known Error Occurred!" },

--- a/test/services/bulkstatus.service.test.js
+++ b/test/services/bulkstatus.service.test.js
@@ -26,7 +26,7 @@ describe('checkBulkStatus logic', () => {
       .get(response.body.outcome[0].url.replace(`http://${process.env.SERVER_HOST}:${process.env.SERVER_PORT}`, '')) //TODO: may need to break apart base_url to get slug
       .expect(200);
   });
-  test('check 200 returned with error OperationOUtcome ndjson file when it exists', async () => {
+  test('check 200 returned with error OperationOutcome ndjson file when it exists', async () => {
     const response = await supertest(server.app)
       .get('/4_0_1/bulkstatus/COMPLETED_REQUEST_WITH_RESOURCE_ERRORS')
       .expect(200);

--- a/test/services/bulkstatus.service.test.js
+++ b/test/services/bulkstatus.service.test.js
@@ -26,6 +26,19 @@ describe('checkBulkStatus logic', () => {
       .get(response.body.outcome[0].url.replace(`http://${process.env.SERVER_HOST}:${process.env.SERVER_PORT}`, '')) //TODO: may need to break apart base_url to get slug
       .expect(200);
   });
+  test('check 200 returned with error OperationOUtcome ndjson file when it exists', async () => {
+    const response = await supertest(server.app)
+      .get('/4_0_1/bulkstatus/COMPLETED_REQUEST_WITH_RESOURCE_ERRORS')
+      .expect(200);
+    expect(response.headers.expires).toBeDefined();
+    expect(response.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(response.body).toBeDefined();
+    expect(response.body.outcome.length).toEqual(2);
+    expect(response.body.outcome[1].type).toEqual('OperationOutcome');
+    await supertest(server.app)
+      .get(response.body.outcome[1].url.replace(`http://${process.env.HOST}:${process.env.PORT}`, '')) //TODO: may need to break apart base_url to get slug
+      .expect(200);
+  });
   test('check 500 and error returned for failed request with known error', async () => {
     await supertest(server.app)
       .get('/4_0_1/bulkstatus/KNOWN_ERROR_REQUEST')

--- a/test/services/bulkstatus.service.test.js
+++ b/test/services/bulkstatus.service.test.js
@@ -36,7 +36,7 @@ describe('checkBulkStatus logic', () => {
     expect(response.body.outcome.length).toEqual(2);
     expect(response.body.outcome[1].type).toEqual('OperationOutcome');
     await supertest(server.app)
-      .get(response.body.outcome[1].url.replace(`http://${process.env.HOST}:${process.env.PORT}`, '')) //TODO: may need to break apart base_url to get slug
+      .get(response.body.outcome[1].url.replace(`http://${process.env.SERVER_HOST}:${process.env.SERVER_PORT}`, '')) //TODO: may need to break apart base_url to get slug
       .expect(200);
   });
   test('check 500 and error returned for failed request with known error', async () => {


### PR DESCRIPTION
# Summary
Added a new outcome to bulk Import response with access to an error NDJson file when appropriate

## New behavior
When some or all resources fail during an $import or bulk submit data request, the bulkstatus endpoint will now provide a second OperationOutcome ndjson URL. Sending a `GET` request to this URL will return an NDJson file of OperationOutcome resources, one for each resource that failed import, with information on why the resources failed

## Code changes
- Added new failedOutcomes array to bulkstatus entry which stores error messages
- Added new function in dbOperations to push to this failedOutcomes array
- Added functionality to bulkstatus service that constructs the ndjson file on bulkstatus query and returns a URL at which the ndjson file can be accessed
- Added error for situation where bulkExportServer exports no resources (previously caused the request to hang)
- Added testing and updated existing fixtures

# Testing guidance
- Run the new tests using `npm test`
- Run a typical $import and bulk submit data request and ensure that the output is as expected
- Add the line `resourceStr = resourceStr.slice(1)` on line 44 in src/server/ndjsonWorker.js. This will cause the JSON.parse command to fail.
- Run a typical $import and bulk submit data request, follow the bulkstatus endpoint and ensure that the Error.ndjson url appears
- Send a `GET` request to the Error.ndjson url and ensure that the number of resources that failed on the parsing step is equivalent to the total number of resources that the bulk export server exported (They should all fail)
- Delete the JSON scrambling line
- Add the line `data.resourceType = 'INVALID'` on line 49 in src/server/ndjsonWorker.js. This will cause the `checkSupportedResourceType()` call to fail
- Repeat the $import and bulk submit steps detailed above and confirm the same results, this time with different error messages
- NOTE: Take special care to note the number of errors given and compare it to the number expected. It's unclear if Mongo db can handle the potential race conditions caused by pushing to a stored array from multiple processes.