### PR TITLE
No id gaps

### DIFF
--- a/src/scripts/getConnectathonBundles.js
+++ b/src/scripts/getConnectathonBundles.js
@@ -4,14 +4,15 @@ const mongoUtil = require('../database/connection');
 const { createResource } = require('../database/dbOperations');
 
 const connectathonPath = path.resolve(path.join(__dirname, '../../connectathon/fhir401/bundles/measure/'));
-// bundles that are not the latest available version
+// bundles that are not the latest available version or contain errors that prevent valid gaps calculation
 const IGNORED_BUNDLES = [
   'EXM347-3.2.000-bundle.json',
   'EXM347-4.3.000-bundle.json',
   'EXM529-1.0.000-bundle.json',
   'EXM349-2.10.000-bundle.json',
   'EXM111-9.1.000-bundle.json',
-  'EXM149-9.2.000-bundle.json'
+  'EXM149-9.2.000-bundle.json',
+  'EXM124-8.2.000-bundle.json'
 ];
 
 // files containing EXM bundles of interest from connectathon repo

--- a/src/scripts/getConnectathonBundles.js
+++ b/src/scripts/getConnectathonBundles.js
@@ -6,6 +6,12 @@ const { createResource } = require('../database/dbOperations');
 const connectathonPath = path.resolve(path.join(__dirname, '../../connectathon/fhir401/bundles/measure/'));
 // bundles that are not the latest available version
 const IGNORED_BUNDLES = ['EXM347-3.2.000-bundle.json'];
+//   'EXM347-4.3.000-bundle.json',
+//   'EXM529-1.0.000-bundle.json',
+//   'EXM104-8.2.000-bundle.json',
+//   'EXM108-8.3.000-bundle.json',
+//   'EXM124-8.2.000-bundle.json'
+// ];
 // files containing EXM bundles of interest from connectathon repo
 const bundleFiles = [];
 

--- a/src/scripts/getConnectathonBundles.js
+++ b/src/scripts/getConnectathonBundles.js
@@ -5,13 +5,15 @@ const { createResource } = require('../database/dbOperations');
 
 const connectathonPath = path.resolve(path.join(__dirname, '../../connectathon/fhir401/bundles/measure/'));
 // bundles that are not the latest available version
-const IGNORED_BUNDLES = ['EXM347-3.2.000-bundle.json'];
-//   'EXM347-4.3.000-bundle.json',
-//   'EXM529-1.0.000-bundle.json',
-//   'EXM104-8.2.000-bundle.json',
-//   'EXM108-8.3.000-bundle.json',
-//   'EXM124-8.2.000-bundle.json'
-// ];
+const IGNORED_BUNDLES = [
+  'EXM347-3.2.000-bundle.json',
+  'EXM347-4.3.000-bundle.json',
+  'EXM529-1.0.000-bundle.json',
+  'EXM349-2.10.000-bundle.json',
+  'EXM111-9.1.000-bundle.json',
+  'EXM149-9.2.000-bundle.json'
+];
+
 // files containing EXM bundles of interest from connectathon repo
 const bundleFiles = [];
 

