### PR TITLE
Add error utility that extends from ServerError

### DIFF
--- a/src/resources/transactionBundle.js
+++ b/src/resources/transactionBundle.js
@@ -3,7 +3,8 @@
  * a txn bundle in the proper format and convert the representation to JSON
  */
 
-const { ServerError, resolveSchema } = require('@projecttacoma/node-fhir-server-core');
+const { resolveSchema } = require('@projecttacoma/node-fhir-server-core');
+const { UnprocessableEntityError } = require('../util/errorUtils');
 
 const createTransactionBundleClass = baseVersion => {
   const Bundle = resolveSchema(baseVersion, 'bundle');
@@ -23,19 +24,8 @@ const createTransactionBundleClass = baseVersion => {
       } else if (requestType === 'PUT') {
         request.url = `${resource.resourceType}/${resource.id}`;
       } else {
-        throw new ServerError(null, {
-          statusCode: 422,
-          issue: [
-            {
-              severity: 'error',
-              code: 'UnprocessableEntity',
-              details: {
-                text: `Invalid request type for transaction bundle entry for resource with id: ${resource.id}. 
-              Request must be of type POST or PUT, received type: ${requestType}`
-              }
-            }
-          ]
-        });
+        throw new UnprocessableEntityError(`Invalid request type for transaction bundle entry for resource with id: ${resource.id}. 
+        Request must be of type POST or PUT, received type: ${requestType}`);
       }
       const newEntry = {
         resource,

--- a/src/services/bundle.service.js
+++ b/src/services/bundle.service.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const { v4: uuidv4 } = require('uuid');
-const { ServerError, resolveSchema } = require('@projecttacoma/node-fhir-server-core');
+const { resolveSchema } = require('@projecttacoma/node-fhir-server-core');
+const { BadRequestError } = require('../util/errorUtils');
 const { replaceReferences } = require('../util/bundleUtils');
 const { checkProvenanceHeader, populateProvenanceTarget } = require('../util/provenanceUtils');
 const { createResource, pushToResource, updateResource } = require('../database/dbOperations');
@@ -117,32 +118,10 @@ async function uploadTransactionBundle(req, res) {
   checkContentTypeHeader(headers);
   // TODO: we will need to somehow store all data that is uploaded, even if it's bad data
   if (resourceType !== 'Bundle') {
-    throw new ServerError(null, {
-      statusCode: 400,
-      issue: [
-        {
-          severity: 'error',
-          code: 'BadRequest',
-          details: {
-            text: `Expected 'resourceType: Bundle', but received 'resourceType: ${resourceType}'.`
-          }
-        }
-      ]
-    });
+    throw new BadRequestError(`Expected 'resourceType: Bundle', but received 'resourceType: ${resourceType}'.`);
   }
   if (type.toLowerCase() !== 'transaction') {
-    throw new ServerError(null, {
-      statusCode: 400,
-      issue: [
-        {
-          severity: 'error',
-          code: 'BadRequest',
-          details: {
-            text: `Expected 'type: transaction'. Received 'type: ${type}'.`
-          }
-        }
-      ]
-    });
+    throw new BadRequestError(`Expected 'type: transaction'. Received 'type: ${type}'.`);
   }
   let xprovenanceIncluded;
   if (req.headers['x-provenance']) {
@@ -223,18 +202,9 @@ async function insertBundleResources(entry, method) {
       entry.statusText = 'OK';
     }
   } else {
-    throw new ServerError(null, {
-      statusCode: 400,
-      issue: [
-        {
-          severity: 'error',
-          code: 'BadRequest',
-          details: {
-            text: `Expected requests of type PUT or POST, received ${method} for ${entry.resource.resourceType}/${entry.resource.id}`
-          }
-        }
-      ]
-    });
+    throw new BadRequestError(
+      `Expected requests of type PUT or POST, received ${method} for ${entry.resource.resourceType}/${entry.resource.id}`
+    );
   }
   return entry;
 }

--- a/src/services/clientfile.service.js
+++ b/src/services/clientfile.service.js
@@ -1,4 +1,4 @@
-const { ServerError } = require('@projecttacoma/node-fhir-server-core');
+const { NotFoundError } = require('../util/errorUtils');
 const fs = require('fs');
 const path = require('path');
 
@@ -19,18 +19,7 @@ async function getClientFile(req, res) {
     res.set('Content-Type', 'application/ndjson+fhir');
     return path.resolve(`./tmp/${clientId}/${fileName}`);
   } else {
-    throw new ServerError(null, {
-      statusCode: 404,
-      issue: [
-        {
-          severity: 'error',
-          code: 'not-found',
-          details: {
-            text: `The following file was not found: ${clientId}/${fileName}`
-          }
-        }
-      ]
-    });
+    throw new NotFoundError(`The following file was not found: ${clientId}/${fileName}`);
   }
 }
 

--- a/src/services/patient.service.js
+++ b/src/services/patient.service.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const { ServerError } = require('@projecttacoma/node-fhir-server-core');
+const { NotImplementedError } = require('../util/errorUtils');
 const { baseCreate, baseSearchById, baseRemove, baseUpdate, baseSearch } = require('./base.service');
 const { mapArrayToSearchSetBundle } = require('../util/bundleUtils');
 const { getPatientData, getPatientDataSearchSetBundle } = require('../util/patientUtils');
@@ -91,7 +91,7 @@ const patientEverything = async (args, { req }) => {
 
 /**
  * Checks if unsupported parameters are provided in the http request.
- * If any unsupported parameters are present, a ServerError is thrown.
+ * If any unsupported parameters are present, a NotImplemented error is thrown.
  * @param {Object} req http request object
  */
 const validatePatientEverythingParams = req => {
@@ -102,20 +102,11 @@ const validatePatientEverythingParams = req => {
   const presentUnsupportedParams = UNSUPPORTED_PARAMS.filter(key => req.query[key]);
 
   if (presentUnsupportedParams.length > 0) {
-    throw new ServerError(null, {
-      statusCode: 501,
-      issue: [
-        {
-          severity: 'error',
-          code: 'NotImplemented',
-          details: {
-            text: `$everything functionality has not yet been implemented for requests with parameters: ${presentUnsupportedParams.join(
-              ', '
-            )}`
-          }
-        }
-      ]
-    });
+    throw new NotImplementedError(
+      `$everything functionality has not yet been implemented for requests with parameters: ${presentUnsupportedParams.join(
+        ', '
+      )}`
+    );
   }
 };
 

--- a/src/util/baseUtils.js
+++ b/src/util/baseUtils.js
@@ -1,4 +1,4 @@
-const { ServerError } = require('@projecttacoma/node-fhir-server-core');
+const { BadRequestError } = require('./errorUtils');
 const supportedResources = require('../server/supportedResources');
 
 /**
@@ -8,18 +8,7 @@ const supportedResources = require('../server/supportedResources');
  */
 function checkSupportedResource(resourceType) {
   if (!supportedResources.includes(resourceType)) {
-    throw new ServerError(null, {
-      statusCode: 400,
-      issue: [
-        {
-          severity: 'error',
-          code: 'BadRequest',
-          details: {
-            text: `resourceType: ${resourceType} is not a supported resourceType`
-          }
-        }
-      ]
-    });
+    throw new BadRequestError(`resourceType: ${resourceType} is not a supported resourceType`);
   }
 }
 

--- a/src/util/bundleUtils.js
+++ b/src/util/bundleUtils.js
@@ -1,4 +1,5 @@
-const { ServerError, resolveSchema } = require('@projecttacoma/node-fhir-server-core');
+const { resolveSchema } = require('@projecttacoma/node-fhir-server-core');
+const { ResourceNotFoundError, InternalError } = require('./errorUtils');
 const _ = require('lodash');
 const url = require('url');
 const { v4: uuidv4 } = require('uuid');
@@ -106,18 +107,7 @@ function getQueryFromReference(reference) {
 async function getMeasureBundleFromId(measureId) {
   const measure = await findResourceById(measureId, 'Measure');
   if (!measure) {
-    throw new ServerError(null, {
-      statusCode: 404,
-      issue: [
-        {
-          severity: 'error',
-          code: 'ResourceNotFound',
-          details: {
-            text: `Measure with id ${measureId} does not exist in the server`
-          }
-        }
-      ]
-    });
+    throw new ResourceNotFoundError(`Measure with id ${measureId} does not exist in the server`);
   }
   return assembleCollectionBundleFromMeasure(measure);
 }
@@ -135,18 +125,7 @@ async function assembleCollectionBundleFromMeasure(measure) {
   const mainLib = await findOneResourceWithQuery(mainLibQuery, 'Library');
 
   if (!mainLib) {
-    throw new ServerError(null, {
-      statusCode: 500,
-      issue: [
-        {
-          severity: 'error',
-          code: 'internal',
-          details: {
-            text: `Could not find Library ${mainLibraryRef} referenced by Measure ${measure.id}`
-          }
-        }
-      ]
-    });
+    throw new InternalError(`Could not find Library ${mainLibraryRef} referenced by Measure ${measure.id}`);
   }
 
   // TODO: Could we simplify the logic to avoid the need for de-duplication?

--- a/src/util/errorUtils.js
+++ b/src/util/errorUtils.js
@@ -1,0 +1,130 @@
+const { ServerError } = require('@projecttacoma/node-fhir-server-core');
+
+class BadRequestError extends ServerError {
+  constructor(message) {
+    super(null, {
+      statusCode: 400,
+      issue: [
+        {
+          severity: 'error',
+          code: 'BadRequest',
+          details: {
+            text: message
+          }
+        }
+      ]
+    });
+  }
+}
+
+class NotImplementedError extends ServerError {
+  constructor(message) {
+    super(null, {
+      statusCode: 501,
+      issue: [
+        {
+          severity: 'error',
+          code: 'NotImplemented',
+          details: {
+            text: message
+          }
+        }
+      ]
+    });
+  }
+}
+
+class ResourceNotFoundError extends ServerError {
+  constructor(message) {
+    super(null, {
+      statusCode: 404,
+      issue: [
+        {
+          severity: 'error',
+          code: 'ResourceNotFound',
+          details: {
+            text: message
+          }
+        }
+      ]
+    });
+  }
+}
+
+class NotFoundError extends ServerError {
+  constructor(message) {
+    super(null, {
+      statusCode: 404,
+      issue: [
+        {
+          severity: 'error',
+          code: 'NotFound',
+          details: {
+            text: message
+          }
+        }
+      ]
+    });
+  }
+}
+
+class InternalError extends ServerError {
+  constructor(message) {
+    super(null, {
+      statusCode: 500,
+      issue: [
+        {
+          severity: 'error',
+          code: 'internal',
+          details: {
+            text: message
+          }
+        }
+      ]
+    });
+  }
+}
+
+class UnprocessableEntityError extends ServerError {
+  constructor(message) {
+    super(null, {
+      statusCode: 422,
+      issue: [
+        {
+          severity: 'error',
+          code: 'UnprocessableEntity',
+          details: {
+            text: message
+          }
+        }
+      ]
+    });
+  }
+}
+
+class BulkStatusError extends ServerError {
+  constructor(message, errorCode) {
+    super(null, {
+      statusCode: 500,
+      issue: [
+        {
+          severity: 'error',
+          code: errorCode,
+          details: {
+            text: message
+          }
+        }
+      ]
+    });
+  }
+}
+
+module.exports = {
+  BadRequestError,
+  NotImplementedError,
+  ResourceNotFoundError,
+  NotFoundError,
+  InternalError,
+  UnprocessableEntityError,
+  BulkStatusError
+};

--- a/src/util/errorUtils.js
+++ b/src/util/errorUtils.js
@@ -1,13 +1,16 @@
 const { ServerError } = require('@projecttacoma/node-fhir-server-core');
 
-class BadRequestError extends ServerError {
-  constructor(message) {
+/**
+ * Child class of ServerError with custom options object
+ */
+class CustomServerError extends ServerError {
+  constructor(message, customStatusCode, customCode) {
     super(null, {
-      statusCode: 400,
+      statusCode: customStatusCode,
       issue: [
         {
           severity: 'error',
-          code: 'BadRequest',
+          code: customCode,
           details: {
             text: message
           }
@@ -17,105 +20,66 @@ class BadRequestError extends ServerError {
   }
 }
 
-class NotImplementedError extends ServerError {
+/**
+ * Error class that throws ServerError with status code 400 and code BadRequest
+ */
+class BadRequestError extends CustomServerError {
   constructor(message) {
-    super(null, {
-      statusCode: 501,
-      issue: [
-        {
-          severity: 'error',
-          code: 'NotImplemented',
-          details: {
-            text: message
-          }
-        }
-      ]
-    });
+    super(message, 400, 'BadRequest');
   }
 }
 
-class ResourceNotFoundError extends ServerError {
+/**
+ * Error class that throws ServerError with status code 501 and code NotImplemented
+ */
+class NotImplementedError extends CustomServerError {
   constructor(message) {
-    super(null, {
-      statusCode: 404,
-      issue: [
-        {
-          severity: 'error',
-          code: 'ResourceNotFound',
-          details: {
-            text: message
-          }
-        }
-      ]
-    });
+    super(message, 501, 'NotImplemented');
   }
 }
 
-class NotFoundError extends ServerError {
+/**
+ * Error class that throws ServerError with status code 404 and code ResourceNotFound
+ */
+class ResourceNotFoundError extends CustomServerError {
   constructor(message) {
-    super(null, {
-      statusCode: 404,
-      issue: [
-        {
-          severity: 'error',
-          code: 'NotFound',
-          details: {
-            text: message
-          }
-        }
-      ]
-    });
+    super(message, 404, 'ResourceNotFound');
   }
 }
 
-class InternalError extends ServerError {
+/**
+ * Error class that throws ServerError with status code 404 and code NotFound
+ */
+class NotFoundError extends CustomServerError {
   constructor(message) {
-    super(null, {
-      statusCode: 500,
-      issue: [
-        {
-          severity: 'error',
-          code: 'internal',
-          details: {
-            text: message
-          }
-        }
-      ]
-    });
+    super(message, 404, 'NotFound');
   }
 }
 
-class UnprocessableEntityError extends ServerError {
+/**
+ * Error class that throws ServerError with status code 500 and code Internal
+ */
+class InternalError extends CustomServerError {
   constructor(message) {
-    super(null, {
-      statusCode: 422,
-      issue: [
-        {
-          severity: 'error',
-          code: 'UnprocessableEntity',
-          details: {
-            text: message
-          }
-        }
-      ]
-    });
+    super(message, 500, 'Internal');
   }
 }
 
-class BulkStatusError extends ServerError {
+/**
+ * Error class that throws ServerError with status code 422 and code UnprocessableEntity
+ */
+class UnprocessableEntityError extends CustomServerError {
+  constructor(message) {
+    super(message, 422, 'UnprocessableEntity');
+  }
+}
+
+/**
+ * Error class that throws ServerError with status code 500 and custom error code
+ */
+class BulkStatusError extends CustomServerError {
   constructor(message, errorCode) {
-    super(null, {
-      statusCode: 500,
-      issue: [
-        {
-          severity: 'error',
-          code: errorCode,
-          details: {
-            text: message
-          }
-        }
-      ]
-    });
+    super(message, 500, errorCode);
   }
 }
 

--- a/src/util/exportUtils.js
+++ b/src/util/exportUtils.js
@@ -1,4 +1,4 @@
-const { ServerError } = require('@projecttacoma/node-fhir-server-core');
+const { BadRequestError } = require('./errorUtils');
 const logger = require('../server/logger');
 
 /**
@@ -35,47 +35,14 @@ const retrieveExportUrl = parameters => {
  */
 const checkExportUrlArray = exportUrlArray => {
   if (exportUrlArray.length === 0) {
-    throw new ServerError(null, {
-      statusCode: 400,
-      issue: [
-        {
-          severity: 'error',
-          code: 'BadRequest',
-          details: {
-            text: `No exportUrl parameter was found.`
-          }
-        }
-      ]
-    });
+    throw new BadRequestError(`No exportUrl parameter was found.`);
   }
   if (exportUrlArray.length !== 1) {
-    throw new ServerError(null, {
-      statusCode: 400,
-      issue: [
-        {
-          severity: 'error',
-          code: 'BadRequest',
-          details: {
-            text: `Expected exactly one export URL. Received: ${exportUrlArray.length}`
-          }
-        }
-      ]
-    });
+    throw new BadRequestError(`Expected exactly one export URL. Received: ${exportUrlArray.length}`);
   }
   // if one export URL exists, check that valueUrl exists
   if (!exportUrlArray[0].valueUrl) {
-    throw new ServerError(null, {
-      statusCode: 400,
-      issue: [
-        {
-          severity: 'error',
-          code: 'BadRequest',
-          details: {
-            text: `Expected a valueUrl for the exportUrl, but none was found`
-          }
-        }
-      ]
-    });
+    throw new BadRequestError(`Expected a valueUrl for the exportUrl, but none was found`);
   }
 };
 

--- a/src/util/patientUtils.js
+++ b/src/util/patientUtils.js
@@ -1,4 +1,4 @@
-const { ServerError } = require('@projecttacoma/node-fhir-server-core');
+const { ResourceNotFoundError } = require('./errorUtils');
 const _ = require('lodash');
 const supportedResources = require('../server/supportedResources');
 // lookup from patient compartment-definition
@@ -46,18 +46,7 @@ async function getPatientDataSearchSetBundle(patientId, base_version, host) {
 async function getPatientData(patientId, dataRequirements) {
   const patient = await findResourceById(patientId, 'Patient');
   if (!patient) {
-    throw new ServerError(null, {
-      statusCode: 404,
-      issue: [
-        {
-          severity: 'error',
-          code: 'ResourceNotFound',
-          details: {
-            text: `Patient with id ${patientId} does not exist in the server`
-          }
-        }
-      ]
-    });
+    throw new ResourceNotFoundError(`Patient with id ${patientId} does not exist in the server`);
   }
   let requiredTypes;
   if (dataRequirements) {

--- a/src/util/provenanceUtils.js
+++ b/src/util/provenanceUtils.js
@@ -1,4 +1,5 @@
-const { resolveSchema, ServerError } = require('@projecttacoma/node-fhir-server-core');
+const { resolveSchema } = require('@projecttacoma/node-fhir-server-core');
+const { BadRequestError } = require('./errorUtils');
 const { v4: uuidv4 } = require('uuid');
 const logger = require('../server/logger');
 
@@ -99,48 +100,17 @@ const buildDelegator = reference => {
 const checkProvenanceHeader = requestHeaders => {
   const provenanceRequest = JSON.parse(requestHeaders['x-provenance']);
   if (provenanceRequest.resourceType !== 'Provenance') {
-    throw new ServerError(null, {
-      statusCode: 400,
-      issue: [
-        {
-          severity: 'error',
-          code: 'BadRequest',
-          details: {
-            text: `Expected resourceType 'Provenance' for Provenance header. Received ${provenanceRequest.resourceType}.`
-          }
-        }
-      ]
-    });
+    throw new BadRequestError(
+      `Expected resourceType 'Provenance' for Provenance header. Received ${provenanceRequest.resourceType}.`
+    );
   }
 
   if (provenanceRequest.target) {
-    throw new ServerError(null, {
-      statusCode: 400,
-      issue: [
-        {
-          severity: 'error',
-          code: 'BadRequest',
-          details: {
-            text: `The 'target' attribute should not be populated in the provenance header`
-          }
-        }
-      ]
-    });
+    throw new BadRequestError(`The 'target' attribute should not be populated in the provenance header`);
   }
 
   if (!provenanceRequest.agent || provenanceRequest.agent.length === 0) {
-    throw new ServerError(null, {
-      statusCode: 400,
-      issue: [
-        {
-          severity: 'error',
-          code: 'BadRequest',
-          details: {
-            text: `The provenance header must specify at least 1 agent in the agent attribute`
-          }
-        }
-      ]
-    });
+    throw new BadRequestError(`The provenance header must specify at least 1 agent in the agent attribute`);
   }
 };
 

--- a/test/resources/transactionBundle.test.js
+++ b/test/resources/transactionBundle.test.js
@@ -37,7 +37,7 @@ describe('Test functionality for adding resource entry to the bundle', () => {
       expect(e.statusCode).toEqual(422);
       expect(e.issue[0].details.text).toEqual(
         `Invalid request type for transaction bundle entry for resource with id: ${testPatient.id}. 
-              Request must be of type POST or PUT, received type: INVALID`
+        Request must be of type POST or PUT, received type: INVALID`
       );
     }
   });

--- a/test/services/base.service.test.js
+++ b/test/services/base.service.test.js
@@ -223,7 +223,7 @@ describe('base.service', () => {
 });
 
 describe('checkContentTypeHeader', () => {
-  test('throw ServerError for invalid ContentType header', () => {
+  test('throw error for invalid ContentType header', () => {
     const INVALID_HEADER = 'INVALID';
     try {
       checkContentTypeHeader(INVALID_HEADER);

--- a/test/services/clientfile.service.test.js
+++ b/test/services/clientfile.service.test.js
@@ -21,7 +21,7 @@ describe('check client file', () => {
       .get('/4_0_1/file/testid/invalid.ndjson')
       .expect(404)
       .then(response => {
-        expect(response.body.issue[0].code).toEqual('not-found');
+        expect(response.body.issue[0].code).toEqual('NotFound');
         expect(response.body.issue[0].details.text).toEqual('The following file was not found: testid/invalid.ndjson');
       });
   });

--- a/test/util/validationUtils.test.js
+++ b/test/util/validationUtils.test.js
@@ -187,7 +187,7 @@ describe('validateCareGapsParams', () => {
     } catch (e) {
       expect(e.statusCode).toEqual(400);
       expect(e.issue[0].details.text).toEqual(
-        `subject may only be a Group resource of format "Group/{id}" or Patient resource of format "Patient/{id}".`
+        `Subject may only be a Group resource of format "Group/{id}" or Patient resource of format "Patient/{id}".`
       );
     }
   });
@@ -208,7 +208,7 @@ describe('validateCareGapsParams', () => {
     } catch (e) {
       expect(e.statusCode).toEqual(400);
       expect(e.issue[0].details.text).toEqual(
-        `subject may only be a Group resource of format "Group/{id}" or Patient resource of format "Patient/{id}".`
+        `Subject may only be a Group resource of format "Group/{id}" or Patient resource of format "Patient/{id}".`
       );
     }
   });


### PR DESCRIPTION
# Summary
A utility was added to the test server for throwing different errors, which allows us to avoid repeating the `ServerError` object throughout the repository.

## New behavior
Behavior is unchanged.

## Code changes
This new utility is available in `errorUtils.js`. The `CustomServerError` class extends from the `ServerError` class and creates the `options` object that contains the `severity`, `code`, and `details` attributes. Then, various classes extend from the `CustomServerError` class to fill in the details of the `statusCode`, `code`, and `details.text` (the message that we want contained in the error).

Throughout the codebase, the `ServerError` instances have been replaced with the appropriate child error classes. Now, when throwing an error, the only parameter needed (for most cases) is the message that we want contained in the error.

# Testing Guidance
Run all unit tests.
Look through the codebase for instances where each of the different errors are thrown. Try replicating each of these error scenarios in Insomnia to ensure that the error functionality is unchanged.

Here are some examples:
* To throw a BadRequest error, send a GET request to `$evaluate-measure` with an invalid `reportType`
* To throw a NotImplementedError, send a GET request to `$evaluate-measure` with the `subject-list` `reportType`

Check that all the direct `ServerError` calls have been removed from the codebase.

