### PR TITLE
Fix evaluate-measure reportType option

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,8 @@ Optional parameters include:
 
 - `practitioner`: practitioner for which the measure will be calculated
 
-Currently, `measure` and `lastReceivedOn` parameters are not supported by the test server. The `subject-list` `reportType` is not supported by the test server - only `subject` and `population` `reportTypes` are supported at this time.
+Currently, `measure` and `lastReceivedOn` parameters are not supported by the test server. The `subject-list` `reportType` is not supported by the test server - only `subject` and `population` `reportTypes` are supported at this time,
+which will generate `individual` and `summary` `MeasureReport`s respectively.
 
 To use, first POST a measure bundle into your database, then send a GET request to `http://localhost:3000/4_0_1/Measure/<your-measure-id>/$evaluate-measure` with the required parameters.
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Optional parameters include:
 
 - `practitioner`: practitioner for which the measure will be calculated
 
-Currently, `measure` and `lastReceivedOn` parameters are not supported by the test server. The `subject-list` `reportType` is not supported by the test server - only `individual` and `population` `reportTypes` are supported at this time.
+Currently, `measure` and `lastReceivedOn` parameters are not supported by the test server. The `subject-list` `reportType` is not supported by the test server - only `subject` and `population` `reportTypes` are supported at this time.
 
 To use, first POST a measure bundle into your database, then send a GET request to `http://localhost:3000/4_0_1/Measure/<your-measure-id>/$evaluate-measure` with the required parameters.
 

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -245,9 +245,17 @@ const evaluateMeasure = async (args, { req }) => {
   // or using unsupported report type
   validateEvalMeasureParams(req.query);
 
-  return req.query.reportType === 'population'
-    ? evaluateMeasureForPopulation(args, { req })
-    : evaluateMeasureForIndividual(args, { req });
+  const { reportType, subject } = req.query;
+
+  // If reportType is not specified, default to 'subject', but
+  // only if the 'subject' parameter is also specificed
+  if (reportType === 'subject' || (reportType == null && subject != null)) {
+    logger.debug('Evaluating measure for individual');
+    return evaluateMeasureForIndividual(args, { req });
+  }
+
+  logger.debug('Evaluating measure for population');
+  return evaluateMeasureForPopulation(args, { req });
 };
 
 /**

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -337,7 +337,7 @@ const evaluateMeasureForIndividual = async (args, { req }) => {
     measurementPeriodEnd: req.query.periodEnd
   });
 
-  const { periodStart, periodEnd, reportType = 'individual', subject, practitioner } = req.query;
+  const { periodStart, periodEnd, subject, practitioner } = req.query;
   let patientBundle;
   if (practitioner) {
     let patientId = subject;
@@ -366,7 +366,7 @@ const evaluateMeasureForIndividual = async (args, { req }) => {
   const { results } = await Calculator.calculateMeasureReports(measureBundle, [patientBundle], {
     measurementPeriodStart: periodStart,
     measurementPeriodEnd: periodEnd,
-    reportType: reportType
+    reportType: 'individual'
   });
   return results[0];
 };

--- a/src/util/operationValidationUtils.js
+++ b/src/util/operationValidationUtils.js
@@ -22,9 +22,9 @@ function validateEvalMeasureParams(query) {
     throw new BadRequestError(`reportType ${query.reportType} is not supported for $evaluate-measure`);
   }
 
-  if (!query.subject && query.reportType !== 'population') {
+  if (!query.subject && query.reportType === 'subject') {
     throw new BadRequestError(
-      `Must specify subject for all $evaluate-measure requests with reportType parameter: ${query.reportType}`
+      `Must specify subject for all $evaluate-measure requests with reportType parameter: subject`
     );
   }
 

--- a/src/util/operationValidationUtils.js
+++ b/src/util/operationValidationUtils.js
@@ -18,7 +18,7 @@ function validateEvalMeasureParams(query) {
   }
 
   // returns unsupported report type that is included in the http request
-  if (!['individual', 'population', 'subject-list', undefined].includes(query.reportType)) {
+  if (!['subject', 'population', 'subject-list', undefined].includes(query.reportType)) {
     throw new BadRequestError(`reportType ${query.reportType} is not supported for $evaluate-measure`);
   }
 
@@ -37,11 +37,11 @@ function validateEvalMeasureParams(query) {
     }
   }
 
-  if (query.reportType === 'individual') {
+  if (query.reportType === 'subject') {
     const subjectReference = query.subject.split('/');
     if (subjectReference.length > 1 && subjectReference[0] !== 'Patient') {
       throw new BadRequestError(
-        `For report type 'individual', subject reference may only be a Patient resource of format "Patient/{id}".`
+        `For report type 'subject', subject reference may only be a Patient resource of format "Patient/{id}".`
       );
     }
   }

--- a/src/util/operationValidationUtils.js
+++ b/src/util/operationValidationUtils.js
@@ -24,7 +24,7 @@ function validateEvalMeasureParams(query) {
 
   if (!query.subject && query.reportType !== 'population') {
     throw new BadRequestError(
-      `Must specify subject for all $evaluate-measure requests with reportType: ${query.reportType}`
+      `Must specify subject for all $evaluate-measure requests with reportType parameter: ${query.reportType}`
     );
   }
 
@@ -32,7 +32,7 @@ function validateEvalMeasureParams(query) {
     const subjectReference = query.subject.split('/');
     if (subjectReference.length !== 2 || subjectReference[0] !== 'Group') {
       throw new BadRequestError(
-        `For report type 'population', subject may only be a Group resource of format "Group/{id}".`
+        `For reportType parameter 'population', subject may only be a Group resource of format "Group/{id}".`
       );
     }
   }
@@ -41,7 +41,7 @@ function validateEvalMeasureParams(query) {
     const subjectReference = query.subject.split('/');
     if (subjectReference.length > 1 && subjectReference[0] !== 'Patient') {
       throw new BadRequestError(
-        `For report type 'subject', subject reference may only be a Patient resource of format "Patient/{id}".`
+        `For reportType parameter 'subject', subject reference may only be a Patient resource of format "Patient/{id}".`
       );
     }
   }

--- a/test/services/measure.service.test.js
+++ b/test/services/measure.service.test.js
@@ -361,7 +361,7 @@ describe('measure.service', () => {
         .query({
           periodStart: '01-01-2020',
           periodEnd: '01-01-2021',
-          reportType: 'individual',
+          reportType: 'subject',
           subject: 'testPatient',
           practitioner: 'Practitioner/testPractitioner'
         })
@@ -466,7 +466,7 @@ describe('measure.service', () => {
       await supertest(server.app)
         .get('/4_0_1/Measure/testMeasure/$evaluate-measure')
         .query({
-          reportType: 'individual',
+          reportType: 'subject',
           periodStart: '01-01-2020',
           periodEnd: '01-01-2021',
           subject: 'testPatient',

--- a/test/util/operationValidationUtils.test.js
+++ b/test/util/operationValidationUtils.test.js
@@ -152,7 +152,7 @@ describe('validateEvalMeasureParams', () => {
 
   test('error thrown for missing subject for $evaluate-measure', () => {
     const MISSING_SUBJECT_REQ = {
-      query: { reportType: 'individual', periodStart: '2019-01-01', periodEnd: '2019-12-31' }
+      query: { reportType: 'subject', periodStart: '2019-01-01', periodEnd: '2019-12-31' }
     };
     try {
       validateEvalMeasureParams(MISSING_SUBJECT_REQ.query);
@@ -160,7 +160,7 @@ describe('validateEvalMeasureParams', () => {
     } catch (e) {
       expect(e.statusCode).toEqual(400);
       expect(e.issue[0].details.text).toEqual(
-        `Must specify subject for all $evaluate-measure requests with reportType: individual`
+        `Must specify subject for all $evaluate-measure requests with reportType: subject`
       );
     }
   });
@@ -185,10 +185,10 @@ describe('validateEvalMeasureParams', () => {
     }
   });
 
-  test('error thrown for individual $evaluate-measure with non-Patient reference subject', () => {
+  test('error thrown for subject $evaluate-measure with non-Patient reference subject', () => {
     const INDIVIDUAL_REQ = {
       query: {
-        reportType: 'individual',
+        reportType: 'subject',
         periodStart: '2019-01-01',
         periodEnd: '2019-12-31',
         subject: 'Group/testGroup'
@@ -196,11 +196,11 @@ describe('validateEvalMeasureParams', () => {
     };
     try {
       validateEvalMeasureParams(INDIVIDUAL_REQ.query);
-      expect.fail('validateEvalMeasureParams failed to throw error for individual report with non-Patient subject');
+      expect.fail('validateEvalMeasureParams failed to throw error for subject report with non-Patient subject');
     } catch (e) {
       expect(e.statusCode).toEqual(400);
       expect(e.issue[0].details.text).toEqual(
-        `For report type 'individual', subject reference may only be a Patient resource of format "Patient/{id}".`
+        `For report type 'subject', subject reference may only be a Patient resource of format "Patient/{id}".`
       );
     }
   });
@@ -208,7 +208,7 @@ describe('validateEvalMeasureParams', () => {
   test('should throw error for invalid Practitioner reference', () => {
     try {
       validateEvalMeasureParams({
-        reportType: 'individual',
+        reportType: 'subject',
         periodStart: '2019-01-01',
         periodEnd: '2019-12-31',
         subject: 'Patient/testPatient',

--- a/test/util/operationValidationUtils.test.js
+++ b/test/util/operationValidationUtils.test.js
@@ -160,7 +160,7 @@ describe('validateEvalMeasureParams', () => {
     } catch (e) {
       expect(e.statusCode).toEqual(400);
       expect(e.issue[0].details.text).toEqual(
-        `Must specify subject for all $evaluate-measure requests with reportType: subject`
+        `Must specify subject for all $evaluate-measure requests with reportType parameter: subject`
       );
     }
   });
@@ -180,7 +180,7 @@ describe('validateEvalMeasureParams', () => {
     } catch (e) {
       expect(e.statusCode).toEqual(400);
       expect(e.issue[0].details.text).toEqual(
-        `For report type 'population', subject may only be a Group resource of format "Group/{id}".`
+        `For reportType parameter 'population', subject may only be a Group resource of format "Group/{id}".`
       );
     }
   });
@@ -196,11 +196,13 @@ describe('validateEvalMeasureParams', () => {
     };
     try {
       validateEvalMeasureParams(INDIVIDUAL_REQ.query);
-      expect.fail('validateEvalMeasureParams failed to throw error for subject report with non-Patient subject');
+      expect.fail(
+        'validateEvalMeasureParams failed to throw error for subject report type parameter with non-Patient subject'
+      );
     } catch (e) {
       expect(e.statusCode).toEqual(400);
       expect(e.issue[0].details.text).toEqual(
-        `For report type 'subject', subject reference may only be a Patient resource of format "Patient/{id}".`
+        `For reportType parameter 'subject', subject reference may only be a Patient resource of format "Patient/{id}".`
       );
     }
   });


### PR DESCRIPTION
individual -> subject in all uses, docs, and tests.

Note that fqm-execution still requires a reportType of `individual` in its calculation options. This is fine.
