### PR TITLE
Change periodStart and periodEnd params to optional for dataRequirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,10 +190,12 @@ Check out the [$care-gaps operation spec](https://build.fhir.org/ig/HL7/davinci-
 
 This operation retrieves all the data requirements for a given measure as a FHIR library.
 
-Required parameters include:
+Optional parameters for this function include:
 
 - `periodStart`: start of the measurement period
 - `periodEnd`: end of the measurement period
+
+If `periodStart` and `periodEnd` params are omitted, the measurement period for the operation will default to the `effectivePeriod` of the referenced FHIR Measure. If no `effectivePeriod` property is present, `dateFilters` will be excluded from the returned FHIR Library entirely.
 
 To use, first POST a measure bundle into your database, then send a GET request to `http://localhost:3000/4_0_1/Measure/<your-measure-id>/$data-requirements`.
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Optional parameters for this function include:
 - `periodStart`: start of the measurement period
 - `periodEnd`: end of the measurement period
 
-If `periodStart` and `periodEnd` params are omitted, the measurement period for the operation will default to the `effectivePeriod` of the referenced FHIR Measure. If no `effectivePeriod` property is present, `dateFilters` will be excluded from the returned FHIR Library entirely.
+If either `periodStart` or `periodEnd` parameter is supplied without the other, a measurement period will be used with duration 1 year starting or ending at the provided date. If `periodStart` and `periodEnd` parameters are omitted entirely, the measurement period for the operation will default to the `effectivePeriod` of the referenced FHIR Measure. If no `effectivePeriod` property is present, `dateFilters` will be excluded from the returned FHIR Library entirely.
 
 To use, first POST a measure bundle into your database, then send a GET request to `http://localhost:3000/4_0_1/Measure/<your-measure-id>/$data-requirements`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "cql-exec-fhir-mongo": "git+https://git@github.com/projecttacoma/cql-exec-fhir-mongo",
         "dotenv": "^10.0.0",
         "express": "^4.17.1",
-        "fqm-execution": "^1.0.1",
+        "fqm-execution": "^1.0.5",
         "lodash": "^4.17.21",
         "mongodb": "^4.1.3",
         "uuid": "^8.3.2",
@@ -5244,16 +5244,16 @@
       }
     },
     "node_modules/fqm-execution": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fqm-execution/-/fqm-execution-1.0.1.tgz",
-      "integrity": "sha512-o6WsFJ51aEemUi2pPIkSXPTUbfeS+CF4+8EVnZ7CoNFKgEhU7THif5IZf+ylT4K2swYRrg1IIW9A4ILVuFBlOQ==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/fqm-execution/-/fqm-execution-1.0.5.tgz",
+      "integrity": "sha512-l8w36jGczmaQUucLMf1MvKRdgPIY+0FFVRTl0ifEgdB/llsleHVrSkwyhgGx0oRaOBwWsq9EapXZUCrSSCHQUw==",
       "dependencies": {
         "@types/fhir": "0.0.34",
         "atob": "^2.1.2",
         "axios": "^0.21.1",
         "commander": "^6.1.0",
-        "cql-exec-fhir": "^2.1.2",
-        "cql-execution": "^3.0.0-beta.2",
+        "cql-exec-fhir": "^2.1.3",
+        "cql-execution": "^3.0.0-beta.3",
         "handlebars": "^4.7.7",
         "lodash": "^4.17.21",
         "moment": "^2.29.4",
@@ -5275,12 +5275,13 @@
       }
     },
     "node_modules/fqm-execution/node_modules/cql-execution": {
-      "version": "3.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.0-beta.2.tgz",
-      "integrity": "sha512-rpBUkUotVAUfz73HGF+Vs1UItULuZcEGmAwHkPxCpWEUXXVKWL7Dc9vPbRu5lCteMovKSJDSZsK+jHqDd+iYhQ==",
+      "version": "3.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.0-beta.3.tgz",
+      "integrity": "sha512-Mcr3vUilXfnz2qooyKzKZT3lexWTo/U7ktwt3DXnAFfsKfCYBe4zHyGv9ThRwW7OFMM/mr5LmM4szbm2StSfZw==",
       "dependencies": {
         "@lhncbc/ucum-lhc": "^4.1.3",
-        "luxon": "^1.25.0"
+        "immutable": "^4.1.0",
+        "luxon": "^1.28.1"
       }
     },
     "node_modules/fraction.js": {
@@ -5818,6 +5819,11 @@
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
       "dev": true
+    },
+    "node_modules/immutable": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.2.2.tgz",
+      "integrity": "sha512-fTMKDwtbvO5tldky9QZ2fMX7slR0mYpY5nbnFWYp0fOzDhHqhgIw9KoYgxLWsoNTS9ZHGauHj18DTyEw6BK3Og=="
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -7286,9 +7292,9 @@
       }
     },
     "node_modules/luxon": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.0.tgz",
