### PR TITLE
Resource count endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ connectathon
 coverage
 docker_ssl_setup.sh
 tmp
+.DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,33 +24,6 @@
         "moment": "^2.24.0",
         "sequelize": "^5.19.0",
         "xregexp": "^4.2.0"
-      },
-      "dependencies": {
-        "decimal.js": {
-          "version": "10.3.1",
-          "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
-          "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ=="
-        },
-        "mathjs": {
-          "version": "7.6.0",
-          "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-7.6.0.tgz",
-          "integrity": "sha512-abywR28hUpKF4at5jE8Ys+Kigk40eKMT5mcBLD0/dtsqjfOLbtzd3WjlRqIopNo7oQ6FME51qph6lb8h/bhpUg==",
-          "requires": {
-            "complex.js": "^2.0.11",
-            "decimal.js": "^10.2.1",
-            "escape-latex": "^1.2.0",
-            "fraction.js": "^4.0.12",
-            "javascript-natural-sort": "^0.7.1",
-            "seed-random": "^2.2.0",
-            "tiny-emitter": "^2.1.0",
-            "typed-function": "^2.0.0"
-          }
-        },
-        "typed-function": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-2.1.0.tgz",
-          "integrity": "sha512-bctQIOqx2iVbWGDGPWwIm18QScpu2XRmkC19D8rQGFsjKSgteq/o1hTZvIG/wuDq8fanpBDrLkLq+aEN/6y5XQ=="
-        }
       }
     },
     "@asymmetrik/fhir-qb-mongo": {
@@ -70,70 +43,6 @@
         "sanitize-html": "^1.20.0",
         "validator": "^10.8.0",
         "xss": "^1.0.3"
-      },
-      "dependencies": {
-        "domhandler": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-          "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
-          "requires": {
-            "domelementtype": "^2.2.0"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
-        },
-        "htmlparser2": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
-          "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
-          "requires": {
-            "domelementtype": "^2.0.1",
-            "domhandler": "^4.0.0",
-            "domutils": "^2.5.2",
-            "entities": "^2.0.0"
-          }
-        },
-        "nanoid": {
-          "version": "3.3.4",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-          "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
-        },
-        "picocolors": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-          "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
-        },
-        "postcss": {
-          "version": "8.4.13",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.13.tgz",
-          "integrity": "sha512-jtL6eTBrza5MPzy8oJLFuUscHDXTV5KcLlqAWHl5q5WYRfnNRGSmOZmOZ1T6Gy7A99mOZfqungmZMpMmCVJ8ZA==",
-          "requires": {
-            "nanoid": "^3.3.3",
-            "picocolors": "^1.0.0",
-            "source-map-js": "^1.0.2"
-          }
-        },
-        "sanitize-html": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.7.0.tgz",
-          "integrity": "sha512-jfQelabOn5voO7FAfnQF7v+jsA6z9zC/O4ec0z3E35XPEtHYJT/OdUziVWlKW4irCr2kXaQAyXTXDHWAibg1tA==",
-          "requires": {
-            "deepmerge": "^4.2.2",
-            "escape-string-regexp": "^4.0.0",
-            "htmlparser2": "^6.0.0",
-            "is-plain-object": "^5.0.0",
-            "parse-srcset": "^1.0.2",
-            "postcss": "^8.3.11"
-          }
-        },
-        "validator": {
-          "version": "13.7.0",
-          "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
-          "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw=="
-        }
       }
     },
     "@asymmetrik/sof-scope-checker": {
@@ -1268,9 +1177,9 @@
           }
         },
         "validator": {
-          "version": "13.7.0",
-          "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
-          "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw=="
+          "version": "9.4.1",
+          "resolved": "https://registry.npmjs.org/validator/-/validator-9.4.1.tgz",
+          "integrity": "sha512-YV5KjzvRmSyJ1ee/Dm5UED0G+1L4GZnLN3w6/T+zZm8scVua4sOhYKWTUrKa0H/tMiJyO9QLHMPN+9mB/aMunA=="
         },
         "xss": {
           "version": "0.3.8",
@@ -1770,32 +1679,6 @@
         "p-finally": "^1.0.0",
         "promise-callbacks": "^3.8.1",
         "redis": "^2.7.1"
-      },
-      "dependencies": {
-        "denque": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
-          "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw=="
-        },
-        "redis": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/redis/-/redis-3.1.2.tgz",
-          "integrity": "sha512-grn5KoZLr/qrRQVwoSkmzdbw6pwF+/rwODtrOr6vuBRiR/f3rjSTGupbF90Zpqm2oenix8Do6RV7pYEkGwlKkw==",
-          "requires": {
-            "denque": "^1.5.0",
-            "redis-commands": "^1.7.0",
-            "redis-errors": "^1.2.0",
-            "redis-parser": "^3.0.0"
-          }
-        },
-        "redis-parser": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
-          "integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
-          "requires": {
-            "redis-errors": "^1.0.0"
-          }
-        }
       }
     },
     "binary-extensions": {
@@ -2572,6 +2455,11 @@
         "ms": "2.1.2"
       }
     },
