### PR TITLE
Ecqm-content-r4-2021 upload script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 .vscode/
 connectathon
+ecqm-content-r4-2021
 coverage
 docker_ssl_setup.sh
 tmp

--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ The following `npm` commands can be used to set up the database:
 - `npm run db:setup` creates collections for all the valid FHIR resource types
 - `npm run db:delete` deletes all existing collections in the database
 - `npm run db:reset` runs both of the above, deleting all current collections and then creating new, empty collections
-- To upload all the Connectathon measure bundles, `git clone` the [Connectathon repository](https://github.com/DBCG/connectathon) into the root directory of the `deqm-test-server` repository. Run `npm run connectathon-upload`. This runs a script that uploads all the Connectathon bundle resources to the appropriate Mongo collections.
+- To upload all the ecqm-content-r4-2021 measure bundles, `git clone` the [ecqm-content-r4-2021 repo](https://github.com/cqframework/ecqm-content-r4-2021) into the root directory of the `deqm-test-server` repository. Run `npm run upload-bundles`. This runs a script that uploads all the measure bundle resources to the appropriate Mongo collections.
+- The full CLI function signature of `upload-bundles` script is `npm run upload-bundles [dirPath] [searchPattern]`. The command can be run more dynamically by specifying a `dirPath` string which represents the path to a repository that contains the desired bundles for upload. `searchPattern` is a string which is used as a regex to filter bundle files for upload by file name. Example: `npm run upload-bundles connectathon/fhir401/bundles/measure "^EXM124.*-bundle.json"`
 
 ### CRUD Operations
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "db:delete": "node src/scripts/deleteCollections.js",
     "db:reset": "npm run db:delete && npm run db:setup",
     "parse-references": "node src/scripts/parseCompartmentDefinition.js",
-    "connectathon-upload": "node src/scripts/getConnectathonBundles.js",
+    "upload-bundles": "node src/scripts/uploadPremadeBundles.js",
     "test": "jest --runInBand",
     "test:coverage": "jest --collectCoverage --runInBand",
     "test:watch": "jest --watchAll --runInBand",

--- a/src/scripts/uploadPremadeBundles.js
+++ b/src/scripts/uploadPremadeBundles.js
@@ -4,7 +4,6 @@ const mongoUtil = require('../database/connection');
 const { createResource } = require('../database/dbOperations');
 
 const ecqmContentR4Path = path.resolve(path.join(__dirname, '../../ecqm-content-r4-2021/bundles/measure/'));
-// bundles that are not the latest available version or contain errors that prevent valid gaps calculation
 
 // files containing EXM bundles of interest from specified directory
 const bundleFiles = [];

--- a/src/scripts/uploadPremadeBundles.js
+++ b/src/scripts/uploadPremadeBundles.js
@@ -94,16 +94,19 @@ async function main() {
       );
     }
   }