-      "integrity": "sha512-TfTiyvZhwBYM/7QdAVDh+7dBTBA29v4ik0Ce9zda3Mnf8on1S5KJI8P2jKFZ8+5C0jhmr0KwJEO/Wdpm0VeWJQ==",
+      "version": "1.28.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.1.tgz",
+      "integrity": "sha512-gYHAa180mKrNIUJCbwpmD0aTu9kV0dREDrwNnuyFAsO1Wt0EVYSZelPnJlbj9HplzXX/YWXHFTL45kvZ53M0pw==",
       "engines": {
         "node": "*"
       }
@@ -14206,16 +14212,16 @@
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
     },
     "fqm-execution": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fqm-execution/-/fqm-execution-1.0.1.tgz",
-      "integrity": "sha512-o6WsFJ51aEemUi2pPIkSXPTUbfeS+CF4+8EVnZ7CoNFKgEhU7THif5IZf+ylT4K2swYRrg1IIW9A4ILVuFBlOQ==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/fqm-execution/-/fqm-execution-1.0.5.tgz",
+      "integrity": "sha512-l8w36jGczmaQUucLMf1MvKRdgPIY+0FFVRTl0ifEgdB/llsleHVrSkwyhgGx0oRaOBwWsq9EapXZUCrSSCHQUw==",
       "requires": {
         "@types/fhir": "0.0.34",
         "atob": "^2.1.2",
         "axios": "^0.21.1",
         "commander": "^6.1.0",
-        "cql-exec-fhir": "^2.1.2",
-        "cql-execution": "^3.0.0-beta.2",
+        "cql-exec-fhir": "^2.1.3",
+        "cql-execution": "^3.0.0-beta.3",
         "handlebars": "^4.7.7",
         "lodash": "^4.17.21",
         "moment": "^2.29.4",
@@ -14231,12 +14237,13 @@
           }
         },
         "cql-execution": {
-          "version": "3.0.0-beta.2",
-          "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.0-beta.2.tgz",
-          "integrity": "sha512-rpBUkUotVAUfz73HGF+Vs1UItULuZcEGmAwHkPxCpWEUXXVKWL7Dc9vPbRu5lCteMovKSJDSZsK+jHqDd+iYhQ==",
+          "version": "3.0.0-beta.3",
+          "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.0-beta.3.tgz",
+          "integrity": "sha512-Mcr3vUilXfnz2qooyKzKZT3lexWTo/U7ktwt3DXnAFfsKfCYBe4zHyGv9ThRwW7OFMM/mr5LmM4szbm2StSfZw==",
           "requires": {
             "@lhncbc/ucum-lhc": "^4.1.3",
-            "luxon": "^1.25.0"
+            "immutable": "^4.1.0",
+            "luxon": "^1.28.1"
           }
         }
       }
@@ -14618,6 +14625,11 @@
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
       "dev": true
+    },
+    "immutable": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.2.2.tgz",
+      "integrity": "sha512-fTMKDwtbvO5tldky9QZ2fMX7slR0mYpY5nbnFWYp0fOzDhHqhgIw9KoYgxLWsoNTS9ZHGauHj18DTyEw6BK3Og=="
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -15751,9 +15763,9 @@
       }
     },
     "luxon": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.0.tgz",
-      "integrity": "sha512-TfTiyvZhwBYM/7QdAVDh+7dBTBA29v4ik0Ce9zda3Mnf8on1S5KJI8P2jKFZ8+5C0jhmr0KwJEO/Wdpm0VeWJQ=="
+      "version": "1.28.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.1.tgz",
+      "integrity": "sha512-gYHAa180mKrNIUJCbwpmD0aTu9kV0dREDrwNnuyFAsO1Wt0EVYSZelPnJlbj9HplzXX/YWXHFTL45kvZ53M0pw=="
     },
     "make-dir": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "cql-exec-fhir-mongo": "git+https://git@github.com/projecttacoma/cql-exec-fhir-mongo",
     "dotenv": "^10.0.0",
     "express": "^4.17.1",