+    "decimal.js": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.0.tgz",
+      "integrity": "sha512-vDPw+rDgn3bZe1+F/pyEwb1oMG2XTlRVgAa6B4KccTEpYgF8w6eQllVbQcfIJnZyvzFtFpxnpGtx8dd7DJp/Rw=="
+    },
     "decompress-response": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
@@ -2709,6 +2597,14 @@
         }
       }
     },
+    "domhandler": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.3.0.tgz",
+      "integrity": "sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==",
+      "requires": {
+        "domelementtype": "^2.0.1"
+      }
+    },
     "domutils": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
@@ -2752,6 +2648,11 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
       "integrity": "sha512-fmrwR04lsniq/uSr8yikThDTrM7epXHBAAjH9TbeH3rEA8tdCO7mRzB9hdmdGyJCxF8KERo9CITcm3kGuoyMhg=="
+    },
+    "double-ended-queue": {
+      "version": "2.1.0-0",
+      "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
+      "integrity": "sha512-+BNfZ+deCo8hMNpDqDnvT+c0XpJ5cUa6mqYq89bho2Ifze4URTqRkcwR399hWoTrTkbZ/XJYDgP6rc7pRgffEQ=="
     },
     "duplexer3": {
       "version": "0.1.4",
@@ -4056,6 +3957,17 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "htmlparser2": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.1.0.tgz",
+      "integrity": "sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==",
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^3.0.0",
+        "domutils": "^2.0.0",
+        "entities": "^2.0.0"
+      }
     },
     "http-cache-semantics": {
       "version": "4.1.0",
@@ -6226,6 +6138,21 @@
         "tmpl": "1.0.5"
       }
     },
+    "mathjs": {
+      "version": "5.10.3",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-5.10.3.tgz",
+      "integrity": "sha512-ySjg30BC3dYjQm73ILZtwcWzFJde0VU6otkXW/57IjjuYRa3Qaf0Kb8pydEuBZYtqW2OxreAtsricrAmOj3jIw==",
+      "requires": {
+        "complex.js": "2.0.11",
+        "decimal.js": "10.2.0",
+        "escape-latex": "1.2.0",
+        "fraction.js": "4.0.12",
+        "javascript-natural-sort": "0.7.1",
+        "seed-random": "2.2.0",
+        "tiny-emitter": "2.1.0",
+        "typed-function": "1.1.0"
+      }
+    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -6508,7 +6435,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
     },
     "object-inspect": {
       "version": "1.12.0",
@@ -6741,6 +6668,11 @@
       "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
       "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
     },
+    "picocolors": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+      "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA=="
+    },
     "picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -6760,6 +6692,15 @@
       "dev": true,
       "requires": {
         "find-up": "^4.0.0"
+      }
+    },
+    "postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "requires": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
       }
     },
     "prelude-ls": {
@@ -6947,15 +6888,25 @@
         "picomatch": "^2.2.1"
       }
     },
+    "redis": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
+      "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
+      "requires": {
+        "double-ended-queue": "^2.1.0-0",
+        "redis-commands": "^1.2.0",
+        "redis-parser": "^2.6.0"
+      }
+    },
     "redis-commands": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
       "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
     },
