### PR TITLE
Dependent library missing descriptive error

### DIFF
--- a/src/util/bundleUtils.js
+++ b/src/util/bundleUtils.js
@@ -192,7 +192,9 @@ async function getAllDependentLibraries(lib) {
     const lib = await findOneResourceWithQuery(libQuery, 'Library');
     if (lib === null) {
       throw new InternalError(
-        `Failed to find dependent library with canonical url: ${libQuery.url} and version: ${libQuery.version}`
+        `Failed to find dependent library with ${
+          libQuery.id ? `id: ${libQuery.id}` : `canonical url: ${libQuery.url}`
+        }${libQuery.version ? `and version: ${libQuery.version}` : ''}`
       );
     }
     return getAllDependentLibraries(lib);
@@ -265,5 +267,6 @@ module.exports = {
   replaceReferences,
   assembleCollectionBundleFromMeasure,
   getQueryFromReference,
-  mapResourcesToCollectionBundle
+  mapResourcesToCollectionBundle,
+  getAllDependentLibraries
 };

--- a/src/util/bundleUtils.js
+++ b/src/util/bundleUtils.js
@@ -190,6 +190,11 @@ async function getAllDependentLibraries(lib) {
     }
     const libQuery = getQueryFromReference(url);
     const lib = await findOneResourceWithQuery(libQuery, 'Library');
+    if (lib === null) {
+      throw new InternalError(
+        `Failed to find dependent library with canonical url: ${libQuery.url} and version: ${libQuery.version}`
+      );
+    }
     return getAllDependentLibraries(lib);
   });
 

--- a/src/util/bundleUtils.js
+++ b/src/util/bundleUtils.js
@@ -194,7 +194,7 @@ async function getAllDependentLibraries(lib) {
       throw new InternalError(
         `Failed to find dependent library with ${
           libQuery.id ? `id: ${libQuery.id}` : `canonical url: ${libQuery.url}`
-        }${libQuery.version ? `and version: ${libQuery.version}` : ''}`
+        }${libQuery.version ? ` and version: ${libQuery.version}` : ''}`
       );
     }
     return getAllDependentLibraries(lib);

--- a/test/fixtures/fhir-resources/testLibraryDependencies.json
+++ b/test/fixtures/fhir-resources/testLibraryDependencies.json
@@ -1,0 +1,10 @@
+{
+  "id": "LibraryWithDependencies",
+  "resourceType": "Library",
+  "relatedArtifact": [
+    {
+      "type": "depends-on",
+      "resource": "Library/Missing"
+    }
+  ]
+}


### PR DESCRIPTION
# Summary
Adds a descriptive server error throw when a dependent library for an $evaluate-measure request cannot be found

## New behavior
Previously, when a dependent library could not be found, an error would be thrown with message: `"Unexpected: Cannot read property 'id' of null"`. The current message now details the id or canonical url of the missing library as well as the version when appropriate

## Code changes
- Updated `getAllDependentLibraries()` function to check whether the found lib is null and throw an error if so
- Added testing

# Testing guidance
- Run `npm test`
- Run `npm run db:reset`
- Run `npm run connectathon-upload`
- Run `npm start`
- Send a `DELETE` request to `http://localhost:3000/4_0_1/Library/library-FHIRHelpers-4.0.1` and ensure `204` is returned
- Send a `POST` request to `http://localhost:3000/4_0_1/Measure/measure-EXM130-7.3.000/$evaluate-measure?subject=numer-EXM130&periodStart=2019-01-01&periodEnd=2019-12-31` and ensure that a `500` response code is returned with an appropriate error message.