-    "fqm-execution": "^1.0.1",
+    "fqm-execution": "^1.0.5",
     "lodash": "^4.17.21",
     "mongodb": "^4.1.3",
     "uuid": "^8.3.2",

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -9,7 +9,6 @@ const { retrieveExportType, retrieveExportUrl } = require('../util/exportUtils')
 const {
   validateEvalMeasureParams,
   validateCareGapsParams,
-  validateDataRequirementsParams,
   gatherParams,
   checkSubmitDataBody
 } = require('../util/operationValidationUtils');
@@ -207,8 +206,6 @@ const dataRequirements = async (args, { req }) => {
   logger.debug(`Request body: ${JSON.stringify(req.body)}`);
 
   const id = args.id;
-
-  validateDataRequirementsParams(req.query);
 
   const measureBundle = await getMeasureBundleFromId(id);
 

--- a/src/util/operationValidationUtils.js
+++ b/src/util/operationValidationUtils.js
@@ -114,16 +114,6 @@ const validateCareGapsParams = query => {
 };
 
 /**
- * Checks that the parameters passed in for $data-requirements are valid
- * @param {Object} query query from the request passed in by the user
- * @returns void but throws a detailed error if necessary
- */
-const validateDataRequirementsParams = query => {
-  const REQUIRED_PARAMS = ['periodStart', 'periodEnd'];
-  checkRequiredParams(query, REQUIRED_PARAMS, '$data-requirements');
-};
-
-/**
  * Dynamic function for checking the presence of required params for all validation functions
  * @param {Object} query the query passed in through the client's request
  * @param {Array} requiredParams  an array of strings detailing which params are required
@@ -204,7 +194,6 @@ const checkSubmitDataBody = body => {
 module.exports = {
   validateEvalMeasureParams,
   validateCareGapsParams,
-  validateDataRequirementsParams,
   checkRequiredParams,
   gatherParams,
   checkSubmitDataBody

--- a/test/services/measure.service.test.js
+++ b/test/services/measure.service.test.js
@@ -582,22 +582,6 @@ describe('measure.service', () => {
         });
     });
 
-    test('$data-requirements returns 400 when required param is omitted', async () => {
-      const { Calculator } = require('fqm-execution');
-      jest.spyOn(Calculator, 'calculateDataRequirements').mockImplementation(() => ({ results: null }));
-      await supertest(server.app)
-        .get('/4_0_1/Measure/testMeasure/$data-requirements')
-        .query({
-          periodEnd: '01-01-2021'
-        })
-        .expect(400)
-        .then(response => {
-          expect(response.body.resourceType).toEqual('OperationOutcome');
-          expect(response.body.issue[0].details.text).toEqual(
-            `Missing required parameters for $data-requirements: periodStart.`
-          );
-        });
-    });
     test('$data-requirements returns 200 with valid params', async () => {
       const { Calculator } = require('fqm-execution');
       jest.spyOn(Calculator, 'calculateDataRequirements').mockImplementation(() => ({ results: null }));


### PR DESCRIPTION
# Summary
Converted periodStart and periodEnd parameters to optional for $data-requirements operation. Also bumped fqm-execution dependency to 1.0.5

## New behavior
An error will no longer be thrown when periodStart and periodEnd parameters are omitted from a $data-requirements operation instead, each situation will be handled in the following manor: 

 - If a measurement period start and end calculation option are provided, this period will be used
 - If a measurement period start calculation option is provided with no end, a period with duration 1 year beginning at the provided start will be used
 - If a measurement period end calculation option is provided with no start, a period with duration 1 year ending at the provided end will be used
 - If no measurement period start or end calculation option is provided, the measurement period will be determined by the effective period of the FHIR Measure, using the same logic as above to handle missing start and end dates
 - If no measurement period start or end calculation option is provided and no effectivePeriod is found on the measure, no measurement period will be used, and all dateFilters will be excluded from the resulting library

## Code changes
 - Deleted validateDataRequirementsParams function and removed all calls to it
 - Updated README
 - Bumped fqm-execution to 1.0.5
 - Updated unit tests

# Testing guidance
 - `npm install`
 - `npm run db:reset`
 - `npm run upload-bundles`
 - `npm start`
 - Head over to insomnia and run the attached test suite
 - Ensure the output for each example fits the logic outlined above. Keep in mind that the effectivePeriod of ColorectalCancerScreeningsFHIR is 2022-01-01 - 2022-12-31
[dr-tests.json.zip](https://github.com/projecttacoma/deqm-test-server/files/10537152/dr-tests.json.zip)

