### PR TITLE
Update bulk submit endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Test server for executing FHIR-based Electronic Clinical Quality Measures (eCQMs
 
 ### Prerequisites
 
-- [Node.js >=11.15.0](https://nodejs.org/en/)
+- [Node.js >=14.0.0](https://nodejs.org/en/)
 - [MongoDB >= 5.0](https://www.mongodb.com)
 - [Git](https://git-scm.com/)
 - [Docker](https://docs.docker.com/get-docker/)
@@ -219,7 +219,7 @@ The server contains functionality for the FHIR Bulk Data Import operation using 
 
 To implement a bulk data import operation of all the resources on a FHIR Bulk Data Export server, POST a valid FHIR parameters object to `http://localhost:3000/$import`. Use the parameter format below to specify a bulk export server.
 
-To implement the bulk data import operation from the data requirements for a specific measure, first POST a valid transaction bundle. Then, POST a valid FHIR parameters object to `http://localhost:3000/4_0_1/Measure/$submit-data` or `http://localhost:3000/4_0_1/Measure/<your-measure-id>/$submit-data` with the `"prefer": "respond-async"` header populated. This will kick off the "ping and pull" bulk import.
+To implement the bulk data import operation from the data requirements for a specific measure, first POST a valid transaction bundle. Then, POST a valid FHIR parameters object to `http://localhost:3000/4_0_1/Measure/$bulk-submit-data` or `http://localhost:3000/4_0_1/Measure/<your-measure-id>/$bulk-submit-data` with the `"prefer": "respond-async"` header populated. This will kick off the "ping and pull" bulk import.
 
 For the bulk data import operation to be successful, the user must specify an export URL to a FHIR Bulk Data Export server in the request body of the FHIR parameters object. For example, in the `parameter` array of the FHIR parameters object, the user can include
 
@@ -232,11 +232,11 @@ For the bulk data import operation to be successful, the user must specify an ex
 
 with a valid kickoff endpoint URL for the `valueString`.
 
-The user can check the status of an $import or async $submit-data request by copying the content-location header in the response, and sending a GET request to `http://localhost:3000/<content-location-header>`.
+The user can check the status of an $import or $bulk-submit-data request by copying the content-location header in the response, and sending a GET request to `http://localhost:3000/<content-location-header>`.
 
 ## License
 
-Copyright 2021 The MITRE Corporation
+Copyright 2021-2022 The MITRE Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 

--- a/src/config/profileConfig.js
+++ b/src/config/profileConfig.js
@@ -66,13 +66,13 @@ const buildConfig = () => {
               reference: 'http://hl7.org/fhir/OperationDefinition/Measure-submit-data'
             },
             {
-              name: 'bulkImportFromRequirements',
+              name: 'bulkSubmitData',
               route: '/$bulk-submit-data',
               method: 'POST',
               reference: 'http://hl7.org/fhir/us/davinci-deqm/OperationDefinition/bulk-submit-data'
             },
             {
-              name: 'bulkImportFromRequirements',
+              name: 'bulkSubmitData',
               route: '/:id/$bulk-submit-data',
               method: 'POST',
               reference: 'http://hl7.org/fhir/us/davinci-deqm/OperationDefinition/bulk-submit-data'

--- a/src/config/profileConfig.js
+++ b/src/config/profileConfig.js
@@ -66,6 +66,18 @@ const buildConfig = () => {
               reference: 'http://hl7.org/fhir/OperationDefinition/Measure-submit-data'
             },
             {
+              name: 'bulkImportFromRequirements',
+              route: '/$bulk-submit-data',
+              method: 'POST',
+              reference: 'http://hl7.org/fhir/us/davinci-deqm/OperationDefinition/bulk-submit-data'
+            },
+            {
+              name: 'bulkImportFromRequirements',
+              route: '/:id/$bulk-submit-data',
+              method: 'POST',
+              reference: 'http://hl7.org/fhir/us/davinci-deqm/OperationDefinition/bulk-submit-data'
+            },
+            {
               name: 'dataRequirements',
               route: '/:id/$data-requirements',
               method: 'GET',

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -111,6 +111,13 @@ const submitData = async (args, { req }) => {
 
   checkSubmitDataBody(req.body);
   const parameters = req.body.parameter;
+  // Ensure no bulk submit data parameters are included
+  const invalidParameters = parameters.filter(param => !param.resource);
+  if (invalidParameters.length > 0) {
+    throw new BadRequestError(
+      'Unexpected parameter included in request. All parameters for the $submit-data operation must be FHIR resources.'
+    );
+  }
 
   const { base_version: baseVersion } = req.params;
   const tb = createTransactionBundleClass(baseVersion);

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -132,7 +132,7 @@ const submitData = async (args, { req }) => {
  * @param {Object} args the args object passed in by the user
  * @param {Object} req the request object passed in by the user
  */
-const bulkImportFromRequirements = async (args, { req }) => {
+const bulkSubmitData = async (args, { req }) => {
   logger.info('Measure >>> $bulk-submit-data');
   logger.debug(`Request headers: ${JSON.stringify(req.header)}`);
   logger.debug(`Request body: ${JSON.stringify(req.body)}`);
@@ -147,12 +147,12 @@ const bulkImportFromRequirements = async (args, { req }) => {
   let measureId;
   let measureBundle;
   const parameters = req.body.parameter;
-  // case 1: request is in Measure/<id>/$submit-data format
+  // case 1: request is in Measure/<id>/$bulk-submit-data format
   if (req.params.id) {
     measureId = req.params.id;
     measureBundle = await getMeasureBundleFromId(measureId);
   }
-  // case 2: request is in Measure/$submit-data format
+  // case 2: request is in Measure/$bulk-submit-data format
   else {
     const measureReport = parameters.filter(param => param.resource?.resourceType === 'MeasureReport')[0];
     // get measure resource from db that matches measure param since no id is present in request
@@ -566,7 +566,7 @@ module.exports = {
   update,
   search,
   submitData,
-  bulkImportFromRequirements,
+  bulkSubmitData,
   dataRequirements,
   evaluateMeasure,
   careGaps,

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -112,16 +112,6 @@ const submitData = async (args, { req }) => {
   checkSubmitDataBody(req.body);
   const parameters = req.body.parameter;
 
-  // TODO: move this? or have bulk submit data call this?
-  // then normal submit-data just does these checks 
-  // and bulk submit data also does these checks plus checks headers and returns bulk import
-  // and i guess throw an error if for some reason the header is not present?
-
-  // check if we want to do a bulk import
-  // if (req.headers['prefer'] === 'respond-async') {
-  //   return await bulkImportFromRequirements(args, { req });
-  // }
-
   const { base_version: baseVersion } = req.params;
   const tb = createTransactionBundleClass(baseVersion);
   parameters.forEach(param => {
@@ -143,7 +133,6 @@ const submitData = async (args, { req }) => {
  * @param {Object} req the request object passed in by the user
  */
 const bulkImportFromRequirements = async (args, { req }) => {
-  // TODO: should we just use this for bulk submit data maybe?
   logger.info('Measure >>> $bulk-submit-data');
   logger.debug(`Request headers: ${JSON.stringify(req.header)}`);
   logger.debug(`Request body: ${JSON.stringify(req.body)}`);

--- a/src/util/operationValidationUtils.js
+++ b/src/util/operationValidationUtils.js
@@ -180,10 +180,10 @@ const gatherParams = (query, body) => {
 /**
  * Checks that $submit-data/$bulk-submit-data request body contains
  * a Parameters resource and the appropriate parameters.
- * @param {Object} body HTTP request body 
+ * @param {Object} body HTTP request body
  * @returns void but throws a detailed error if necessary
  */
-const checkSubmitDataBody = (body) => {
+const checkSubmitDataBody = body => {
   if (body.resourceType !== 'Parameters') {
     throw new BadRequestError(`Expected 'resourceType: Parameters'. Received 'type: ${body.resourceType}'.`);
   }

--- a/src/util/operationValidationUtils.js
+++ b/src/util/operationValidationUtils.js
@@ -181,7 +181,6 @@ const gatherParams = (query, body) => {
  * Checks that $submit-data/$bulk-submit-data request body contains
  * a Parameters resource and the appropriate parameters.
  * @param {Object} body HTTP request body
- * @returns void but throws a detailed error if necessary
  */
 const checkSubmitDataBody = body => {
   if (body.resourceType !== 'Parameters') {

--- a/src/util/operationValidationUtils.js
+++ b/src/util/operationValidationUtils.js
@@ -177,10 +177,36 @@ const gatherParams = (query, body) => {
   return params;
 };
 
+/**
+ * Checks that $submit-data/$bulk-submit-data request body contains
+ * a Parameters resource and the appropriate parameters.
+ * @param {Object} body HTTP request body 
+ * @returns void but throws a detailed error if necessary
+ */
+const checkSubmitDataBody = (body) => {
+  if (body.resourceType !== 'Parameters') {
+    throw new BadRequestError(`Expected 'resourceType: Parameters'. Received 'type: ${body.resourceType}'.`);
+  }
+  if (!body.parameter) {
+    throw new BadRequestError(`Unreadable or empty entity for attribute 'parameter'. Received: ${body.parameter}`);
+  }
+  const parameters = body.parameter;
+  // Ensure exactly 1 measureReport is in parameters
+  const numMeasureReportsInput = parameters.filter(
+    param => param.name === 'measureReport' || param.resource?.resourceType === 'MeasureReport'
+  ).length;
+  if (numMeasureReportsInput !== 1) {
+    throw new BadRequestError(
+      `Expected exactly one resource with name: 'measureReport' and/or resourceType: 'MeasureReport. Received: ${numMeasureReportsInput}`
+    );
+  }
+};
+
 module.exports = {
   validateEvalMeasureParams,
   validateCareGapsParams,
   validateDataRequirementsParams,
   checkRequiredParams,
-  gatherParams
+  gatherParams,
+  checkSubmitDataBody
 };

--- a/src/util/resourceValidationUtils.js
+++ b/src/util/resourceValidationUtils.js
@@ -71,6 +71,7 @@ function retrieveProfiles(originalUrl, body) {
   if (metaProfiles) {
     profiles.push(...metaProfiles);
   }
+  // TODO: change this to also apply to bulk submit data?
   if (params[params.length - 1] === '$submit-data') {
     profiles.push('Parameters');
   }

--- a/src/util/resourceValidationUtils.js
+++ b/src/util/resourceValidationUtils.js
@@ -71,8 +71,7 @@ function retrieveProfiles(originalUrl, body) {
   if (metaProfiles) {
     profiles.push(...metaProfiles);
   }
-  // TODO: change this to also apply to bulk submit data?
-  if (params[params.length - 1] === '$submit-data') {
+  if (params[params.length - 1] === '$submit-data' || params[params.length - 1] === '$bulk-submit-data') {
     profiles.push('Parameters');
   }
   // We don't need to validate posted Parameters bodies for dollar-sign operations since these aren't stored in the db

--- a/test/services/measure.service.test.js
+++ b/test/services/measure.service.test.js
@@ -9,6 +9,7 @@ const testGroup = require('../fixtures/fhir-resources/testGroup.json');
 const testOrganization = require('../fixtures/fhir-resources/testOrganization.json');
 const testOrganization2 = require('../fixtures/fhir-resources/testOrganization2.json');
 const testParam = require('../fixtures/fhir-resources/parameters/paramNoExport.json');
+const testParamWithExport = require('../fixtures/fhir-resources/parameters/paramWithExport.json');
 const testParamTwoExports = require('../fixtures/fhir-resources/parameters/paramTwoExports.json');
 const testParamNoValString = require('../fixtures/fhir-resources/parameters/paramNoValueUrl.json');
 const testParamInvalidResourceType = require('../fixtures/fhir-resources/parameters/paramInvalidType.json');
@@ -164,6 +165,21 @@ describe('measure.service', () => {
           expect(response.body.issue[0].code).toEqual('BadRequest');
           expect(response.body.issue[0].details.text).toEqual(
             `Expected exactly one resource with name: 'measureReport' and/or resourceType: 'MeasureReport. Received: 2`
+          );
+        });
+    });
+
+    test('$submit-data returns 400 for invalid parameter included in request', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/Measure/$submit-data')
+        .send(testParamWithExport)
+        .set('Accept', 'application/json+fhir')
+        .set('content-type', 'application/json+fhir')
+        .expect(400)
+        .then(response => {
+          expect(response.body.issue[0].code).toEqual('BadRequest');
+          expect(response.body.issue[0].details.text).toEqual(
+            'Unexpected parameter included in request. All parameters for the $submit-data operation must be FHIR resources.'
           );
         });
     });

--- a/test/services/measure.service.test.js
+++ b/test/services/measure.service.test.js
@@ -76,10 +76,10 @@ describe('measure.service', () => {
     });
   });
 
-  describe('bulk $submit-data', () => {
+  describe('$bulk-submit-data', () => {
     test('FHIR Parameters object is missing export URL returns 400', async () => {
       await supertest(server.app)
-        .post('/4_0_1/Measure/$submit-data')
+        .post('/4_0_1/Measure/$bulk-submit-data')
         .send(testParam)
         .set('Accept', 'application/json+fhir')
         .set('content-type', 'application/json+fhir')
@@ -93,7 +93,7 @@ describe('measure.service', () => {
 
     test('FHIR Parameters object has two export URLs', async () => {
       await supertest(server.app)
-        .post('/4_0_1/Measure/$submit-data')
+        .post('/4_0_1/Measure/$bulk-submit-data')
         .send(testParamTwoExports)
         .set('Accept', 'application/json+fhir')
         .set('content-type', 'application/json+fhir')
@@ -107,7 +107,7 @@ describe('measure.service', () => {
 
     test('FHIR Parameters object is missing valueUrl for export URL', async () => {
       await supertest(server.app)
-        .post('/4_0_1/Measure/$submit-data')
+        .post('/4_0_1/Measure/$bulk-submit-data')
         .send(testParamNoValString)
         .set('Accept', 'application/json+fhir')
         .set('content-type', 'application/json+fhir')
@@ -1027,7 +1027,7 @@ describe('measure.service', () => {
 
     test('bulk import fails if measure bundle cannot be found', async () => {
       await supertest(server.app)
-        .post('/4_0_1/Measure/invalid-id/$submit-data')
+        .post('/4_0_1/Measure/invalid-id/$bulk-submit-data')
         .send(testParam)
         .set('Accept', 'application/json+fhir')
         .set('content-type', 'application/json+fhir')


### PR DESCRIPTION
# Summary
Updates `$bulk-submit-data` endpoint to align with the [latest CI build of DEQM](https://build.fhir.org/ig/HL7/davinci-deqm/OperationDefinition-bulk-submit-data.html).

## New behavior
When specifying a bulk submit data request, the user must now use the `$bulk-submit-data` endpoint with the `”prefer”: “respond-async”` header populated. Behavior for sending a standard submit data request should remain unchanged.

## Code changes
* README updates
* The route `/$bulk-submit-data` is now defined in the test server
* Moved submit data request body validation to its own function in `operationValidationUtils.js` with unit tests
* Added error handling for situation where a standard submit data request body includes parameters for bulk submit data (throws a 500 error on the main branch)
* Updated unit tests for new endpoint

# Testing guidance
* Run unit tests
* Check that all instances of bulk submit data now use the `/$bulk-submit-data` endpoint instead of the `/$submit-data` endpoint in combination with the `”prefer”: “respond-async”` header.
* Test both the standard submit data and bulk submit data endpoints in Insomnia
    * Send POST to `http://localhost:3000/4_0_1/Measure/<measure-id>/$submit-data`(replace `measure-id` with the id of the measure you are testing with) with `Parameters` resource containing FHIR resources and FHIR Measure Report
    * Send POST to `http://localhost:3000/4_0_1/Measure/<measure-id>/$bulk-submit-data` with `Parameters` resource containing a FHIR Measure Report, `exportUrl`, and other bulk data parameters