-
-  const bundlePromises = bundleFiles.map(async filePath => {
+  let filesUploaded = 0;
+  let resourcesUploaded = 0;
+  for (const filePath of bundleFiles) {
     // read each EXM bundle file
     const data = fs.readFileSync(filePath, 'utf8');
     if (data) {
+      console.log(`Uploading ${filePath.split('/').slice(-1)}...`);
       const bundle = JSON.parse(data);
       // retrieve each resource and insert into database
       const uploads = bundle.entry.map(async res => {
         try {
           await createResource(res.resource, res.resource.resourceType);
+          resourcesUploaded += 1;
         } catch (e) {
           // ignore duplicate key errors for Libraries, ValueSets
           if (e.code !== 11000 || res.resource.resourceType === 'Measure') {
@@ -112,10 +115,10 @@ async function main() {
         }
       });
       await Promise.all(uploads);
+      filesUploaded += 1;
     }
-  });
-  await Promise.all(bundlePromises);
-  return `${bundlePromises.length} Bundle entries uploaded.`;
+  }
+  return `${resourcesUploaded} resources uploaded from ${filesUploaded} Bundle files.`;
 }
 
 main()

--- a/src/scripts/uploadPremadeBundles.js
+++ b/src/scripts/uploadPremadeBundles.js
@@ -3,53 +3,46 @@ const path = require('path');
 const mongoUtil = require('../database/connection');
 const { createResource } = require('../database/dbOperations');
 
-const connectathonPath = path.resolve(path.join(__dirname, '../../connectathon/fhir401/bundles/measure/'));
+const ecqmContentR4Path = path.resolve(path.join(__dirname, '../../ecqm-content-r4-2021/bundles/measure/'));
 // bundles that are not the latest available version or contain errors that prevent valid gaps calculation
-const IGNORED_BUNDLES = [
-  'EXM347-3.2.000-bundle.json',
-  'EXM347-4.3.000-bundle.json',
-  'EXM529-1.0.000-bundle.json',
-  'EXM349-2.10.000-bundle.json',
-  'EXM111-9.1.000-bundle.json',
-  'EXM149-9.2.000-bundle.json',
-  'EXM124-8.2.000-bundle.json'
-];
 
-// files containing EXM bundles of interest from connectathon repo
+// files containing EXM bundles of interest from specified directory
 const bundleFiles = [];
 
 /**
- * Retrieves EXM bundle files from the connectathon repo using a regular expression.
+ * Retrieves all measure bundle files from the passed in directory that match the passed in regex
  * Uses recursion to parse through all available subdirectories.
  * @param {string} directory - directory path to start at
+ * @param {string} searchPattern - regex to match potential measure bundle files against
  * @returns {Array} array of string paths that represent the bundle files of interest
  */
-const getConnectathonBundleFiles = directory => {
-  const fileNameRegExp = new RegExp(/(^EXM.*.json$)/);
+const getEcqmBundleFiles = (directory, searchPattern) => {
+  const fileNameRegExp = new RegExp(searchPattern);
   const filesInDirectory = fs.readdirSync(directory);
   filesInDirectory.forEach(file => {
     const absolute = path.join(directory, file);
     if (fs.statSync(absolute).isDirectory()) {
-      getConnectathonBundleFiles(absolute);
-    } else if (fileNameRegExp.test(file) && !IGNORED_BUNDLES.includes(file)) {
+      getEcqmBundleFiles(absolute, searchPattern);
+    } else if (fileNameRegExp.test(file)) {
       bundleFiles.push(absolute);
     }
   });
 };
 
 /**
- * Retrieves EXM bundle files from arbitrary folder using a regular expression.
+ * Retrieves bundle files from arbitrary folder using a regular expression.
  * Uses recursion to parse through all available subdirectories.
- * @param {string} directory - directory path to start at
+ * @param {string} directory - directory path to start a
+ * @param {string} searchPattern - regex to match potential measure bundle files against
  * @returns {Array} array of string paths that represent the bundle files of interest
  */
-const getBundleFiles = directory => {
-  const fileNameRegExp = new RegExp(/.json$/);
+const getBundleFiles = (directory, searchPattern) => {
+  const fileNameRegExp = new RegExp(searchPattern);
   const filesInDirectory = fs.readdirSync(directory);
   filesInDirectory.forEach(file => {
     const absolute = path.join(directory, file);
     if (fs.statSync(absolute).isDirectory()) {
-      getBundleFiles(absolute);
+      getBundleFiles(absolute, searchPattern);
     } else if (
       fileNameRegExp.test(file) &&
       !file.endsWith('MeasureReport.json') &&
@@ -61,34 +54,44 @@ const getBundleFiles = directory => {
 };
 
 /**
- * Uploads all the resources from the connectathon measure bundles into the
+ * Uploads all the resources from the specified directory into the
  * database.
  *
- * TODO: Currently configured for fhir401 connectathon measure bundles,
+ * TODO: Currently configured for ecqm-content-r4-2021 measure bundles,
  * but may want to expand to other measure bundle providers in the future.
  */
 async function main() {
   await mongoUtil.client.connect();
   console.log('Connected successfully to server');
-
-  // if a path is provided
+  // default searchPattern to retrieve all filenames that begin with a capital letter and end with -bundle.json
+  let searchPattern;
+  if (process.argv[3]) {
+    searchPattern = process.argv[3];
+  }
   if (process.argv[2]) {
+    // if a path is provided
     const bundlePath = path.resolve(process.argv[2]);
     try {
+      if (!searchPattern) {
+        searchPattern = /.json$/;
+      }
       console.log(`Finding bundles in ${bundlePath}.`);
-      getBundleFiles(bundlePath);
+      getBundleFiles(bundlePath, searchPattern);
     } catch (e) {
       throw new Error('Provided directory not found.');
     }
 
-    // otherwise load from connectathon
+    // otherwise load from ecqm-content-r4-2021
   } else {
     try {
-      console.log(`Finding bundles in connectathon repo at ${connectathonPath}.`);
-      getConnectathonBundleFiles(connectathonPath);
+      if (!searchPattern) {
+        searchPattern = /^[A-Z].*-bundle.json$/;
+      }
+      console.log(`Finding bundles in ecqm-content-r4-2021 repo at ${ecqmContentR4Path}.`);
+      getEcqmBundleFiles(ecqmContentR4Path, searchPattern);
     } catch (e) {
       throw new Error(
-        'Connectathon directory not found. Git clone the connectathon repo into the root directory and run script again'
+        'ecqm-content-r4-2021 directory not found. Git clone the ecqm-content-r4-2021 repo into the root directory and run script again'
       );
     }
   }


### PR DESCRIPTION
# Summary
Replacing connectathon upload script with ecqm-content-r4-2021 bundles since these are more commonly used nowadays

## New behavior
Renamed `connectathon-upload` script to `upload-bundles`. The script now, when run with no args, pulls all the measure bundles from the `ecqm-content-r4-2021` repo. An optional `dirPath` argument can be provided to specify upload from a different directory, and a `searchPattern` arg can also be included to specify a regex to filter out bundles for upload by file name.

## Code changes
 - `getConnectathonBundles.js` -> `uploadPremadeBundles.js`
 - `connnectathon-upload` -> `upload-bundles`
 - Default `upload-bundles` run now pulls from `ecqm-content-r4-2021` repo
 - Added option to include regex as an arg to filter out files by filename for upload

# Testing guidance
 - Follow instructions in the README.md to upload ecqm-content-r4-2021 bundles and ensure all bundles upload
 - Try running the upload-bundles script with and without `dirPath` and `searchPattern` args and ensure that the results are as expected
