### PR TITLE
Added meta.lastUpdated to created and updated resources

### DIFF
--- a/src/services/base.service.js
+++ b/src/services/base.service.js
@@ -11,7 +11,7 @@ const {
   findResourcesWithAggregation
 } = require('../database/dbOperations');
 const { checkProvenanceHeader, populateProvenanceTarget } = require('../util/provenanceUtils');
-const { checkSupportedResource, checkContentTypeHeader } = require('../util/baseUtils');
+const { checkSupportedResource, checkContentTypeHeader, getCurrentInstant} = require('../util/baseUtils');
 const logger = require('../server/logger.js');
 
 /**
@@ -91,6 +91,7 @@ const baseCreate = async ({ req }, resourceType) => {
   checkSupportedResource(data.resourceType);
   //Create a new id regardless of whether one is passed
   data['id'] = uuidv4();
+  data['meta'] = {lastUpdated: getCurrentInstant(), ...data['meta']};
   if (req.headers['x-provenance']) {
     checkProvenanceHeader(req.headers);
     const res = req.res;
@@ -215,6 +216,7 @@ const baseUpdate = async (args, { req }, resourceType) => {
   if (data.id !== args.id) {
     throw new BadRequestError('Argument id must match request body id for PUT request');
   }
+  data['meta'] = {lastUpdated: getCurrentInstant(), ...data['meta']};
   if (req.headers['x-provenance']) {
     checkProvenanceHeader(req.headers);
     const res = req.res;

--- a/src/services/base.service.js
+++ b/src/services/base.service.js
@@ -11,7 +11,7 @@ const {
   findResourcesWithAggregation
 } = require('../database/dbOperations');
 const { checkProvenanceHeader, populateProvenanceTarget } = require('../util/provenanceUtils');
-const { checkSupportedResource, checkContentTypeHeader, getCurrentInstant} = require('../util/baseUtils');
+const { checkSupportedResource, checkContentTypeHeader, getCurrentInstant } = require('../util/baseUtils');
 const logger = require('../server/logger.js');
 
 /**
@@ -91,7 +91,7 @@ const baseCreate = async ({ req }, resourceType) => {
   checkSupportedResource(data.resourceType);
   //Create a new id regardless of whether one is passed
   data['id'] = uuidv4();
-  data['meta'] = {lastUpdated: getCurrentInstant(), ...data['meta']};
+  data['meta'] = { lastUpdated: getCurrentInstant(), ...data['meta'] };
   if (req.headers['x-provenance']) {
     checkProvenanceHeader(req.headers);
     const res = req.res;
@@ -216,7 +216,7 @@ const baseUpdate = async (args, { req }, resourceType) => {
   if (data.id !== args.id) {
     throw new BadRequestError('Argument id must match request body id for PUT request');
   }
-  data['meta'] = {lastUpdated: getCurrentInstant(), ...data['meta']};
+  data['meta'] = { lastUpdated: getCurrentInstant(), ...data['meta'] };
   if (req.headers['x-provenance']) {
     checkProvenanceHeader(req.headers);
     const res = req.res;

--- a/src/services/base.service.js
+++ b/src/services/base.service.js
@@ -91,7 +91,8 @@ const baseCreate = async ({ req }, resourceType) => {
   checkSupportedResource(data.resourceType);
   //Create a new id regardless of whether one is passed
   data['id'] = uuidv4();
-  data['meta'] = { lastUpdated: getCurrentInstant(), ...data['meta'] };
+  //lastUpdated should be second because it should overwrite a meta.lastUpdated tag in the request body
+  data['meta'] = { ...data['meta'], lastUpdated: getCurrentInstant() };
   if (req.headers['x-provenance']) {
     checkProvenanceHeader(req.headers);
     const res = req.res;
@@ -216,7 +217,8 @@ const baseUpdate = async (args, { req }, resourceType) => {
   if (data.id !== args.id) {
     throw new BadRequestError('Argument id must match request body id for PUT request');
   }
-  data['meta'] = { lastUpdated: getCurrentInstant(), ...data['meta'] };
+  //lastUpdated should be second because it should overwrite a meta.lastUpdated tag in the request body
+  data['meta'] = { ...data['meta'], lastUpdated: getCurrentInstant() };
   if (req.headers['x-provenance']) {
     checkProvenanceHeader(req.headers);
     const res = req.res;

--- a/src/util/baseUtils.js
+++ b/src/util/baseUtils.js
@@ -33,7 +33,7 @@ const checkContentTypeHeader = requestHeaders => {
  */
 const getCurrentInstant = () => {
   const event = new Date();
-  return event.toISOString(); 
-}
+  return event.toISOString();
+};
 
-module.exports = { checkSupportedResource, checkContentTypeHeader, getCurrentInstant};
+module.exports = { checkSupportedResource, checkContentTypeHeader, getCurrentInstant };

--- a/src/util/baseUtils.js
+++ b/src/util/baseUtils.js
@@ -27,4 +27,13 @@ const checkContentTypeHeader = requestHeaders => {
   }
 };
 
-module.exports = { checkSupportedResource, checkContentTypeHeader };
+/**
+ * Gets the current time as a FHIR instant to populate meta.lastUpdated for resource creation and updating
+ * @returns {string} current time in GMT as a FHIR instant
+ */
+const getCurrentInstant = () => {
+  const event = new Date();
+  return event.toISOString(); 
+}
+
+module.exports = { checkSupportedResource, checkContentTypeHeader, getCurrentInstant};

--- a/test/fixtures/fhir-resources/testPatient2.json
+++ b/test/fixtures/fhir-resources/testPatient2.json
@@ -1,4 +1,7 @@
 {
   "resourceType": "Patient",
-  "id": "testPatient2"
+  "id": "testPatient2",
+  "meta": {
+    "lastUpdated": "2022-01-01T00:00:00Z"
+  }
 }