-    "redis-errors": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
-      "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60="
+    "redis-parser": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
+      "integrity": "sha512-9Hdw19gwXFBJdN8ENUoNVJFRyMDFrE/ZBClPicKYDPwNPJ4ST1TedAHYNSiGKElwh2vrmRGMoJYbVdJd+WQXIw=="
     },
     "referrer-policy": {
       "version": "1.2.0",
@@ -7102,6 +7053,17 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "sanitize-html": {
+      "version": "1.27.5",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.27.5.tgz",
+      "integrity": "sha512-M4M5iXDAUEcZKLXkmk90zSYWEtk5NH3JmojQxKxV371fnMh+x9t1rqdmXaGoyEHw3z/X/8vnFhKjGL5xFGOJ3A==",
+      "requires": {
+        "htmlparser2": "^4.1.0",
+        "lodash": "^4.17.15",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^7.0.27"
+      }
     },
     "saslprep": {
       "version": "1.0.3",
@@ -7894,6 +7856,11 @@
         "mime-types": "~2.1.24"
       }
     },
+    "typed-function": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-1.1.0.tgz",
+      "integrity": "sha512-TuQzwiT4DDg19beHam3E66oRXhyqlyfgjHB/5fcvsRXbfmWPJfto9B4a0TBdTrQAPGlGmXh/k7iUI+WsObgORA=="
+    },
     "typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -8098,6 +8065,11 @@
           "dev": true
         }
       }
