### PR TITLE
Fix updating resource logic

### DIFF
--- a/src/database/dbOperations.js
+++ b/src/database/dbOperations.js
@@ -74,17 +74,18 @@ const findResourceIdsWithQuery = async (query, resourceType) => {
 const updateResource = async (id, data, resourceType) => {
   const collection = db.collection(resourceType);
   logger.debug(`Finding and updating ${resourceType}/${data.id} in database`);
-  const results = await collection.findOneAndUpdate({ id: id }, { $set: data }, { upsert: true });
+
+  const results = await collection.replaceOne({ id }, data, { upsert: true });
 
   // If the document cannot be created with the passed id, Mongo will throw an error
   // before here, so should be ok to just return the passed id
-  if (results.value === null) {
-    // null value indicates a newly created document
-    return { id: id, created: true };
+  // upsertedCount indicates that we have created a brand new document
+  if (results.upsertedCount === 1) {
+    return { id, created: true };
   }
 
   // value being present indicates an update, so set created flag to false
-  return { id: results.value.id, created: false };
+  return { id, created: false };
 };
 
 /**

--- a/test/services/measure.service.test.js
+++ b/test/services/measure.service.test.js
@@ -22,8 +22,6 @@ const { initialize } = require('../../src/server/server');
 const { SINGLE_AGENT_PROVENANCE } = require('../fixtures/provenanceFixtures');
 const testParamResource = require('../fixtures/fhir-resources/parameters/paramNoExportResource.json');
 
-const updateMeasure = { resourceType: 'Measure', id: 'testMeasure', name: 'anUpdate' };
-
 let server;
 
 describe('measure.service', () => {

--- a/test/services/measure.service.test.js
+++ b/test/services/measure.service.test.js
@@ -69,19 +69,6 @@ describe('measure.service', () => {
         });
     });
 
-    test('test update with correctHeaders and the id is in database returns 200', async () => {
-      await supertest(server.app)
-        .put('/4_0_1/Measure/testMeasure')
-        .send(updateMeasure)
-        .set('Accept', 'application/json+fhir')
-        .set('content-type', 'application/json+fhir')
-        .set('x-provenance', JSON.stringify(SINGLE_AGENT_PROVENANCE))
-        .expect(200)
-        .then(response => {
-          expect(response.headers.location).toBeDefined();
-        });
-    });
-
     test('removing the measure from the database when the measure is indeed present returns 204', async () => {
       await supertest(server.app).delete('/4_0_1/Measure/deleteMeasure').expect(204);
     });


### PR DESCRIPTION
# Summary

we were using findOneAndUpdate which didn't allow you to remove properties from resources. We wanted `replaceOne` instead. Rest is the same

## New behavior

Removing property during a PUT request from an existing resource now works

## Code changes

* Change to replaceOne
* Add test case for it
* Remove crazy test case in measure.service that had insane side effects (not sorry)

# Testing guidance

Sent PUT for a new resource. Should upsert as before

Send a PUT to modify that resource to add a property to it. Should work

Send a PUT to modify that resource to modify an existing property. Should work

Send a PUT to modify that resource to *delete* an existing property. Should work
