### PR TITLE
Ignore modelinfo dependency and update DB_HOST

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 SERVER_HOST = localhost
 SERVER_PORT = 3000
-DB_HOST = localhost
+DB_HOST = 127.0.0.1
 DB_PORT = 27017
 DB_NAME = deqm-test-server
 KEYCLOAK_VERSION = 15.0.2

--- a/.env.test
+++ b/.env.test
@@ -1,4 +1,4 @@
-DB_HOST = localhost
+DB_HOST = 127.0.0.1
 DB_PORT = 27017
 DB_NAME = deqm-test-server-test
 EXEC_WORKERS = 4

--- a/src/util/bundleUtils.js
+++ b/src/util/bundleUtils.js
@@ -177,8 +177,12 @@ async function getAllDependentLibraries(lib) {
   // This filter checks for the 'Library' keyword on all related artifacts
   // TODO: This filter can probably be improved, but will work in our cases for now
   const depLibUrls = lib.relatedArtifact
-    .filter(ra => ra.type === 'depends-on' && ra.resource.includes('Library') && 
-    ra.resource !== 'http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1') // exclude modelinfo dependency
+    .filter(
+      ra =>
+        ra.type === 'depends-on' &&
+        ra.resource.includes('Library') &&
+        ra.resource !== 'http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1'
+    ) // exclude modelinfo dependency
     .map(ra => ra.resource);
   // Obtain all libraries referenced in the related artifact, and recurse on their dependencies
   const libraryGets = depLibUrls.map(async url => {

--- a/src/util/bundleUtils.js
+++ b/src/util/bundleUtils.js
@@ -177,7 +177,8 @@ async function getAllDependentLibraries(lib) {
   // This filter checks for the 'Library' keyword on all related artifacts
   // TODO: This filter can probably be improved, but will work in our cases for now
   const depLibUrls = lib.relatedArtifact
-    .filter(ra => ra.type === 'depends-on' && ra.resource.includes('Library'))
+    .filter(ra => ra.type === 'depends-on' && ra.resource.includes('Library') && 
+    ra.resource !== 'http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1') // exclude modelinfo dependency
     .map(ra => ra.resource);
   // Obtain all libraries referenced in the related artifact, and recurse on their dependencies
   const libraryGets = depLibUrls.map(async url => {

--- a/test/populateTestData.js
+++ b/test/populateTestData.js
@@ -20,8 +20,10 @@ async function cleanUpTest() {
   if (!!client.topology && client.topology.isConnected()) await cleanUpDb();
   if (fs.existsSync('./tmp/testid')) fs.rmSync('./tmp/testid', { recursive: true });
   if (fs.existsSync('./tmp/COMPLETED_REQUEST')) fs.rmSync('./tmp/COMPLETED_REQUEST', { recursive: true });
-  if (fs.existsSync('./tmp/COMPLETED_REQUEST_WITH_RESOURCE_COUNT')) fs.rmSync('./tmp/COMPLETED_REQUEST_WITH_RESOURCE_COUNT', { recursive: true });
-  if (fs.existsSync('./tmp/COMPLETED_REQUEST_WITH_RESOURCE_ERRORS')) fs.rmSync('./tmp/COMPLETED_REQUEST_WITH_RESOURCE_ERRORS', { recursive: true });
+  if (fs.existsSync('./tmp/COMPLETED_REQUEST_WITH_RESOURCE_COUNT'))
+    fs.rmSync('./tmp/COMPLETED_REQUEST_WITH_RESOURCE_COUNT', { recursive: true });
+  if (fs.existsSync('./tmp/COMPLETED_REQUEST_WITH_RESOURCE_ERRORS'))
+    fs.rmSync('./tmp/COMPLETED_REQUEST_WITH_RESOURCE_ERRORS', { recursive: true });
   if (fs.existsSync('./tmp/INVALID_ID')) fs.rmSync('./tmp/INVALID_ID', { recursive: true });
   if (fs.existsSync('./tmp/KNOWN_ERROR_REQUEST')) fs.rmSync('./tmp/KNOWN_ERROR_REQUEST', { recursive: true });
   if (fs.existsSync('./tmp/UNKNOWN_ERROR_REQUEST')) fs.rmSync('./tmp/UNKNOWN_ERROR_REQUEST', { recursive: true });

--- a/test/populateTestData.js
+++ b/test/populateTestData.js
@@ -20,6 +20,11 @@ async function cleanUpTest() {
   if (!!client.topology && client.topology.isConnected()) await cleanUpDb();
   if (fs.existsSync('./tmp/testid')) fs.rmSync('./tmp/testid', { recursive: true });
   if (fs.existsSync('./tmp/COMPLETED_REQUEST')) fs.rmSync('./tmp/COMPLETED_REQUEST', { recursive: true });
+  if (fs.existsSync('./tmp/COMPLETED_REQUEST_WITH_RESOURCE_COUNT')) fs.rmSync('./tmp/COMPLETED_REQUEST_WITH_RESOURCE_COUNT', { recursive: true });
+  if (fs.existsSync('./tmp/COMPLETED_REQUEST_WITH_RESOURCE_ERRORS')) fs.rmSync('./tmp/COMPLETED_REQUEST_WITH_RESOURCE_ERRORS', { recursive: true });
+  if (fs.existsSync('./tmp/INVALID_ID')) fs.rmSync('./tmp/INVALID_ID', { recursive: true });
+  if (fs.existsSync('./tmp/KNOWN_ERROR_REQUEST')) fs.rmSync('./tmp/KNOWN_ERROR_REQUEST', { recursive: true });
+  if (fs.existsSync('./tmp/UNKNOWN_ERROR_REQUEST')) fs.rmSync('./tmp/UNKNOWN_ERROR_REQUEST', { recursive: true });
   await importQueue.close();
   await execQueue.close();
 }


### PR DESCRIPTION
# Summary
Update functionality to ignore modelinfo file dependencies because these are not necessary for calculation and are not formatted properly for use of the provided canonical url.
Update issue with mongo connection client introduced with node 17 and thus affecting node updates from 16->18/lts.

## New behavior

Basic requests should work against measures provided in the [ecqm-content-r4-2021 repo](https://github.com/cqframework/ecqm-content-r4-2021).

## Code changes

Environment variable update to be able to connect with database while using node 18.
Update to bundleUtils.js to ignore modelinfo dependency.

# Testing guidance

'npm run test`
It would be good to check main against node 18 before merging this code to make sure it is necessary. Otherwise, check with node 16 and node 18. Make sure that normal functionality continues to work. Sample requests as described [here](https://confluence.mitre.org/display/TAC/Sample+Requests) should work.
