### PR TITLE
Clean up test fix setup to accept an array 

### DIFF
--- a/test/populateTestData.js
+++ b/test/populateTestData.js
@@ -22,13 +22,16 @@ async function cleanUpTest() {
   await queue.close();
 }
 
-const testSetup = async (testMeasure, testPatient, testLibrary) => {
-  await client.connect();
-  await createTestResource(testMeasure, 'Measure');
-  await createTestResource(testPatient, 'Patient');
-  await createTestResource(testLibrary, 'Library');
-};
+/**DOD: testSetup() function takes an array of FHIR resources and creates an
+ * entry in mongo for each of them. All calls to testSetup() are updated. */
 
+const testSetup = async (testfixtureList) => {
+  await client.connect();
+
+  for (const x of testfixtureList) {
+    await createTestResource(x, toString(x.resourceType));
+  }
+};
 const bulkStatusSetup = async () => {
   await client.connect();
   const promises = testStatuses.map(async status => {

--- a/test/populateTestData.js
+++ b/test/populateTestData.js
@@ -25,7 +25,7 @@ async function cleanUpTest() {
 const testSetup = async testfixtureList => {
   await client.connect();
 
-  let result = testfixtureList.map(async x => {
+  const result = testfixtureList.map(async x => {
     return await createTestResource(x, x.resourceType);
   });
   await Promise.all(result);

--- a/test/populateTestData.js
+++ b/test/populateTestData.js
@@ -22,21 +22,13 @@ async function cleanUpTest() {
   await queue.close();
 }
 
-/**DOD: testSetup() function takes an array of FHIR resources and creates an
- * entry in mongo for each of them. All calls to testSetup() are updated. */
-
-const testSetup = async (testfixtureList) => {
+const testSetup = async testfixtureList => {
   await client.connect();
 
-  /*for (const x of testfixtureList) {
-    await createTestResource(x, toString(x.resourceType));
-  }*/
-
-  let result = testfixtureList.map(async (x)=>{
-    let test = createTestResource(x, x.resourceType);
-  return test;
+  let result = testfixtureList.map(async x => {
+    return await createTestResource(x, x.resourceType);
   });
-  await Promise.all(result)
+  await Promise.all(result);
 };
 const bulkStatusSetup = async () => {
   await client.connect();

--- a/test/populateTestData.js
+++ b/test/populateTestData.js
@@ -28,9 +28,15 @@ async function cleanUpTest() {
 const testSetup = async (testfixtureList) => {
   await client.connect();
 
-  for (const x of testfixtureList) {
+  /*for (const x of testfixtureList) {
     await createTestResource(x, toString(x.resourceType));
-  }
+  }*/
+
+  let result = testfixtureList.map(async (x)=>{
+    let test = createTestResource(x, x.resourceType);
+  return test;
+  });
+  await Promise.all(result)
 };
 const bulkStatusSetup = async () => {
   await client.connect();

--- a/test/services/base.service.test.js
+++ b/test/services/base.service.test.js
@@ -18,7 +18,7 @@ describe('base.service', () => {
     server = initialize(config);
   });
   beforeEach(async () => {
-    const dataToImport= [ testMeasure, testLibrary,testPatient]
+    const dataToImport = [testMeasure, testLibrary, testPatient];
     await testSetup(dataToImport);
   });
   describe('searchById', () => {

--- a/test/services/base.service.test.js
+++ b/test/services/base.service.test.js
@@ -18,7 +18,8 @@ describe('base.service', () => {
     server = initialize(config);
   });
   beforeEach(async () => {
-    await testSetup(testMeasure, testPatient, testLibrary);
+    const dataToImport= [ testMeasure, testLibrary,testPatient]
+    await testSetup(dataToImport);
   });
   describe('searchById', () => {
     test('test searchById with correctHeaders and the id should be in database', async () => {

--- a/test/services/measure.service.test.js
+++ b/test/services/measure.service.test.js
@@ -16,7 +16,7 @@ const testParamInvalidResourceType = require('../fixtures/fhir-resources/paramet
 const testEmptyParam = require('../fixtures/fhir-resources/parameters/emptyParam.json');
 const testParamTwoMeasureReports = require('../fixtures/fhir-resources/parameters/paramTwoMeasureReports.json');
 const testCareGapsMeasureReport = require('../fixtures/testCareGapsMeasureReport.json');
-const { testSetup, cleanUpTest, createTestResource } = require('../populateTestData');
+const { testSetup, cleanUpTest } = require('../populateTestData');
 const { buildConfig } = require('../../src/config/profileConfig');
 const { initialize } = require('../../src/server/server');
 const { SINGLE_AGENT_PROVENANCE } = require('../fixtures/provenanceFixtures');
@@ -38,7 +38,9 @@ describe('measure.service', () => {
       testLibrary,
       testGroup,
       testOrganization,
-      testOrganization2
+      testOrganization2,
+      testParam,
+      testParamInvalidResourceType
     ];
 
     await testSetup(dataToImport);

--- a/test/services/measure.service.test.js
+++ b/test/services/measure.service.test.js
@@ -30,13 +30,18 @@ describe('measure.service', () => {
   beforeAll(async () => {
     const config = buildConfig();
     server = initialize(config);
-    await testSetup(testMeasure, testPatient, testLibrary);
-    await createTestResource(testPatient2, 'Patient');
-    await createTestResource(testGroup, 'Group');
-    await createTestResource(testMeasure2, 'Measure');
-    await createTestResource(deleteMeasure, 'Measure');
-    await createTestResource(testOrganization, 'Organization');
-    await createTestResource(testOrganization2, 'Organization');
+    const dataToImport = [
+      testMeasure,
+      testMeasure2,
+      testPatient,
+      testPatient2,
+      testLibrary,
+      testGroup,
+      testOrganization,
+      testOrganization2
+    ];
+
+    await testSetup(dataToImport);
   });
   describe('CRUD operations', () => {
     test('test create with correct headers', async () => {

--- a/test/services/measure.service.test.js
+++ b/test/services/measure.service.test.js
@@ -2,7 +2,6 @@ require('../../src/config/envConfig');
 const supertest = require('supertest');
 const testMeasure = require('../fixtures/fhir-resources/testMeasure.json');
 const testMeasure2 = require('../fixtures/fhir-resources/testMeasure2.json');
-const deleteMeasure = require('../fixtures/fhir-resources/deleteMeasure.json');
 const testLibrary = require('../fixtures/fhir-resources/testLibrary.json');
 const testPatient = require('../fixtures/fhir-resources/testPatient.json');
 const testPatient2 = require('../fixtures/fhir-resources/testPatient2.json');

--- a/test/services/measure.service.test.js
+++ b/test/services/measure.service.test.js
@@ -15,6 +15,7 @@ const testParamInvalidResourceType = require('../fixtures/fhir-resources/paramet
 const testEmptyParam = require('../fixtures/fhir-resources/parameters/emptyParam.json');
 const testParamTwoMeasureReports = require('../fixtures/fhir-resources/parameters/paramTwoMeasureReports.json');
 const testCareGapsMeasureReport = require('../fixtures/testCareGapsMeasureReport.json');
+const deleteMeasure = require('../fixtures/fhir-resources/deleteMeasure.json');
 const { testSetup, cleanUpTest } = require('../populateTestData');
 const { buildConfig } = require('../../src/config/profileConfig');
 const { initialize } = require('../../src/server/server');
@@ -38,8 +39,7 @@ describe('measure.service', () => {
       testGroup,
       testOrganization,
       testOrganization2,
-      testParam,
-      testParamInvalidResourceType
+      deleteMeasure
     ];
 
     await testSetup(dataToImport);

--- a/test/services/patient.service.test.js
+++ b/test/services/patient.service.test.js
@@ -17,9 +17,8 @@ describe('patient.service', () => {
   beforeAll(async () => {
     const config = buildConfig();
     server = initialize(config);
-    await testSetup(testMeasure, testPatient, testLibrary);
-    await createTestResource(testPatient2, 'Patient');
-    await createTestResource(deletePatient, 'Patient');
+    const dataToImport = [testMeasure,testLibrary,testPatient, testPatient2,deletePatient]
+    await testSetup(dataToImport);
   });
   describe('CRUD operations', () => {
     test('test create with correct headers', async () => {

--- a/test/services/patient.service.test.js
+++ b/test/services/patient.service.test.js
@@ -1,6 +1,6 @@
 require('../../src/config/envConfig');
 const supertest = require('supertest');
-const { testSetup, createTestResource, cleanUpTest } = require('../populateTestData');
+const { testSetup, cleanUpTest } = require('../populateTestData');
 const { buildConfig } = require('../../src/config/profileConfig');
 const { initialize } = require('../../src/server/server');
 const { SINGLE_AGENT_PROVENANCE } = require('../fixtures/provenanceFixtures');
@@ -17,7 +17,7 @@ describe('patient.service', () => {
   beforeAll(async () => {
     const config = buildConfig();
     server = initialize(config);
-    const dataToImport = [testMeasure,testLibrary,testPatient, testPatient2,deletePatient]
+    const dataToImport = [testMeasure, testLibrary, testPatient, testPatient2, deletePatient];
     await testSetup(dataToImport);
   });
   describe('CRUD operations', () => {


### PR DESCRIPTION
# Summary
Changed `testSetup` to no longer accept a fixed list of 3 items but to now accept an array of items that can be updated for new tests as resources are added
## New behavior
The behavior should be identical to prior behavior however it should make the beforeAll and beforeEach blocks cleaner as all that is needed to add a new resource for a test 
## Code changes
 `test/populateTestData.js` - modified `testSetup` to now accept an array of resources and add them to the database
`test/services/base.service.test.js` - updated to use the new `testSetup` call and remove the unneeded method
`test/services/measure.service.test.js`   -updated to use the new `testSetup` call and remove the unneeded method
`test/services/patient.service.test.js` -updated to use the new `testSetup` call and remove the unneeded method

# Testing guidance
 Run npm test and assure all the tests pass. Ultimately the behavior should be the same. 