### PR TITLE
enable cors exposedHeaders for frontend use

### DIFF
--- a/src/server/server.js
+++ b/src/server/server.js
@@ -36,7 +36,7 @@ class DEQMServer extends Server {
   }
 
   enableCors() {
-    this.app.use(cors());
+    this.app.use(cors({ exposedHeaders: 'Location' }));
     return this;
   }
 }


### PR DESCRIPTION
# Summary
cors use was updated to allow the frontend to access Location from a POST request response Header

## New behavior
POST request origin can access the response's header's location attribute

## Code changes
**src/server/server.js** - one line was edited

# Testing guidance
not unit tested