+    },
+    "validator": {
+      "version": "10.11.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-10.11.0.tgz",
+      "integrity": "sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "axios": "^0.21.4",
     "bee-queue": "^1.4.0",
     "bulk-data-utilities": "git+https://github.com/projecttacoma/bulk-data-utilities.git",
+    "cors": "^2.8.5",
     "dotenv": "^10.0.0",
     "express": "^4.17.1",
     "fqm-execution": "^1.0.0-beta.2",

--- a/src/controllers/resourcecount.controller.js
+++ b/src/controllers/resourcecount.controller.js
@@ -1,0 +1,15 @@
+const service = require('../services/resourcecount.service');
+
+/**
+ *
+ * @param {*} req
+ * @param {*} res
+ * @param {*} next
+ * @returns service
+ */
+module.exports.resourceCount = (req, res, next) => {
+  return service
+    .getAllResourceCounts()
+    .then(result => res.status(200).json(result))
+    .catch(err => next(err));
+};

--- a/src/database/dbOperations.js
+++ b/src/database/dbOperations.js
@@ -288,7 +288,7 @@ const getCurrentSuccessfulImportCount = async clientId => {
 
 /**
  * gets the number of documents in a specified collection
- * @param {*} resourceType specifies the name of the collection to be counted
+ * @param {string} resourceType specifies the name of the collection to be counted
  * @returns number that is the count of documents in the specified collection
  */
 const getCountOfCollection = async resourceType => {

--- a/src/database/dbOperations.js
+++ b/src/database/dbOperations.js
@@ -286,6 +286,18 @@ const getCurrentSuccessfulImportCount = async clientId => {
   return bulkStatus.successCount;
 };
 
+/**
+ * gets the number of documents in a specified collection
+ * @param {*} resourceType specifies the name of the collection to be counted
+ * @returns number that is the count of documents in the specified collection
+ */
+const getCountOfCollection = async resourceType => {
+  const collection = db.collection(resourceType);
+  logger.debug('Retrieving count for specified collection');
+  const count = await collection.countDocuments();
+  return count;
+};
+
 module.exports = {
   addPendingBulkImportRequest,
   completeBulkImportRequest,
@@ -304,5 +316,6 @@ module.exports = {
   pushToResource,
   removeResource,
   updateResource,
-  updateSuccessfulImportCount
+  updateSuccessfulImportCount,
+  getCountOfCollection
 };

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -1,4 +1,5 @@
 const { Server } = require('@projecttacoma/node-fhir-server-core');
+const cors = require('cors');
 const configBulkImport = require('../controllers/import.controller');
 const configTransaction = require('../controllers/bundle.controller');
 const configBulkStatus = require('../controllers/bulkstatus.controller');
@@ -33,6 +34,11 @@ class DEQMServer extends Server {
     this.app.get('/:base_version/resourceCount/', configResourceCount.resourceCount);
     return this;
   }
+
+  enableCors() {
+    this.app.use(cors());
+    return this;
+  }
 }
 
 function initialize(config, app) {
@@ -43,6 +49,7 @@ function initialize(config, app) {
     server = server.enableValidationMiddleWare();
   }
   server = server
+    .enableCors()
     .configureMiddleware()
     .configureSession()
     .configureHelmet()

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -3,6 +3,7 @@ const configBulkImport = require('../controllers/import.controller');
 const configTransaction = require('../controllers/bundle.controller');
 const configBulkStatus = require('../controllers/bulkstatus.controller');
 const configClientFile = require('../controllers/clientfile.controller');
+const configResourceCount = require('../controllers/resourcecount.controller');
 const { validateFhir } = require('../util/resourceValidationUtils');
 const logger = require('./logger.js');
 class DEQMServer extends Server {
@@ -28,6 +29,10 @@ class DEQMServer extends Server {
     this.app.post('/:base_version*', validateFhir);
     return this;
   }
+  enableResourceCountRoute() {
+    this.app.get('/:base_version/resourceCount/', configResourceCount.resourceCount);
+    return this;
+  }
 }
 
 function initialize(config, app) {
@@ -47,6 +52,7 @@ function initialize(config, app) {
     .enableBulkStatusRoute()
     .enableImportRoute()
     .enableClientFileRoute()
+    .enableResourceCountRoute()
     .setProfileRoutes()
     .setErrorRoutes();
 

--- a/src/services/resourcecount.service.js
+++ b/src/services/resourcecount.service.js
@@ -1,0 +1,21 @@
+const { getCountOfCollection } = require('../database/dbOperations');
+const supportedResources = require('../server/supportedResources');
+
+/**
+ * retrieves counts for each resourceType and then formats and returns all counts as resourceType:count key:value pairs
+ * @returns key:value pairs of resourceTypes and their counts
+ */
+const getAllResourceCounts = async () => {
+  const allCounts = supportedResources.map(async resourceType => {
+    return { resourceType, count: await getCountOfCollection(resourceType) };
+  });
+  const allResourceCounts = await Promise.all(allCounts);
+
+  const resourceCountPairs = {};
+  allResourceCounts.forEach(el => (resourceCountPairs[el.resourceType] = el.count));
+  return resourceCountPairs;
+};
+
+module.exports = {
+  getAllResourceCounts
+};

--- a/test/database/dbOperations.test.js
+++ b/test/database/dbOperations.test.js
@@ -1,10 +1,12 @@
-const { bulkStatusSetup, cleanUpTest } = require('../populateTestData');
+const { bulkStatusSetup, cleanUpTest, createTestResource } = require('../populateTestData');
+const { client } = require('../../src/database/connection');
 const {
   initializeBulkFileCount,
   decrementBulkFileCount,
   failBulkImportRequest,
   findResourceById,
-  pushBulkFailedOutcomes
+  pushBulkFailedOutcomes,
+  getCountOfCollection
 } = require('../../src/database/dbOperations');
 
 describe('check bulk file count logic', () => {
@@ -80,6 +82,23 @@ describe('check bulk import status logic', () => {
     await pushBulkFailedOutcomes(CLIENT_ID, exampleOutcomes);
     const result = await findResourceById(CLIENT_ID, 'bulkImportStatuses');
     expect(result.failedOutcomes).toEqual(['test1', 'test2']);
+  });
+
+  afterAll(cleanUpTest);
+});
+
+describe('check collection counts', () => {
+  beforeAll(async () => {
+    await client.connect();
+    await createTestResource({ resourceType: 'Patient', id: 'patient1' }, 'Patient');
+  });
+  test('get count of specified resource', async () => {
+    const result = await getCountOfCollection('Measure');
+    expect(result).toEqual(0);
+  });
+  test('get count of specified resource', async () => {
+    const result = await getCountOfCollection('Patient');
+    expect(result).toEqual(1);
   });
 
   afterAll(cleanUpTest);

--- a/test/database/dbOperations.test.js
+++ b/test/database/dbOperations.test.js
@@ -92,11 +92,11 @@ describe('check collection counts', () => {
     await client.connect();
     await createTestResource({ resourceType: 'Patient', id: 'patient1' }, 'Patient');
   });
-  test('get count of specified resource', async () => {
+  test('get count of 0 for empty collection', async () => {
     const result = await getCountOfCollection('Measure');
     expect(result).toEqual(0);
   });
-  test('get count of specified resource', async () => {
+  test('get count of 1 for collection with 1 document', async () => {
     const result = await getCountOfCollection('Patient');
     expect(result).toEqual(1);
   });

--- a/test/services/resourcecount.service.test.js
+++ b/test/services/resourcecount.service.test.js
@@ -12,16 +12,14 @@ const supportedResources = require('../../src/server/supportedResources');
 
 let server;
 
-describe('resource count', () => {
-  beforeAll(() => {
+describe('populated collections counts', () => {
+  beforeAll(async () => {
     const config = buildConfig();
     server = initialize(config);
-  });
-  beforeEach(async () => {
     const dataToImport = [testMeasure, testLibrary, testPatient, testPatient2];
     await testSetup(dataToImport);
   });
-  test('test for meta.lastUpdated inclusion when not included in update request', async () => {
+  test('test that populated collections return expected counts', async () => {
     await supertest(server.app)
       .get('/4_0_1/resourceCount')
       .set('Accept', 'application/json+fhir')
@@ -35,13 +33,13 @@ describe('resource count', () => {
   afterAll(cleanUpTest);
 });
 
-describe('test that all empty collections return count 0', () => {
+describe('empty collections count', () => {
   beforeAll(async () => {
     const config = buildConfig();
     server = initialize(config);
     await client.connect();
   });
-  test('test for meta.lastUpdated inclusion when not included in update request', async () => {
+  test('test that all empty collections return count of 0', async () => {
     await supertest(server.app)
       .get('/4_0_1/resourceCount')
       .set('Accept', 'application/json+fhir')

--- a/test/services/resourcecount.service.test.js
+++ b/test/services/resourcecount.service.test.js
@@ -1,0 +1,57 @@
+require('../../src/config/envConfig');
+const supertest = require('supertest');
+const { buildConfig } = require('../../src/config/profileConfig');
+const { initialize } = require('../../src/server/server');
+const testMeasure = require('../fixtures/fhir-resources/testMeasure.json');
+const testLibrary = require('../fixtures/fhir-resources/testLibrary.json');
+const testPatient = require('../fixtures/fhir-resources/testPatient.json');
+const testPatient2 = require('../fixtures/fhir-resources/testPatient2.json');
+const { testSetup, cleanUpTest } = require('../populateTestData');
+const { client } = require('../../src/database/connection');
+const supportedResources = require('../../src/server/supportedResources');
+
+let server;
+
+describe('resource count', () => {
+  beforeAll(() => {
+    const config = buildConfig();
+    server = initialize(config);
+  });
+  beforeEach(async () => {
+    const dataToImport = [testMeasure, testLibrary, testPatient, testPatient2];
+    await testSetup(dataToImport);
+  });
+  test('test for meta.lastUpdated inclusion when not included in update request', async () => {
+    await supertest(server.app)
+      .get('/4_0_1/resourceCount')
+      .set('Accept', 'application/json+fhir')
+      .expect(200)
+      .then(response => {
+        expect(response.body.Library).toEqual(1);
+        expect(response.body.Measure).toEqual(1);
+        expect(response.body.Patient).toEqual(2);
+      });
+  });
+  afterAll(cleanUpTest);
+});
+
+describe('test that all empty collections return count 0', () => {
+  beforeAll(async () => {
+    const config = buildConfig();
+    server = initialize(config);
+    await client.connect();
+  });
+  test('test for meta.lastUpdated inclusion when not included in update request', async () => {
+    await supertest(server.app)
+      .get('/4_0_1/resourceCount')
+      .set('Accept', 'application/json+fhir')
+      .expect(200)
+      .then(response => {
+        supportedResources.forEach(resourceType => {
+          expect(response.body[resourceType]).toBeDefined();
+          expect(response.body[resourceType]).toEqual(0);
+        });
+      });
+  });
+  afterAll(cleanUpTest);
+});


### PR DESCRIPTION
# Summary
We added API endpoints to do a resource count, and return a key:value pair of resourceTypes and their counts. 
## New behavior
New endpoint exists that gets a key:value pair of resourceTypes and their counts. 
## Code changes

Code changes made to:
- database/dbOperations.js, server/server.js and new files created to handle the new endpoint
- controllers/resourcecount.controller.js
- new function getAllResourceCounts() that retrieves all resource counts from db, then formats and returns them as key:value pairs
- services/resourcecount.service.js
- test/services/resourcecount.service.test.js

# Testing guidance
- GET request: http://localhost:3000/4_0_1/resourceCount
- Run unit tests