### PR TITLE
updated docker autobuild org

### DIFF
--- a/.github/workflows/docker_hub_build.yml
+++ b/.github/workflows/docker_hub_build.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           # list of Docker images to use as base name for tags
           images: |
-            tacoma/deqm-test-server
+            mitrehealthdocker/deqm-test-server
           flavor: |
             latest=${{ github.ref == 'refs/heads/main' }}
           # generate Docker tags based on the following events/attributes


### PR DESCRIPTION
# Summary
Updated the docker autobuild organization to mitrehealthdocker. To be reviewed with [deqm-test-kit #24](https://github.com/projecttacoma/deqm-test-kit/pull/24) and [fqm-execution-service #25](https://github.com/projecttacoma/fqm-execution-service/pull/25)

## New behavior
Future pushes to main will update deqm-test-server:latest tag in mitrehealthdocker instead of tacoma

## Code changes

# Testing guidance
Try pulling the new docker image from mitrehealthdocker for deqm-test-server and ensure that it has all the functionality of deqm-test-server main

**NOTE** this code may not work at all. Contingent on whether we need a group key for the organization
