### PR TITLE
Search Pagination Links

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+coverage

--- a/src/services/base.service.js
+++ b/src/services/base.service.js
@@ -234,6 +234,7 @@ const baseSearch = async (args, { req }, resourceType, paramDefs) => {
       }
 
       // last page
+      searchParams.set('page', numberOfPages);
       links.push({
         relation: 'last',
         url: new url.URL(`${resourceType}?${searchParams}`, `http://${req.headers.host}/${args.base_version}/`)

--- a/test/services/base.service.test.js
+++ b/test/services/base.service.test.js
@@ -57,6 +57,19 @@ describe('base.service', () => {
   });
 
   describe('search', () => {
+    beforeEach(async () => {
+      // create a bunch of observations for testing pagination
+      const extraObservations = [];
+      for (let i = 0; i < 25; i++) {
+        extraObservations.push({
+          resourceType: 'Observation',
+          id: `observation${i}`,
+          status: 'final'
+        });
+      }
+      await testSetup(extraObservations);
+    });
+
     test('test search with correct args and headers', async () => {
       await supertest(server.app)
         .get('/4_0_1/Patient')
@@ -82,6 +95,103 @@ describe('base.service', () => {
           ]);
           expect(response.body.entry[0].resource.id).toEqual(testPatient.id);
           expect(response.body.entry[0].resource.resourceType).toEqual('Patient');
+        });
+    });
+
+    test('test search with enough data for pagination', async () => {
+      await supertest(server.app)
+        .get('/4_0_1/Observation')
+        .set('Accept', 'application/json+fhir')
+        .expect(200)
+        .then(response => {
+          expect(response.body.resourceType).toEqual('Bundle');
+          expect(response.body.type).toEqual('searchset');
+          expect(response.body.total).toEqual(25);
+          expect(response.body.link).toEqual([
+            {
+              relation: 'self',
+              url: expect.stringMatching(/\/4_0_1\/Observation$/)
+            },
+            {
+              relation: 'first',
+              url: expect.stringMatching(/\/4_0_1\/Observation\?page=1$/)
+            },
+            {
+              relation: 'next',
+              url: expect.stringMatching(/\/4_0_1\/Observation\?page=2$/)
+            },
+            {
+              relation: 'last',
+              url: expect.stringMatching(/\/4_0_1\/Observation\?page=3$/)
+            }
+          ]);
+          expect(response.body.entry.length).toEqual(10);
+        });
+    });
+
+    test('test search with enough data for pagination on second page', async () => {
+      await supertest(server.app)
+        .get('/4_0_1/Observation?page=2')
+        .set('Accept', 'application/json+fhir')
+        .expect(200)
+        .then(response => {
+          expect(response.body.resourceType).toEqual('Bundle');
+          expect(response.body.type).toEqual('searchset');
+          expect(response.body.total).toEqual(25);
+          expect(response.body.link).toEqual([
+            {
+              relation: 'self',
+              url: expect.stringMatching(/\/4_0_1\/Observation\?page=2$/)
+            },
+            {
+              relation: 'first',
+              url: expect.stringMatching(/\/4_0_1\/Observation\?page=1$/)
+            },
+            {
+              relation: 'previous',
+              url: expect.stringMatching(/\/4_0_1\/Observation\?page=1$/)
+            },
+            {
+              relation: 'next',
+              url: expect.stringMatching(/\/4_0_1\/Observation\?page=3$/)
+            },
+            {
+              relation: 'last',
+              url: expect.stringMatching(/\/4_0_1\/Observation\?page=3$/)
+            }
+          ]);
+          expect(response.body.entry.length).toEqual(10);
+        });
+    });
+
+    test('test search with enough data for pagination on last page', async () => {
+      await supertest(server.app)
+        .get('/4_0_1/Observation?page=3')
+        .set('Accept', 'application/json+fhir')
+        .expect(200)
+        .then(response => {
+          expect(response.body.resourceType).toEqual('Bundle');
+          expect(response.body.type).toEqual('searchset');
+          expect(response.body.total).toEqual(25);
+          expect(response.body.link).toEqual([
+            {
+              relation: 'self',
+              url: expect.stringMatching(/\/4_0_1\/Observation\?page=3$/)
+            },
+            {
+              relation: 'first',
+              url: expect.stringMatching(/\/4_0_1\/Observation\?page=1$/)
+            },
+            {
+              relation: 'previous',
+              url: expect.stringMatching(/\/4_0_1\/Observation\?page=2$/)
+            },
+            {
+              relation: 'last',
+              url: expect.stringMatching(/\/4_0_1\/Observation\?page=3$/)
+            }
+          ]);
+          expect(response.body.entry.length).toEqual(5);
         });
     });
 

--- a/test/services/base.service.test.js
+++ b/test/services/base.service.test.js
@@ -57,19 +57,6 @@ describe('base.service', () => {
   });
 
   describe('search', () => {
-    beforeEach(async () => {
-      // create a bunch of observations for testing pagination
-      const extraObservations = [];
-      for (let i = 0; i < 25; i++) {
-        extraObservations.push({
-          resourceType: 'Observation',
-          id: `observation${i}`,
-          status: 'final'
-        });
-      }
-      await testSetup(extraObservations);
-    });
-
     test('test search with correct args and headers', async () => {
       await supertest(server.app)
         .get('/4_0_1/Patient')
@@ -98,101 +85,116 @@ describe('base.service', () => {
         });
     });
 
-    test('test search with enough data for pagination', async () => {
-      await supertest(server.app)
-        .get('/4_0_1/Observation')
-        .set('Accept', 'application/json+fhir')
-        .expect(200)
-        .then(response => {
-          expect(response.body.resourceType).toEqual('Bundle');
-          expect(response.body.type).toEqual('searchset');
-          expect(response.body.total).toEqual(25);
-          expect(response.body.link).toEqual([
-            {
-              relation: 'self',
-              url: expect.stringMatching(/\/4_0_1\/Observation$/)
-            },
-            {
-              relation: 'first',
-              url: expect.stringMatching(/\/4_0_1\/Observation\?page=1$/)
-            },
-            {
-              relation: 'next',
-              url: expect.stringMatching(/\/4_0_1\/Observation\?page=2$/)
-            },
-            {
-              relation: 'last',
-              url: expect.stringMatching(/\/4_0_1\/Observation\?page=3$/)
-            }
-          ]);
-          expect(response.body.entry.length).toEqual(10);
-        });
-    });
+    describe('with pagination', () => {
+      beforeEach(async () => {
+        // create a bunch of observations for testing pagination
+        const extraObservations = [];
+        for (let i = 0; i < 25; i++) {
+          extraObservations.push({
+            resourceType: 'Observation',
+            id: `observation${i}`,
+            status: 'final'
+          });
+        }
+        await testSetup(extraObservations);
+      });
 
-    test('test search with enough data for pagination on second page', async () => {
-      await supertest(server.app)
-        .get('/4_0_1/Observation?page=2')
-        .set('Accept', 'application/json+fhir')
-        .expect(200)
-        .then(response => {
-          expect(response.body.resourceType).toEqual('Bundle');
-          expect(response.body.type).toEqual('searchset');
-          expect(response.body.total).toEqual(25);
-          expect(response.body.link).toEqual([
-            {
-              relation: 'self',
-              url: expect.stringMatching(/\/4_0_1\/Observation\?page=2$/)
-            },
-            {
-              relation: 'first',
-              url: expect.stringMatching(/\/4_0_1\/Observation\?page=1$/)
-            },
-            {
-              relation: 'previous',
-              url: expect.stringMatching(/\/4_0_1\/Observation\?page=1$/)
-            },
-            {
-              relation: 'next',
-              url: expect.stringMatching(/\/4_0_1\/Observation\?page=3$/)
-            },
-            {
-              relation: 'last',
-              url: expect.stringMatching(/\/4_0_1\/Observation\?page=3$/)
-            }
-          ]);
-          expect(response.body.entry.length).toEqual(10);
-        });
-    });
+      test('test search with enough data for pagination', async () => {
+        await supertest(server.app)
+          .get('/4_0_1/Observation')
+          .set('Accept', 'application/json+fhir')
+          .expect(200)
+          .then(response => {
+            expect(response.body.resourceType).toEqual('Bundle');
+            expect(response.body.type).toEqual('searchset');
+            expect(response.body.total).toEqual(25);
+            expect(response.body.link).toEqual([
+              {
+                relation: 'self',
+                url: expect.stringMatching(/\/4_0_1\/Observation$/)
+              },
+              {
+                relation: 'first',
+                url: expect.stringMatching(/\/4_0_1\/Observation\?page=1$/)
+              },
+              {
+                relation: 'next',
+                url: expect.stringMatching(/\/4_0_1\/Observation\?page=2$/)
+              },
+              {
+                relation: 'last',
+                url: expect.stringMatching(/\/4_0_1\/Observation\?page=3$/)
+              }
+            ]);
+            expect(response.body.entry.length).toEqual(10);
+          });
+      });
 
-    test('test search with enough data for pagination on last page', async () => {
-      await supertest(server.app)
-        .get('/4_0_1/Observation?page=3')
-        .set('Accept', 'application/json+fhir')
-        .expect(200)
-        .then(response => {
-          expect(response.body.resourceType).toEqual('Bundle');
-          expect(response.body.type).toEqual('searchset');
-          expect(response.body.total).toEqual(25);
-          expect(response.body.link).toEqual([
-            {
-              relation: 'self',
-              url: expect.stringMatching(/\/4_0_1\/Observation\?page=3$/)
-            },
-            {
-              relation: 'first',
-              url: expect.stringMatching(/\/4_0_1\/Observation\?page=1$/)
-            },
-            {
-              relation: 'previous',
-              url: expect.stringMatching(/\/4_0_1\/Observation\?page=2$/)
-            },
-            {
-              relation: 'last',
-              url: expect.stringMatching(/\/4_0_1\/Observation\?page=3$/)
-            }
-          ]);
-          expect(response.body.entry.length).toEqual(5);
-        });
+      test('test search with enough data for pagination on second page', async () => {
+        await supertest(server.app)
+          .get('/4_0_1/Observation?page=2')
+          .set('Accept', 'application/json+fhir')
+          .expect(200)
+          .then(response => {
+            expect(response.body.resourceType).toEqual('Bundle');
+            expect(response.body.type).toEqual('searchset');
+            expect(response.body.total).toEqual(25);
+            expect(response.body.link).toEqual([
+              {
+                relation: 'self',
+                url: expect.stringMatching(/\/4_0_1\/Observation\?page=2$/)
+              },
+              {
+                relation: 'first',
+                url: expect.stringMatching(/\/4_0_1\/Observation\?page=1$/)
+              },
+              {
+                relation: 'previous',
+                url: expect.stringMatching(/\/4_0_1\/Observation\?page=1$/)
+              },
+              {
+                relation: 'next',
+                url: expect.stringMatching(/\/4_0_1\/Observation\?page=3$/)
+              },
+              {
+                relation: 'last',
+                url: expect.stringMatching(/\/4_0_1\/Observation\?page=3$/)
+              }
+            ]);
+            expect(response.body.entry.length).toEqual(10);
+          });
+      });
+
+      test('test search with enough data for pagination on last page', async () => {
+        await supertest(server.app)
+          .get('/4_0_1/Observation?page=3')
+          .set('Accept', 'application/json+fhir')
+          .expect(200)
+          .then(response => {
+            expect(response.body.resourceType).toEqual('Bundle');
+            expect(response.body.type).toEqual('searchset');
+            expect(response.body.total).toEqual(25);
+            expect(response.body.link).toEqual([
+              {
+                relation: 'self',
+                url: expect.stringMatching(/\/4_0_1\/Observation\?page=3$/)
+              },
+              {
+                relation: 'first',
+                url: expect.stringMatching(/\/4_0_1\/Observation\?page=1$/)
+              },
+              {
+                relation: 'previous',
+                url: expect.stringMatching(/\/4_0_1\/Observation\?page=2$/)
+              },
+              {
+                relation: 'last',
+                url: expect.stringMatching(/\/4_0_1\/Observation\?page=3$/)
+              }
+            ]);
+            expect(response.body.entry.length).toEqual(5);
+          });
+      });
     });
 
     test('test search with unsupported parameter', async () => {

--- a/test/services/base.service.test.js
+++ b/test/services/base.service.test.js
@@ -97,7 +97,7 @@ describe('base.service', () => {
           });
         }
         await testSetup(extraObservations);
-      });
+      }, 10000); // give extra time for this to happen because it takes ~5 sec
 
       test('test search with enough data for pagination', async () => {
         await supertest(server.app)

--- a/test/services/base.service.test.js
+++ b/test/services/base.service.test.js
@@ -66,6 +66,20 @@ describe('base.service', () => {
           expect(response.body.resourceType).toEqual('Bundle');
           expect(response.body.type).toEqual('searchset');
           expect(response.body.total).toEqual(2);
+          expect(response.body.link).toEqual([
+            {
+              relation: 'self',
+              url: expect.stringMatching(/\/4_0_1\/Patient$/)
+            },
+            {
+              relation: 'first',
+              url: expect.stringMatching(/\/4_0_1\/Patient\?page=1$/)
+            },
+            {
+              relation: 'last',
+              url: expect.stringMatching(/\/4_0_1\/Patient\?page=1$/)
+            }
+          ]);
           expect(response.body.entry[0].resource.id).toEqual(testPatient.id);
           expect(response.body.entry[0].resource.resourceType).toEqual('Patient');
         });


### PR DESCRIPTION
# Summary
Pagination of search results was already working. This just adds the links to the searchset bundle so they can easily be used.

## New behavior
`link` attribute in searchset bundle resources is now populated with the `self`, `first`, `previous`, `next`, `last` links as appropiate. For example, on page 3 of 11:

```json
{
  "link": [
    {
      "relation": "self",
      "url": "http://localhost:3000/4_0_1/ValueSet?page=3"
    },
    {
      "relation": "first",
      "url": "http://localhost:3000/4_0_1/ValueSet?page=1"
    },
    {
      "relation": "previous",
      "url": "http://localhost:3000/4_0_1/ValueSet?page=2"
    },
    {
      "relation": "next",
      "url": "http://localhost:3000/4_0_1/ValueSet?page=4"
    },
    {
      "relation": "last",
      "url": "http://localhost:3000/4_0_1/ValueSet?page=11"
    }
  ]
}
```

## Code changes
Added link creation to the search result bundle creation using the existing data from returned results from mongo queries.

# Testing guidance
- Load database with more than 10 of any resource type. Connectahon load should do this for ValueSets.
- Run search on the large resource type. Make sure all appropriate links are in results. 
  - Page sizes are 10 resources and 1 indexed.