--- a/src/services/base.service.js
+++ b/src/services/base.service.js
@@ -179,6 +179,7 @@ const baseSearch = async (args, { req }, resourceType, paramDefs) => {
     logger.debug(`Executing aggregation search over ${resourceType}s using query: ${JSON.stringify(filter.query)}`);
     // grab the results from aggregation. has metadata about counts and data with resources in the first array position
     const results = (await findResourcesWithAggregation(filter.query, resourceType))[0];
+
     // If this is undefined, there are no results.
     if (results && results.metadata[0]) {
       // create instances of each of the resulting resources

--- a/src/services/base.service.js
+++ b/src/services/base.service.js
@@ -179,7 +179,6 @@ const baseSearch = async (args, { req }, resourceType, paramDefs) => {
     logger.debug(`Executing aggregation search over ${resourceType}s using query: ${JSON.stringify(filter.query)}`);
     // grab the results from aggregation. has metadata about counts and data with resources in the first array position
     const results = (await findResourcesWithAggregation(filter.query, resourceType))[0];
-
     // If this is undefined, there are no results.
     if (results && results.metadata[0]) {
       // create instances of each of the resulting resources

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -335,7 +335,6 @@ const careGaps = async (args, { req }) => {
   } else {
     query = req.query;
   }
-
   validateCareGapsParams(query);
 
   const { periodStart, periodEnd, subject } = query;

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -435,8 +435,8 @@ const careGaps = async (args, { req }) => {
     }
     return responseParametersArray;
   });
-  gapsResults = await Promise.all(gapsResults).catch(e => console.log(e));
-  console.log(gapsResults);
+
+  gapsResults = await Promise.all(gapsResults);
   const responseParameters = {
     resourceType: 'Parameters',
     parameter: [...gapsResults]
@@ -452,7 +452,6 @@ const careGaps = async (args, { req }) => {
  */
 const retrieveSearchTerm = query => {
   const { measureId, measureIdentifier, measureUrl } = query;
-  console.log(query);
   if (measureId) {
     return { _id: measureId };
   } else if (measureIdentifier) {

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -335,6 +335,7 @@ const careGaps = async (args, { req }) => {
   } else {
     query = req.query;
   }
+
   validateCareGapsParams(query);
 
   const { periodStart, periodEnd, subject } = query;
@@ -344,36 +345,20 @@ const careGaps = async (args, { req }) => {
   } else {
     req.query = searchTerm;
   }
-  //Use the base search function here to allow search by measureId, measureUrl, and measureIdentifier
-  const measure = await search(args, { req });
-  if (measure.total === 0) {
-    //We know the search term will have exactly one key and value, so just fill them in in the error message
-    throw new ServerError(null, {
-      statusCode: 404,
-      issue: [
-        {
-          severity: 'error',
-          code: 'ResourceNotFound',
-          details: {
-            text: `no measure found with ${Object.keys(searchTerm)[0]}: ${searchTerm[Object.keys(searchTerm)[0]]}.`
-          }
-        }
-      ]
-    });
-  }
-  const measureBundle = await assembleCollectionBundleFromMeasure(measure.entry[0].resource);
-
-  logger.info('Calculating data requirements');
-  const dataReq = Calculator.calculateDataRequirements(measureBundle, {
-    measurementPeriodStart: periodStart,
-    measurementPeriodEnd: periodEnd
-  });
-
-  const subjectReference = subject.split('/');
-  let patientBundles;
-  if (subjectReference[0] === 'Group') {
-    const group = await findResourceById(subjectReference[1], subjectReference[0]);
-    if (!group) {
+  const measures = [];
+  if (!searchTerm) {
+    /*
+      If no search term, circumvent asymmetrik query builder and use mongo search directly to avoid
+      pagination bug
+      
+      TODO: Remove this code once pagination bug is fixed
+    */
+    measures.push(...(await findResourcesWithQuery({}, 'Measure')));
+  } else {
+    //Use the base search function here to allow search by measureId, measureUrl, and measureIdentifier
+    const searchResults = await search(args, { req });
+    if (searchResults.total === 0) {
+      //We know the search term will have exactly one key and value, so just fill them in in the error message
       throw new ServerError(null, {
         statusCode: 404,
         issue: [
@@ -381,45 +366,80 @@ const careGaps = async (args, { req }) => {
             severity: 'error',
             code: 'ResourceNotFound',
             details: {
-              text: `No resource found in collection: ${subjectReference[0]}, with: id ${subjectReference[1]}.`
+              text: `no measure found with ${Object.keys(searchTerm)[0]}: ${searchTerm[Object.keys(searchTerm)[0]]}.`
             }
           }
         ]
       });
     }
-    patientBundles = group.member.map(async m => {
-      return getPatientDataCollectionBundle(m.entity.reference, dataReq.results.dataRequirement);
-    });
-    patientBundles = await Promise.all(patientBundles);
-  } else {
-    // single patient
-    patientBundles = [await getPatientDataCollectionBundle(subject, dataReq.results.dataRequirement)];
+
+    const measureResources = searchResults.entry.map(e => e.resource);
+    measures.push(...measureResources);
   }
 
-  logger.info('Calculating gaps in care');
-  const { results } = await Calculator.calculateGapsInCare(measureBundle, patientBundles, {
-    measurementPeriodStart: periodStart,
-    measurementPeriodEnd: periodEnd
-  });
+  let gapsResults = measures.map(async measure => {
+    const measureBundle = await assembleCollectionBundleFromMeasure(measure);
 
-  const responseParametersArray = [];
-  if (results.length > 1) {
-    results.forEach(result => {
+    logger.info(`Calculating data requirements for measure ${measure.id}`);
+    const dataReq = Calculator.calculateDataRequirements(measureBundle, {
+      measurementPeriodStart: periodStart,
+      measurementPeriodEnd: periodEnd
+    });
+
+    const subjectReference = subject.split('/');
+    let patientBundles;
+    if (subjectReference[0] === 'Group') {
+      const group = await findResourceById(subjectReference[1], subjectReference[0]);
+      if (!group) {
+        throw new ServerError(null, {
+          statusCode: 404,
+          issue: [
+            {
+              severity: 'error',
+              code: 'ResourceNotFound',
+              details: {
+                text: `No resource found in collection: ${subjectReference[0]}, with: id ${subjectReference[1]}.`
+              }
+            }
+          ]
+        });
+      }
+      patientBundles = group.member.map(async m => {
+        return getPatientDataCollectionBundle(m.entity.reference, dataReq.results.dataRequirement);
+      });
+      patientBundles = await Promise.all(patientBundles);
+    } else {
+      // single patient
+      patientBundles = [await getPatientDataCollectionBundle(subject, dataReq.results.dataRequirement)];
+    }
+
+    logger.info('Calculating gaps in care');
+    const { results } = await Calculator.calculateGapsInCare(measureBundle, patientBundles, {
+      measurementPeriodStart: periodStart,
+      measurementPeriodEnd: periodEnd
+    });
+
+    const responseParametersArray = [];
+    if (results.length > 1) {
+      results.forEach(result => {
+        responseParametersArray.push({
+          name: 'return',
+          resource: result
+        });
+      });
+    } else {
       responseParametersArray.push({
         name: 'return',
-        resource: result
+        resource: results
       });
-    });
-  } else {
-    responseParametersArray.push({
-      name: 'return',
-      resource: results
-    });
-  }
-
+    }
+    return responseParametersArray;
+  });
+  gapsResults = await Promise.all(gapsResults).catch(e => console.log(e));
+  console.log(gapsResults);
   const responseParameters = {
     resourceType: 'Parameters',
-    parameter: responseParametersArray
+    parameter: [...gapsResults]
   };
   logger.info('Successfully generated $care-gaps report');
   return responseParameters;
@@ -432,7 +452,7 @@ const careGaps = async (args, { req }) => {
  */
 const retrieveSearchTerm = query => {
   const { measureId, measureIdentifier, measureUrl } = query;
-
+  console.log(query);
   if (measureId) {
     return { _id: measureId };
   } else if (measureIdentifier) {

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -397,7 +397,7 @@ const careGaps = async (args, { req }) => {
               severity: 'error',
               code: 'ResourceNotFound',
               details: {
-                text: `No resource found in collection: ${subjectReference[0]}, with: id ${subjectReference[1]}.`
+                text: `No resource found in collection: ${subjectReference[0]}, with id: ${subjectReference[1]}.`
               }
             }
           ]
@@ -436,7 +436,9 @@ const careGaps = async (args, { req }) => {
   });
 
   gapsResults = await Promise.all(gapsResults);
-  gapsResults = gapsResults.flat();
+  // Flatten nested gaps reports and only add the gaps reports that are non-empty
+  gapsResults = gapsResults.flat().filter(gapReport => gapReport.resource.resourceType);
+
   const responseParameters = {
     resourceType: 'Parameters',
     parameter: [...gapsResults]

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -412,7 +412,7 @@ const careGaps = async (args, { req }) => {
       patientBundles = [await getPatientDataCollectionBundle(subject, dataReq.results.dataRequirement)];
     }
 
-    logger.info('Calculating gaps in care');
+    logger.info(`Calculating gaps in care for measure ${measure.id}`);
     const { results } = await Calculator.calculateGapsInCare(measureBundle, patientBundles, {
       measurementPeriodStart: periodStart,
       measurementPeriodEnd: periodEnd
@@ -436,6 +436,7 @@ const careGaps = async (args, { req }) => {
   });
 
   gapsResults = await Promise.all(gapsResults);
+  gapsResults = gapsResults.flat();
   const responseParameters = {
     resourceType: 'Parameters',
     parameter: [...gapsResults]

--- a/src/util/bundleUtils.js
+++ b/src/util/bundleUtils.js
@@ -5,7 +5,11 @@ const { v4: uuidv4 } = require('uuid');
 const { findResourceById, findOneResourceWithQuery } = require('../database/dbOperations');
 const logger = require('../server/logger');
 
-const OUTDATED_CONNECTATHON_URLS = {
+/*
+ Some connectathon bundles currently contain incorrect url references from the main library
+ to its dependent libraries. This map identifies those issues and provides the correct url reference
+*/
+const INCORRECT_CONNECTATHON_URLS_MAP = {
   'http://hl7.org/fhir/Library/SupplementalDataElements|2.0.0':
     'http://fhir.org/guides/dbcg/connectathon/Library/SupplementalDataElements|2.0.0',
   'http://hl7.org/fhir/Library/TJCOverall|5.0.000':
@@ -199,11 +203,11 @@ async function getAllDependentLibraries(lib) {
   // Obtain all libraries referenced in the related artifact, and recurse on their dependencies
   const libraryGets = depLibUrls.map(async url => {
     // Quick fix for invalid connectathon url references
-    if (url in OUTDATED_CONNECTATHON_URLS) {
+    if (url in INCORRECT_CONNECTATHON_URLS_MAP) {
       logger.warn(
-        `Using potentially outdated reference url: ${url}. Replacing with ${OUTDATED_CONNECTATHON_URLS[url]}`
+        `Using potentially outdated reference url: ${url}. Replacing with ${INCORRECT_CONNECTATHON_URLS_MAP[url]}`
       );
-      url = OUTDATED_CONNECTATHON_URLS[url];
+      url = INCORRECT_CONNECTATHON_URLS_MAP[url];
     }
     const libQuery = getQueryFromReference(url);
     const lib = await findOneResourceWithQuery(libQuery, 'Library');

--- a/src/util/bundleUtils.js
+++ b/src/util/bundleUtils.js
@@ -114,7 +114,7 @@ async function getMeasureBundleFromId(measureId) {
  * @returns {Object} FHIR Bundle of Measure resource and all dependent FHIR Library resources
  */
 async function assembleCollectionBundleFromMeasure(measure) {
-  logger.info('Assembling collection bundle from Measure');
+  logger.info(`Assembling collection bundle from Measure ${measure.id}`);
   const [mainLibraryRef] = measure.library;
   const mainLibQuery = getQueryFromReference(mainLibraryRef);
   const mainLib = await findOneResourceWithQuery(mainLibQuery, 'Library');

--- a/src/util/validationUtils.js
+++ b/src/util/validationUtils.js
@@ -109,23 +109,6 @@ const validateCareGapsParams = query => {
   checkRequiredParams(query, REQUIRED_PARAMS, '$care-gaps');
   checkNoUnsupportedParams(query, UNSUPPORTED_PARAMS, '$care-gaps');
 
-  const measureIdentification = query.measureId || query.measureIdentifier || query.measureUrl;
-
-  if (!measureIdentification) {
-    throw new ServerError(null, {
-      statusCode: 400,
-      issue: [
-        {
-          severity: 'error',
-          code: 'BadRequest',
-          details: {
-            text: `No measure identification parameter supplied. Must provide either 'measureId', 'measureUrl', or 'measureIdentifier' parameter for $care-gaps requests`
-          }
-        }
-      ]
-    });
-  }
-
   if (query.status !== 'open-gap') {
     throw new ServerError(null, {
       statusCode: 501,

--- a/test/fixtures/fhir-resources/testMeasure2.json
+++ b/test/fixtures/fhir-resources/testMeasure2.json
@@ -1,0 +1,5 @@
+{
+  "resourceType": "Measure",
+  "id": "testMeasure2",
+  "library": ["Library/testLibrary"]
+}

--- a/test/services/measure.service.test.js
+++ b/test/services/measure.service.test.js
@@ -1,6 +1,7 @@
 require('../../src/config/envConfig');
 const supertest = require('supertest');
 const testMeasure = require('../fixtures/fhir-resources/testMeasure.json');
+const testMeasure2 = require('../fixtures/fhir-resources/testMeasure2.json');
 const testLibrary = require('../fixtures/fhir-resources/testLibrary.json');
 const testPatient = require('../fixtures/fhir-resources/testPatient.json');
 const testPatient2 = require('../fixtures/fhir-resources/testPatient2.json');
@@ -114,6 +115,7 @@ describe('testing custom measure operation', () => {
     await testSetup(testMeasure, testPatient, testLibrary);
     await createTestResource(testPatient2, 'Patient');
     await createTestResource(testGroup, 'Group');
+    await createTestResource(testMeasure2, 'Measure');
   });
 
   test('$submit-data returns 400 for incorrect resourceType', async () => {
@@ -343,7 +345,7 @@ describe('testing custom measure operation', () => {
       .expect(200);
   });
 
-  test('$care-gaps returns 200 with valid params', async () => {
+  test('$care-gaps returns 200 with valid params and specified measureId', async () => {
     const { Calculator } = require('fqm-execution');
     const gapsSpy = jest.spyOn(Calculator, 'calculateGapsInCare').mockImplementation(() => {
       return {
@@ -474,6 +476,8 @@ describe('testing custom measure operation', () => {
         expect(response.body.issue[0].details.text).toEqual('Measure with id invalid-id does not exist in the server');
       });
   });
-
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
   afterAll(cleanUpTest);
 });

--- a/test/util/validationUtils.test.js
+++ b/test/util/validationUtils.test.js
@@ -153,25 +153,6 @@ describe('validateCareGapsParams', () => {
     }
   });
 
-  test('error thrown for missing measure identification for $care-gaps', async () => {
-    const MISSING_MEASURE_REQ = {
-      query: {
-        periodStart: '2019-01-01',
-        periodEnd: '2019-12-31',
-        status: 'open-gap',
-        subject: 'Patient/testPatient'
-      }
-    };
-    try {
-      validateCareGapsParams(MISSING_MEASURE_REQ.query);
-    } catch (e) {
-      expect(e.statusCode).toEqual(400);
-      expect(e.issue[0].details.text).toEqual(
-        `No measure identification parameter supplied. Must provide either 'measureId', 'measureUrl', or 'measureIdentifier' parameter for $care-gaps requests`
-      );
-    }
-  });
-
   test('error thrown for missing open-gap status for $care-gaps', async () => {
     const UNSUPPORTED_STATUS_REQ = {
       query: {


### PR DESCRIPTION
# Summary
A recent investigation into the $care-gaps IG discovered that the parameters which specify the measure (measureId, measureIdentifier, measureUrl) are all 0...*. Previously, we were throwing an error if a user omitted all three of these measure identification parameters. This PR removes that error, and instead runs $care-gaps for the subject on all measures in the system in this situation.

## New behavior
- Sending a $care-gaps request with no measureId, measureUrl, or measureIdentifier will no longer throw an error, but will run $care-gaps for all measures on the system
- `npm run connectathon-upload` will now ignore `EXM347-4.3.000-bundle.json`, `EXM529-1.0.000-bundle.json`, `EXM349-2.10.000-bundle.json`, `EXM111-9.1.000-bundle.json`, `EXM149-9.2.000-bundle.json`, as they all contain errors that prevent valid gaps calculation
- Can now run $care-gaps operations on measures EXM104, EXM108, and EXM124, all of which have invalid library references, which previously tripped up the test server

## Code changes
- Updated `careGaps` function in measure.service.js to search for all measures on system and run a gaps evaluation for each patient in the subject for each measure
- Removed error throw in `validateCareGapsParams` to allow for no measure identification parameter
- Added bundles `EXM347-4.3.000-bundle.json`, `EXM529-1.0.000-bundle.json`, `EXM349-2.10.000-bundle.json`, `EXM111-9.1.000-bundle.json`, `EXM149-9.2.000-bundle.json` to the ignored list

# Testing guidance
- Run `npm install` to ensure you grab the newly updated fqm-execution dependency
- Run `npm test`
- Run `npm run db:reset`
- Run `npm run connectathon-upload` this will omit the newly ignored bundles
- Run `npm start`
- Submit a `$care-gaps` request without a `measureId`, `measureIdentifier`, or `measureUrl`. For more info on $care-gaps requests, see [here](https://github.com/projecttacoma/deqm-test-server/pull/71)
- Ensure the `parameter` attribute returned is of length 10. most/all of these entries will be empty
- Try testing this with the new [$care-gaps group support](https://github.com/projecttacoma/deqm-test-server/pull/89). You should see an entry in the response parameter array for each patient for each measure (i.e. for group size = 2, and number of measures = 10, parameter length should equal 20)
- Try testing with both `POST` and `GET` requests as well