--- a/test/services/base.service.test.js
+++ b/test/services/base.service.test.js
@@ -58,7 +58,7 @@ describe('base.service', () => {
         .then(response => {
           expect(response.body.resourceType).toEqual('Bundle');
           expect(response.body.type).toEqual('searchset');
-          expect(response.body.total).toEqual(1);
+          expect(response.body.total).toEqual(2);
           expect(response.body.entry[0].resource.id).toEqual(testPatient.id);
           expect(response.body.entry[0].resource.resourceType).toEqual('Patient');
         });
@@ -176,7 +176,7 @@ describe('base.service', () => {
         .set('content-type', 'application/json+fhir')
         .set('x-provenance', JSON.stringify(SINGLE_AGENT_PROVENANCE))
         .expect(200)
-        .then(async response => {
+        .then(async () => {
           const patientCollection = db.collection('Patient');
           const retrievedPatient = await patientCollection.findOne({ id: UPDATE_PATIENT_2.id });
           expect(retrievedPatient.meta.lastUpdated).toBeDefined();

--- a/test/services/base.service.test.js
+++ b/test/services/base.service.test.js
@@ -180,7 +180,7 @@ describe('base.service', () => {
           const patientCollection = db.collection('Patient');
           const retrievedPatient = await patientCollection.findOne({ id: UPDATE_PATIENT_2.id });
           expect(retrievedPatient.meta.lastUpdated).toBeDefined();
-          expect(new Date(retrievedPatient.meta.lastUpdated) > new Date(testPatient2.meta.lastUpdated));
+          expect(new Date(retrievedPatient.meta.lastUpdated) > new Date(testPatient2.meta.lastUpdated)).toBe(true);
         });
     });
 

--- a/test/services/base.service.test.js
+++ b/test/services/base.service.test.js
@@ -13,6 +13,13 @@ const { db } = require('../../src/database/connection');
 const updatePatient = { resourceType: 'Patient', id: 'testPatient', name: 'anUpdate' };
 
 const UPDATE_PATIENT_2 = { resourceType: 'Patient', id: 'testPatient2', name: 'anUpdate' };
+const UPDATE_PATIENT_3 = {
+  resourceType: 'Patient',
+  id: 'testPatient3',
+  meta: { lastUpdated: '1900-01-01T00:00:00Z' },
+  name: 'anUpdate'
+};
+
 let server;
 
 describe('base.service', () => {
@@ -91,7 +98,7 @@ describe('base.service', () => {
         });
     });
 
-    test('test for meta.lastUpdated inclusion', async () => {
+    test('test for meta.lastUpdated inclusion when not included in create request', async () => {
       await supertest(server.app)
         .post('/4_0_1/Patient')
         .send(testPatient)
@@ -168,7 +175,7 @@ describe('base.service', () => {
         });
     });
 
-    test('test for meta.lastUpdated inclusion', async () => {
+    test('test for meta.lastUpdated inclusion when not included in update request', async () => {
       await supertest(server.app)
         .put('/4_0_1/Patient/testPatient2')
         .send(UPDATE_PATIENT_2)
@@ -181,6 +188,22 @@ describe('base.service', () => {
           const retrievedPatient = await patientCollection.findOne({ id: UPDATE_PATIENT_2.id });
           expect(retrievedPatient.meta.lastUpdated).toBeDefined();
           expect(new Date(retrievedPatient.meta.lastUpdated) > new Date(testPatient2.meta.lastUpdated)).toBe(true);
+        });
+    });
+
+    test('test that meta.lastUpdated is overwritten when included in update request', async () => {
+      await supertest(server.app)
+        .put('/4_0_1/Patient/testPatient3')
+        .send(UPDATE_PATIENT_3)
+        .set('Accept', 'application/json+fhir')
+        .set('content-type', 'application/json+fhir')
+        .set('x-provenance', JSON.stringify(SINGLE_AGENT_PROVENANCE))
+        .expect(201)
+        .then(async () => {
+          const patientCollection = db.collection('Patient');
+          const retrievedPatient = await patientCollection.findOne({ id: UPDATE_PATIENT_3.id });
+          expect(retrievedPatient.meta.lastUpdated).toBeDefined();
+          expect(new Date(retrievedPatient.meta.lastUpdated)).not.toEqual('1900-01-01T00:00:00Z');
         });
     });
 

--- a/test/services/base.service.test.js
+++ b/test/services/base.service.test.js
@@ -72,8 +72,11 @@ describe('base.service', () => {
     });
   });
 
-  describe('create', () => {
-    test('test create with correct headers', async () => {
+  describe.only('create', () => {
+    test.only('test create with correct headers', async () => {
+      jest
+        .useFakeTimers()
+        .setSystemTime(new Date('2020-01-01')); 
       await supertest(server.app)
         .post('/4_0_1/Patient')
         .send(testPatient)


### PR DESCRIPTION
# Summary
- Added meta.lastUpdated tag as FHIR instant to resources for update and create requests
## New behavior
- When updating or creating a resource, meta.lastUpdated tag gets filled/updated to be current time in GMT
## Code changes
- getCurrentInstant() method added to src/util/baseUtils , which returns current date/time as string
- baseCreate() and baseUpdate() methods in src/service/base.service changed to include meta.lastUpdated set to getCurrentInstant()
- added testing to ensure meta.lastUpdated is added to update and create requests
# Testing guidance
- run `npm run test`
- Send post or put request creating or updating a resource. DO NOT include a meta.lastUpdated field
- Send GET request to the created or updated resource and ensure that the meta.lastUpdated reflects when the resource was created or last updated