### PR TITLE
Change open status to open-gap

### DIFF
--- a/src/util/validationUtils.js
+++ b/src/util/validationUtils.js
@@ -90,7 +90,7 @@ const validateCareGapsParams = query => {
     });
   }
 
-  if (query.status !== 'open') {
+  if (query.status !== 'open-gap') {
     throw new ServerError(null, {
       statusCode: 501,
       issue: [
@@ -98,7 +98,7 @@ const validateCareGapsParams = query => {
           severity: 'error',
           code: 'NotImplemented',
           details: {
-            text: `Currently only supporting $care-gaps requests with status='open'`
+            text: `Currently only supporting $care-gaps requests with status='open-gap'`
           }
         }
       ]

--- a/test/services/measure.service.test.js
+++ b/test/services/measure.service.test.js
@@ -331,7 +331,7 @@ describe('testing custom measure operation', () => {
         subject: 'testPatient',
         periodStart: '01-01-2020',
         periodEnd: '01-01-2021',
-        status: 'open'
+        status: 'open-gap'
       })
       .expect(200);
 

--- a/test/util/validationUtils.test.js
+++ b/test/util/validationUtils.test.js
@@ -10,7 +10,7 @@ const queue = require('../../src/queue/importQueue');
 const VALID_QUERY = {
   periodStart: '2019-01-01',
   periodEnd: '2019-12-31',
-  status: 'open',
+  status: 'open-gap',
   subject: 'testPatient',
   measureId: 'testID'
 };
@@ -100,7 +100,7 @@ describe('validateCareGapsParams', () => {
       query: {
         periodStart: '2019-01-01',
         periodEnd: '2019-12-31',
-        status: 'open',
+        status: 'open-gap',
         subject: 'testPatient',
         practitioner: 'testPractitioner'
       }
@@ -120,7 +120,7 @@ describe('validateCareGapsParams', () => {
       query: {
         periodStart: '2019-01-01',
         periodEnd: '2019-12-31',
-        status: 'open',
+        status: 'open-gap',
         subject: 'testPatient'
       }
     };
@@ -134,7 +134,7 @@ describe('validateCareGapsParams', () => {
     }
   });
 
-  test('error thrown for missing open status for $care-gaps', async () => {
+  test('error thrown for missing open-gap status for $care-gaps', async () => {
     const UNSUPPORTED_STATUS_REQ = {
       query: {
         periodStart: '2019-01-01',
@@ -148,7 +148,7 @@ describe('validateCareGapsParams', () => {
       validateCareGapsParams(UNSUPPORTED_STATUS_REQ.query);
     } catch (e) {
       expect(e.statusCode).toEqual(501);
-      expect(e.issue[0].details.text).toEqual(`Currently only supporting $care-gaps requests with status='open'`);
+      expect(e.issue[0].details.text).toEqual(`Currently only supporting $care-gaps requests with status='open-gap'`);
     }
   });
 
@@ -164,7 +164,7 @@ describe('validateCareGapsParams', () => {
       query: {
         periodStart: '2019-01-01',
         periodEnd: '2019-12-31',
-        status: 'open'
+        status: 'open-gap'
       },
       body: {
         resourceType: 'Parameters',


### PR DESCRIPTION
# Summary
Updates were made to the care-gaps operation to support `open-gap` status instead of `open` so that our implementation aligns with the spec.

## New behavior
After observing the [care-gaps TestScripts in Touchstone](https://touchstone.aegis.net/touchstone/testdefinitions?selectedTestGrp=/FHIRSandbox/DaVinci/FHIR4-0-1-DEQM-GIC&activeOnly=false&contentEntry=TEST_SCRIPTS ) and some of the examples in the [care-gaps spec](https://build.fhir.org/ig/HL7/davinci-deqm/OperationDefinition-care-gaps.html), I noticed that we are using `open` for status instead of `open-gap`. The test server now supports `open-gap` for the `status` parameter.

## Code changes
Changes were made to the status validation code and the unit tests that use the status parameter.

# Testing guidance
Check that all instances of `open` have been changed to `open-gap`. Run the unit tests and make sure they pass. Try sending a care-gaps request in Insomnia with `status=open`. You should receive a ServerError explaining that we only support `status='open-gap'`. Then, send a care-gaps request with `status=open-gap`. You should receive 200 OK.
