### PR TITLE
$care-gaps returns Parameters object

### DIFF
--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -1,4 +1,4 @@
-const { ServerError, loggers, resolveSchema } = require('@projecttacoma/node-fhir-server-core');
+const { ServerError, loggers } = require('@projecttacoma/node-fhir-server-core');
 const { Calculator } = require('fqm-execution');
 const { baseCreate, baseSearchById, baseRemove, baseUpdate, baseSearch } = require('./base.service');
 const { createTransactionBundleClass } = require('../resources/transactionBundle');

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -1,4 +1,4 @@
-const { ServerError, loggers } = require('@projecttacoma/node-fhir-server-core');
+const { ServerError, loggers, resolveSchema } = require('@projecttacoma/node-fhir-server-core');
 const { Calculator } = require('fqm-execution');
 const { baseCreate, baseSearchById, baseRemove, baseUpdate, baseSearch } = require('./base.service');
 const { createTransactionBundleClass } = require('../resources/transactionBundle');
@@ -323,7 +323,18 @@ const careGaps = async (args, { req }) => {
     measurementPeriodStart: periodStart,
     measurementPeriodEnd: periodEnd
   });
-  return results;
+
+  const responseParameters = {
+    resourceType: 'Parameters',
+    parameter: [
+      {
+        name: 'return',
+        resource: results
+      }
+    ]
+  };
+
+  return responseParameters;
 };
 
 /**

--- a/test/services/measure.service.test.js
+++ b/test/services/measure.service.test.js
@@ -299,9 +299,18 @@ describe('testing custom measure operation', () => {
     const { Calculator } = require('fqm-execution');
     const gapsSpy = jest.spyOn(Calculator, 'calculateGapsInCare').mockImplementation(() => {
       return {
-        results: testCareGapsMeasureReport
+        results: {
+          resourceType: 'Bundle',
+          type: 'document',
+          entry: [
+            {
+              resource: testCareGapsMeasureReport
+            }
+          ]
+        }
       };
     });
+
     jest.spyOn(Calculator, 'calculateDataRequirements').mockImplementation(() => {
       return {
         results: {
@@ -314,7 +323,8 @@ describe('testing custom measure operation', () => {
         }
       };
     });
-    await supertest(server.app)
+
+    const { body } = await supertest(server.app)
       .get('/4_0_1/Measure/$care-gaps')
       .query({
         measureId: 'testMeasure',
@@ -329,6 +339,12 @@ describe('testing custom measure operation', () => {
       measurementPeriodStart: '01-01-2020',
       measurementPeriodEnd: '01-01-2021'
     });
+
+    expect(body.resourceType).toEqual('Parameters');
+    expect(body.parameter).toHaveLength(1);
+    expect(body.parameter[0].name).toEqual('return');
+    expect(body.parameter[0].resource).toBeDefined();
+    expect(body.parameter[0].resource.resourceType).toEqual('Bundle');
   });
 
   test('bulk import fails if measure bundle cannot be found', async () => {


### PR DESCRIPTION
# Summary
Converted `$care-gaps` output to FHIR Parameters object instead of Bundle, per the spec

## New behavior
The `$care-gaps` operation will now return a Parameters object upon successful completion

## Code changes
Moved the results of the FQM-execution gaps in care call into the body of a Parameters object before returning in measure.service.js

# Testing guidance

- run `npm run db:reset`
- run `npm run connectathon-upload` after cloning connectathon repository
- send a `POST` request to `http://localhost:3000/4_0_1/Measure/$care-gaps?periodStart=2019-01-01&periodEnd=2019-12-31&subject=denom-EXM130&status=open` with the following body:
```
{
	"resourceType": "Parameters",
	"parameter":[{
		"name":"measureId",
		"valueId":"measure-EXM130-7.3.000"
	}]
}```

- Ensure that the results are stored correctly within a Parameters object and the bundle is unchanged from what is returned from the same request in main.
