### PR TITLE
Bringing the code over from #72

### DIFF
--- a/src/database/dbOperations.js
+++ b/src/database/dbOperations.js
@@ -182,7 +182,8 @@ const initializeBulkFileCount = async (clientId, fileCount, resourceCount) => {
         exportedFileCount: fileCount,
         totalFileCount: fileCount,
         exportedResourceCount: resourceCount,
-        totalResourceCount: resourceCount
+        totalResourceCount: resourceCount,
+        successCount: 0
       }
     }
   );
@@ -220,6 +221,25 @@ const decrementBulkFileCount = async (clientId, resourceCount) => {
     await completeBulkImportRequest(clientId);
   }
 };
+/**
+ * Stores the total number of files successfully processed.
+ * @param {string} clientId The id signifying the bulk status request
+ * @param {number} resourceCount The number of successfully imported resources
+ */
+const updateSuccessfulImportCount = async (clientId, count) => {
+  const collection = db.collection('bulkImportStatuses');
+
+  await collection.findOneAndUpdate(
+    { id: clientId },
+    { $inc: { successCount: count } },
+    { returnDocument: 'after', projection: { exportedFileCount: true, exportedResourceCount: true, _id: 0 } }
+  );
+};
+const getCurrentSuccessfulImportCount = async clientId => {
+  const collection = db.collection('bulkImportStatuses');
+  const bulkStatus = await collection.findOne({ id: clientId });
+  return bulkStatus.successCount;
+};
 
 module.exports = {
   addPendingBulkImportRequest,
@@ -232,8 +252,10 @@ module.exports = {
   findResourcesWithAggregation,
   findResourcesWithQuery,
   getBulkImportStatus,
+  getCurrentSuccessfulImportCount,
   initializeBulkFileCount,
   pushToResource,
   removeResource,
-  updateResource
+  updateResource,
+  updateSuccessfulImportCount
 };

--- a/src/server/ndjsonWorker.js
+++ b/src/server/ndjsonWorker.js
@@ -2,7 +2,7 @@
 // This queue is run in a child process when the server is started
 const Queue = require('bee-queue');
 const axios = require('axios');
-const { updateResource, getCurrentSuccessfulImportCount } = require('../database/dbOperations');
+const { updateResource } = require('../database/dbOperations');
 const mongoUtil = require('../database/connection');
 
 console.log(`ndjson-worker-${process.pid}: ndjson Worker Started!`);
@@ -42,10 +42,9 @@ ndjsonWorker.process(async job => {
       return updateResource(data.id, data, data.resourceType);
     });
 
-  let successCount = await getCurrentSuccessfulImportCount(clientId);
   const results = await Promise.all(insertions);
+  let successCount = results.length;
 
-  successCount = successCount + results.length;
   console.log(`ndjson-worker-${process.pid}: processed ${fileName}`);
 
   process.send({ clientId, resourceCount, successCount });

--- a/src/server/ndjsonWorker.js
+++ b/src/server/ndjsonWorker.js
@@ -43,7 +43,7 @@ ndjsonWorker.process(async job => {
     });
 
   const results = await Promise.all(insertions);
-  let successCount = results.length;
+  const successCount = results.length;
 
   console.log(`ndjson-worker-${process.pid}: processed ${fileName}`);
 

--- a/src/services/bulkstatus.service.js
+++ b/src/services/bulkstatus.service.js
@@ -91,7 +91,7 @@ async function checkBulkStatus(req, res) {
               display: 'New resource created'
             }
           ],
-          text: 'Bulk import successfully completed'
+          text: `Bulk import successfully completed, successfully imported ${bulkStatus.successCount} resources`
         }
       }
     ];

--- a/test/fixtures/testBulkStatus.json
+++ b/test/fixtures/testBulkStatus.json
@@ -41,6 +41,7 @@
     "exportedFileCount": 10,
     "totalResourceCount": 500,
     "exportedResourceCount": 200,
