### PR TITLE
Add check to make sure resourceType matches expected type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -117,9 +117,9 @@
           }
         },
         "sanitize-html": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.7.0.tgz",
-          "integrity": "sha512-jfQelabOn5voO7FAfnQF7v+jsA6z9zC/O4ec0z3E35XPEtHYJT/OdUziVWlKW4irCr2kXaQAyXTXDHWAibg1tA==",
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.7.1.tgz",
+          "integrity": "sha512-oOpe8l4J8CaBk++2haoN5yNI5beekjuHv3JRPKUx/7h40Rdr85pemn4NkvUB3TcBP7yjat574sPlcMAyv4UQig==",
           "requires": {
             "deepmerge": "^4.2.2",
             "escape-string-regexp": "^4.0.0",
@@ -1255,9 +1255,9 @@
           }
         },
         "sanitize-html": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.7.0.tgz",
-          "integrity": "sha512-jfQelabOn5voO7FAfnQF7v+jsA6z9zC/O4ec0z3E35XPEtHYJT/OdUziVWlKW4irCr2kXaQAyXTXDHWAibg1tA==",
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.7.1.tgz",
+          "integrity": "sha512-oOpe8l4J8CaBk++2haoN5yNI5beekjuHv3JRPKUx/7h40Rdr85pemn4NkvUB3TcBP7yjat574sPlcMAyv4UQig==",
           "requires": {
             "deepmerge": "^4.2.2",
             "escape-string-regexp": "^4.0.0",
@@ -6565,7 +6565,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-inspect": {
       "version": "1.12.0",

--- a/src/services/base.service.js
+++ b/src/services/base.service.js
@@ -11,7 +11,12 @@ const {
   findResourcesWithAggregation
 } = require('../database/dbOperations');
 const { checkProvenanceHeader, populateProvenanceTarget } = require('../util/provenanceUtils');
-const { checkSupportedResource, checkContentTypeHeader, getCurrentInstant } = require('../util/baseUtils');
+const {
+  checkSupportedResource,
+  checkContentTypeHeader,
+  getCurrentInstant,
+  checkExpectedResource
+} = require('../util/baseUtils');
 const logger = require('../server/logger.js');
 
 /**
@@ -89,6 +94,7 @@ const baseCreate = async ({ req }, resourceType) => {
   checkContentTypeHeader(req.headers);
   const data = req.body;
   checkSupportedResource(data.resourceType);
+  checkExpectedResource(data.resourceType, resourceType);
   //Create a new id regardless of whether one is passed
   data['id'] = uuidv4();
   //lastUpdated should be second because it should overwrite a meta.lastUpdated tag in the request body
@@ -212,6 +218,7 @@ const baseUpdate = async (args, { req }, resourceType) => {
   checkContentTypeHeader(req.headers);
   const data = req.body;
   checkSupportedResource(data.resourceType);
+  checkExpectedResource(data.resourceType, resourceType);
   //The user passes in an id in the request body and it doesn't match the id arg in the url
   //or user doesn't pass in body
   if (data.id !== args.id) {

--- a/src/util/baseUtils.js
+++ b/src/util/baseUtils.js
@@ -13,6 +13,18 @@ function checkSupportedResource(resourceType) {
 }
 
 /**
+ * Determines whether the passed in resourceType is one matches a given type.
+ * Throws an error if not.
+ * @param {string} resourceType A string representing a FHIR resource type
+ * @param {string} expectedResourceType A string representing a FHIR resource type
+ */
+function checkExpectedResource(resourceType, expectedResourceType) {
+  if (resourceType !== expectedResourceType) {
+    throw new BadRequestError(`Expected resourceType '${expectedResourceType}' in body. Received '${resourceType}'.`);
+  }
+}
+
+/**
  * Checks if the content-type header is incorrect and throws an error with guidance if so
  * @param {Object} requestHeaders the headers from the request body
  */
@@ -36,4 +48,4 @@ const getCurrentInstant = () => {
   return event.toISOString();
 };
 
-module.exports = { checkSupportedResource, checkContentTypeHeader, getCurrentInstant };
+module.exports = { checkSupportedResource, checkExpectedResource, checkContentTypeHeader, getCurrentInstant };

--- a/test/services/base.service.test.js
+++ b/test/services/base.service.test.js
@@ -157,6 +157,21 @@ describe('base.service', () => {
           );
         });
     });
+
+    test('test create with incorrect resourceType in provided resource', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/Library')
+        .send(testPatient)
+        .set('Accept', 'application/json+fhir')
+        .set('content-type', 'application/json+fhir')
+        .expect(400)
+        .then(response => {
+          expect(response.body.issue[0].code).toEqual('BadRequest');
+          expect(response.body.issue[0].details.text).toEqual(
+            `Expected resourceType 'Library' in body. Received 'Patient'.`
+          );
+        });
+    });
   });
   describe('update', () => {
     test('test update with populated provenance target throws error', async () => {
@@ -245,6 +260,21 @@ describe('base.service', () => {
         .then(response => {
           expect(response.headers.location).toBeDefined();
           expect(JSON.parse(response.headers['x-provenance']).target).toEqual([{ reference: 'Patient/testPatient' }]);
+        });
+    });
+
+    test('test update with invalid resourceType, throws 400 error', async () => {
+      await supertest(server.app)
+        .put('/4_0_1/Library/testLibrary')
+        .send({ resourceType: 'Patient', id: 'testLibrary' })
+        .set('Accept', 'application/json+fhir')
+        .set('content-type', 'application/json+fhir')
+        .expect(400)
+        .then(response => {
+          expect(response.body.issue[0].code).toEqual('BadRequest');
+          expect(response.body.issue[0].details.text).toEqual(
+            "Expected resourceType 'Library' in body. Received 'Patient'."
+          );
         });
     });
 


### PR DESCRIPTION
# Summary
Checks that the resourceType of the provided resource matches the expected resourceType for the given resource service/url on create and update calls.

## New behavior
Now returns 400 BadRequest if the resourceType in the body does not match the resourceType of the url.

## Code changes
Added common comparison function that throws an error if the resourceType does not match the expected resourceType. Use that function in baseCreate and baseUpdate functions.

# Testing guidance
- Run unit tests.
- Attempt to POST a mismatch resource. ex. A Patient resource as the body of a request to `/4_0_1/Library` 
  - Response should be 400 and indicate the wrong resource type was found in the body.
- Attempt to PUT a mismatch resource. ex. A Observation resource as the body of a request to `/4_0_1/Patient` 
  - Response should be 400 and indicate the wrong resource type was found in the body.