### PR TITLE
ResourceType/ResourceId reference support in $care-gaps and $evaluate-measure subject

### DIFF
--- a/src/util/patientUtils.js
+++ b/src/util/patientUtils.js
@@ -9,11 +9,14 @@ const { mapResourcesToCollectionBundle, mapArrayToSearchSetBundle } = require('.
 /**
  * Wrapper function to get patient data and data
  * requirements for given patient id and map the resources to a collection bundle.
- * @param {string} patientId patient ID of interest
+ * @param {string} patientReference reference to patient of interest (either of the form {PatientId} or Patient/{PatientId})
  * @param {Array} dataRequirements data requirements array obtained from fqm execution
  * @returns {Object} patient bundle as a collection bundle
  */
-async function getPatientDataCollectionBundle(patientId, dataRequirements) {
+async function getPatientDataCollectionBundle(patientReference, dataRequirements) {
+  // PatientReference can be of the form {PatientId} or Patient/{PatientId} this extracts just the PatientId in both cases
+  const splitRef = patientReference.split('/');
+  const patientId = splitRef[splitRef.length - 1];
   const data = await getPatientData(patientId, dataRequirements);
   return mapResourcesToCollectionBundle(_.flattenDeep(data));
 }

--- a/test/util/patientUtils.test.js
+++ b/test/util/patientUtils.test.js
@@ -32,7 +32,35 @@ describe('Testing dynamic querying for patient references using compartment defi
     expect(reference).toEqual({ reference: 'Patient/test-patient' });
   });
 
+  test('Check that patient reference can be found at one level with Patient/{PatientId} style reference', async () => {
+    await supertest(server.app)
+      .post('/4_0_1/')
+      .send(testBundle)
+      .set('Accept', 'application/json+fhir')
+      .set('content-type', 'application/json+fhir')
+      .set('x-provenance', JSON.stringify(SINGLE_AGENT_PROVENANCE))
+      .expect(200);
+    const patientBundle = await getPatientDataCollectionBundle('Patient/test-patient', DATA_REQ);
+    const procedure = patientBundle.entry.filter(e => e.resource.resourceType === 'Procedure')[0];
+    const reference = procedure.resource.subject;
+    expect(reference).toEqual({ reference: 'Patient/test-patient' });
+  });
+
   test('Check that patient reference can be found when nested', async () => {
+    await supertest(server.app)
+      .post('/4_0_1/')
+      .send(testNestedBundle)
+      .set('Accept', 'application/json+fhir')
+      .set('content-type', 'application/json+fhir')
+      .set('x-provenance', JSON.stringify(SINGLE_AGENT_PROVENANCE))
+      .expect(200);
+    const patientBundle = await getPatientDataCollectionBundle('test-patient', DATA_REQ);
+    const procedure = patientBundle.entry.filter(e => e.resource.resourceType === 'Procedure')[0];
+    const reference = procedure.resource.performer.actor;
+    expect(reference).toEqual({ reference: 'Patient/test-patient' });
+  });
+
+  test('Check that patient reference can be found when nested with Patient/{PatientId} style reference ', async () => {
     await supertest(server.app)
       .post('/4_0_1/')
       .send(testNestedBundle)


### PR DESCRIPTION
# Summary
Added support to parse ResourceType/ResourceId -style subject references for $care-gaps and $evaluate-measure operations

## New behavior
Users can now reference subjects using ResourceType/ResourceId -style references for $care-gaps and $evaluate-measure operations, in addition to the previously supported resourceId references


## Code changes
Added to getPatientDataCollectionBundle function in src/util/patientUtils.js to parse both ResourceType/ResourceId -style and resourceId-style references

# Testing guidance
- Try sending $evaluate-measure and $care-gaps requests using both ResourceType/ResourceId -style and resourceId-style references. For more info on that see below
- Make sure to test operations using both `GET` (requests params in query) and `POST` (request params in body) requests
- [$care-gaps PR](https://github.com/projecttacoma/deqm-test-server/pull/80)
- [$evaluate-measure PR](https://github.com/projecttacoma/deqm-test-server/pull/22)