+    "succesCount":200,
     "error": { "code": null, "message": null }
   }
 ]

--- a/test/fixtures/testBulkStatus.json
+++ b/test/fixtures/testBulkStatus.json
@@ -57,6 +57,7 @@
     "totalResourceCount": 500,
     "exportedResourceCount": 200,
     "succesCount":200,
-    "error": { "code": null, "message": null }
+    "error": { "code": null, "message": null },
+    "failedOutcomes": []
   }
 ]

--- a/test/fixtures/testBulkStatus.json
+++ b/test/fixtures/testBulkStatus.json
@@ -33,5 +33,14 @@
     "status": "Error",
     "error": { "code": "ErrorCode", "message": "Known Error Occurred!" }
   },
-  { "id": "UNKNOWN_ERROR_REQUEST", "status": "Error", "error": { "code": null, "message": null } }
+  { "id": "UNKNOWN_ERROR_REQUEST", "status": "Error", "error": { "code": null, "message": null } },
+  {
+    "id": "COMPLETED_REQUEST_WITH_RESOURCE_COUNT",
+    "status": "Completed",
+    "totalFileCount": 100,
+    "exportedFileCount": 10,
+    "totalResourceCount": 500,
+    "exportedResourceCount": 200,
+    "error": { "code": null, "message": null }
+  }
 ]

--- a/test/services/bulkstatus.service.test.js
+++ b/test/services/bulkstatus.service.test.js
@@ -69,6 +69,19 @@ describe('checkBulkStatus logic', () => {
         expect(response.body.issue[0].details.text).toEqual('Could not find bulk import request with id: INVALID_ID');
       });
   });
+  test('check operationOutcome includes the number of resources when available', async () => {
+    await supertest(server.app).get('/4_0_1/bulkstatus/COMPLETED_REQUEST_WITH_RESOURCE_COUNT').expect(200);
+    const response = await supertest(server.app).get(
+      '/4_0_1/file/COMPLETED_REQUEST_WITH_RESOURCE_COUNT/OperationOutcome.ndjson'
+    );
+    response.text
+      .trim()
+      .split(/\n/)
+      .map(async resourceStr => {
+        //  TODO: improve this assertion when the duplicate OperationOutcome bug is resolved
+        expect(resourceStr.includes('successfully imported 200'));
+      });
+  });
   afterAll(cleanUpTest);
 });
 
@@ -91,19 +104,6 @@ describe('Dynamic X-Progress logic', () => {
       .then(response => {
         // request contains total resource count: 500 and exported resource count: 200
         expect(response.headers['x-progress']).toEqual('60.00% Done');
-      });
-  });
-  test('check operationOutcome includes the number of resources when available', async () => {
-    await supertest(server.app).get('/4_0_1/bulkstatus/COMPLETED_REQUEST_WITH_RESOURCE_COUNT').expect(200);
-    const response = await supertest(server.app).get(
-      '/4_0_1/file/COMPLETED_REQUEST_WITH_RESOURCE_COUNT/OperationOutcome.ndjson'
-    );
-    response.text
-      .trim()
-      .split(/\n/)
-      .map(async resourceStr => {
-        //  TODO: improve this assertion when the duplicate OperationOutcome bug is resolved
-        expect(resourceStr.includes('successfully imported 200'));
       });
   });
 

--- a/test/services/bulkstatus.service.test.js
+++ b/test/services/bulkstatus.service.test.js
@@ -89,6 +89,7 @@ describe('Dynamic X-Progress logic', () => {
       .trim()
       .split(/\n/)
       .map(async resourceStr => {
+        //  TODO: improve this assertion when the duplicate OperationOutcome bug is resolved
         expect(resourceStr.includes('successfully imported 200'));
       });
   });

