### PR TITLE
Bump fqm-execution to 1.0.0-beta.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3526,9 +3526,9 @@
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
     },
     "fqm-execution": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/fqm-execution/-/fqm-execution-1.0.0-beta.2.tgz",
-      "integrity": "sha512-wXgv+IBKTgGire+WteQ3JIfEIZaT1rp/cHEjPHRtzjTu0B1Y1WD6Cdx+uSgEhTgPCF8Kjki7V9CsV/ySndSLpA==",
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/fqm-execution/-/fqm-execution-1.0.0-beta.3.tgz",
+      "integrity": "sha512-Pz71DjWtqVr9ymltbwRKzXALz3lwH2v/19pDICSIOXbUh2nVimnG7Chv7bqZ4KFAxfX3JuxH/oFsrwpWMcjN8A==",
       "requires": {
         "@types/fhir": "0.0.34",
         "atob": "^2.1.2",
@@ -3538,7 +3538,7 @@
         "cql-execution": "github:projecttacoma/cql-execution",
         "handlebars": "^4.7.7",
         "lodash": "^4.17.21",
-        "moment": "^2.29.3",
+        "moment": "^2.29.4",
         "uuid": "^8.3.1"
       },
       "dependencies": {
@@ -3548,7 +3548,7 @@
           "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
         },
         "cql-exec-fhir": {
-          "version": "github:projecttacoma/cql-exec-fhir#45a03f62c8af2905e562b8b1d4919725d585ce25",
+          "version": "github:projecttacoma/cql-exec-fhir#d48d57c3c7e199cbaa02e41418cad9efcd148b15",
           "from": "github:projecttacoma/cql-exec-fhir",
           "requires": {
             "@babel/runtime": "^7.17.2",
@@ -3574,11 +3574,6 @@
             "@lhncbc/ucum-lhc": "^4.1.3",
             "luxon": "^1.25.0"
           }
-        },
-        "moment": {
-          "version": "2.29.4",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-          "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
         }
       }
     },
@@ -6033,9 +6028,9 @@
       "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "moment-timezone": {
-      "version": "0.5.34",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.34.tgz",
-      "integrity": "sha512-3zAEHh2hKUs3EXLESx/wsgw6IQdusOT8Bxm3D9UrHPQR7zlMmzwybC8zHEM1tQ4LJwP7fcxrWr8tuBg05fFCbg==",
+      "version": "0.5.37",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.37.tgz",
+      "integrity": "sha512-uEDzDNFhfaywRl+vwXxffjjq1q0Vzr+fcQpQ1bU0kbzorfS7zVtZnCnGc8mhWmF39d4g4YriF6kwA75mJKE/Zg==",
       "requires": {
         "moment": ">= 2.9.0"
       }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "cql-exec-fhir-mongo": "git+https://github.com/projecttacoma/cql-exec-fhir-mongo.git",
     "dotenv": "^10.0.0",
     "express": "^4.17.1",
-    "fqm-execution": "^1.0.0-beta.2",
+    "fqm-execution": "^1.0.0-beta.3",
     "lodash": "^4.17.21",
     "mongodb": "^4.1.3",
     "uuid": "^8.3.2",


### PR DESCRIPTION
# Summary
fqm-execution version bump. Also refreshes the package-lock to be using the newer sha512 hashes.

## New behavior

## Code changes

# Testing guidance
