### PR TITLE
Check for OperationOutcome file before writing and add unit test to c…

### DIFF
--- a/src/services/bulkstatus.service.js
+++ b/src/services/bulkstatus.service.js
@@ -163,6 +163,9 @@ async function checkBulkStatus(req, res) {
 }
 
 const writeToFile = function (doc, type, clientId) {
+  // Do not write if file already has contents
+  if (checkForFile(type, clientId)) return;
+
   const dirpath = './tmp/' + clientId;
   fs.mkdirSync(dirpath, { recursive: true });
   const filename = path.join(dirpath, `${type}.ndjson`);
@@ -174,6 +177,23 @@ const writeToFile = function (doc, type, clientId) {
     stream.write((++lineCount === 1 ? '' : '\r\n') + JSON.stringify(doc));
     stream.end();
   } else return;
+};
+
+// true if file for type and client id exists with content
+const checkForFile = function (type, clientId) {
+  const dirpath = './tmp/' + clientId;
+  const filename = path.join(dirpath, `${type}.ndjson`);
+  // check file exists and has contents
+  try {
+    if (fs.existsSync(filename)) {
+      //file exists
+      const data = fs.readFileSync(filename);
+      return (data.length !== 0);
+    }
+  } catch(err) {
+    return false;
+  }
+  return false;
 };
 
 module.exports = { checkBulkStatus };

--- a/src/services/bulkstatus.service.js
+++ b/src/services/bulkstatus.service.js
@@ -188,9 +188,9 @@ const checkForFile = function (type, clientId) {
     if (fs.existsSync(filename)) {
       //file exists
       const data = fs.readFileSync(filename);
-      return (data.length !== 0);
+      return data.length !== 0;
     }
-  } catch(err) {
+  } catch (err) {
     return false;
   }
   return false;

--- a/test/services/bulkstatus.service.test.js
+++ b/test/services/bulkstatus.service.test.js
@@ -25,6 +25,16 @@ describe('checkBulkStatus logic', () => {
       .get(response.body.outcome[0].url.replace(`http://${process.env.SERVER_HOST}:${process.env.SERVER_PORT}`, '')) //TODO: may need to break apart base_url to get slug
       .expect(200);
   });
+  test('check single OperationOutcome response for completed request', async () => {
+    // call for status twice
+    await supertest(server.app).get('/4_0_1/bulkstatus/COMPLETED_REQUEST').expect(200);
+    const response = await supertest(server.app).get('/4_0_1/bulkstatus/COMPLETED_REQUEST').expect(200);
+    const operationResponse = await supertest(server.app)
+      .get(response.body.outcome[0].url.replace(`http://${process.env.SERVER_HOST}:${process.env.SERVER_PORT}`, ''))
+      .expect(200);
+    const count = (operationResponse.text.match(/OperationOutcome/g) || []).length;
+    expect(count).toEqual(1);
+  });
   test('check 200 returned with error OperationOutcome ndjson file when it exists', async () => {
     const response = await supertest(server.app)
       .get('/4_0_1/bulkstatus/COMPLETED_REQUEST_WITH_RESOURCE_ERRORS')


### PR DESCRIPTION
…heck for issue

# Summary
Updates to bulk status service to fix a duplicate OperationOutcome issue.

## New behavior
When a user requests a successful bulk status twice and then views the resultant OperationOutcome, there should only be a single OperationOutcome resource.

## Code changes
Updates to bulkstatus service check for an existing OperationOutcome file before writing the OperationOutcome so that it does not get written every time there's a status call.

# Testing guidance
Full steps to replicate issue:
- Send a standard bulk $import request
- Send the status poll request
- (wait to get a 200)
- Send OperationOutcome get request (should be only one OperationOutcome)
- send the status poll request again (should still get 200)
- Send OperationOutcome get request again
- OperationOutcome ndjson contains a duplicate of the previous entry

Updates to bulk status service should fix issue of duplicate OperationOutcome. Run `npm run test` and all tests should pass. New test should fail with previous code, but should pass with the updates to bulkstatus service.

Question...
Would we have a situation where we'd want to add more than one OperationOutcome to the file? We currently only write to file when the status is completed or if the status fails. If we'd want to write multiple to a file, we might need to reorganize this.