--- a/test/services/bulkstatus.service.test.js
+++ b/test/services/bulkstatus.service.test.js
@@ -2,7 +2,8 @@ const supertest = require('supertest');
 const { bulkStatusSetup, cleanUpTest } = require('../populateTestData');
 const { buildConfig } = require('../../src/config/profileConfig');
 const { initialize } = require('../../src/server/server');
-
+const { SINGLE_AGENT_PROVENANCE } = require('../fixtures/provenanceFixtures');
+const validParam = require('../fixtures/fhir-resources/parameters/paramWithExport.json');
 const config = buildConfig();
 const server = initialize(config);
 
@@ -82,12 +83,32 @@ describe('Dynamic X-Progress logic', () => {
       });
   });
   test('check operationOutcome includes the number of resources when available', async () => {
-    await supertest(server.app)
-      .get('/4_0_1/bulkstatus/COMPLETED_REQUEST_WITH_RESOURCE_COUNT')
-      .expect(200)
-      .then(response => {
-        expect(response.body.outcome[0].type).toEqual('OperationOutcome');
+    const response = await supertest(server.app)
+      .post('/4_0_1/$import')
+      .send(validParam)
+      .set('Accept', 'application/json+fhir')
+      .set('content-type', 'application/json+fhir')
+      .set('x-provenance', JSON.stringify(SINGLE_AGENT_PROVENANCE))
+      .expect(202);
+
+    expect(response.headers['content-location']).toBeDefined();
+
+    const id = response.headers['content-location'].split('/');
+    console.log(id[5]);
+    const newResponse = await supertest(server.app)
+      .get('/4_0_1/file/' + id[5] + '/OperationOutcome.ndjson')
+      .expect(200);
+
+    newResponse.text
+      .trim()
+      .split(/\n/)
+      .map(async resourceStr => {
+        console.log(resourceStr + '\n');
+        const data = JSON.parse(resourceStr);
+        expect(data.contains('successfully imported  '));
       });
+    console.log(newResponse.text.length);
   });
+
   afterAll(cleanUpTest);
 });

--- a/test/services/bulkstatus.service.test.js
+++ b/test/services/bulkstatus.service.test.js
@@ -81,6 +81,13 @@ describe('Dynamic X-Progress logic', () => {
         expect(response.headers['x-progress']).toEqual('60.00% Done');
       });
   });
-
+  test('check operationOutcome includes the number of resources when available', async () => {
+    await supertest(server.app)
+      .get('/4_0_1/bulkstatus/COMPLETED_REQUEST_WITH_RESOURCE_COUNT')
+      .expect(200)
+      .then(response => {
+        expect(response.body.outcome[0].type).toEqual('OperationOutcome');
+      });
+  });
   afterAll(cleanUpTest);
 });


### PR DESCRIPTION
Summary
Added a counter of the number of imports completed and added storing the counter as part of the bulk status object

New behavior
The behavior should be unchanged to the user however there is a now a counter that can be added to the operation outcomes/queries about bulk status to inform a user how many of the imports have successfully completed.

Code changes
src/database/dbOperations.js - added getCurrentSuccessfulImportCount, and updateSuccessfulImportCount to now store and update a counter of bulk imports done as a property of bulk status

src/server/importWorker.js - modified executePingAndPull to add a counter and increment it when it uploads the transaction bundles. Also added the passing of this counter to back to `index.js` so that the value can be written to the database without running into any race conditions

src/services/bulkstatus.service.js - updated the text of the operation outcome to now echo out the counter of successful imports that occurred

Testing guidance
Ran unit tests, assured they passed.
Using the bulk export server, I populated the database with the connectathon data script.
I send a bulk export request modelled after the example in the wiki and ensured I got the 202. Using the location header value I sent a bulk status request. (mostly to ensure no errors, I know you can skip this step and go straight to the 3rd request.) 
Once the $bulkstatus request returned 200 I sent a get to the  url in the body of the operation outcome and confirmed that the server responded that it completed my bulk import and the message contained the number of items imported (386 in this case)