### PR TITLE
Update fqmexec 1.3.1

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+connectathon
+ecqm-content-r4-2021

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [16.x, 18.x]
         mongodb-version: ['5.0']
 
     steps:
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [16.x, 18.x]
         mongodb-version: ['5.0']
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
         mongodb-version: ['5.0']
 
     steps:
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
         mongodb-version: ['5.0']
     steps:
       - uses: actions/checkout@v2

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "cql-exec-fhir-mongo": "git+https://git@github.com/projecttacoma/cql-exec-fhir-mongo",
         "dotenv": "^10.0.0",
         "express": "^4.17.1",
-        "fqm-execution": "^1.2.0",
+        "fqm-execution": "^1.3.1",
         "lodash": "^4.17.21",
         "mongodb": "^4.1.3",
         "uuid": "^8.3.2",
@@ -3928,9 +3928,9 @@
       }
     },
     "node_modules/cql-execution": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.0.tgz",
-      "integrity": "sha512-5nVt7XExWkyUbb76l+xlCnDd9c3cCuTdKgr88kkPnCy5SeFC+TYSo2pVb1zGVppWCOqVw2+ju8nQyuYX5xaYzA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.1.tgz",
+      "integrity": "sha512-RC6uxrzvrJImFvyKvYDNLdumCS7nufJobhz5abfV3ZeFxbPR6E2gqJcn0T2KxVh4y40+BqbSGABwgiFTEITCdQ==",
       "dependencies": {
         "@lhncbc/ucum-lhc": "^4.1.3",
         "immutable": "^4.1.0",
@@ -5233,15 +5233,15 @@
       }
     },
     "node_modules/fqm-execution": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fqm-execution/-/fqm-execution-1.2.0.tgz",
-      "integrity": "sha512-vvPiMSTliCvO6n188Z+YNEcB4G6ckhSe3B5HH36SlcKe3AZFVi9dXZWULtcDd1RUzUpRNdi0Vv60VU4yi2HlUQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/fqm-execution/-/fqm-execution-1.3.1.tgz",
+      "integrity": "sha512-LJmnGgdWsYHb0QdlYBFfV9Q8lQDSiOSwwtBlphR+xrKunxwx8MfC2xdacuujqMyK29CLZ8NDFrgJhwPWgGgT7g==",
       "dependencies": {
         "@types/fhir": "0.0.34",
         "axios": "^0.21.1",
         "commander": "^6.1.0",
         "cql-exec-fhir": "^2.1.3",
-        "cql-execution": "^3.0.0",
+        "cql-execution": "^3.0.1",
         "handlebars": "^4.7.7",
         "lodash": "^4.17.21",
         "moment": "^2.29.4",
@@ -13206,9 +13206,9 @@
       }
     },
     "cql-execution": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.0.tgz",
-      "integrity": "sha512-5nVt7XExWkyUbb76l+xlCnDd9c3cCuTdKgr88kkPnCy5SeFC+TYSo2pVb1zGVppWCOqVw2+ju8nQyuYX5xaYzA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.1.tgz",
+      "integrity": "sha512-RC6uxrzvrJImFvyKvYDNLdumCS7nufJobhz5abfV3ZeFxbPR6E2gqJcn0T2KxVh4y40+BqbSGABwgiFTEITCdQ==",
       "requires": {
         "@lhncbc/ucum-lhc": "^4.1.3",
         "immutable": "^4.1.0",
@@ -14185,15 +14185,15 @@
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
     },
     "fqm-execution": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fqm-execution/-/fqm-execution-1.2.0.tgz",
-      "integrity": "sha512-vvPiMSTliCvO6n188Z+YNEcB4G6ckhSe3B5HH36SlcKe3AZFVi9dXZWULtcDd1RUzUpRNdi0Vv60VU4yi2HlUQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/fqm-execution/-/fqm-execution-1.3.1.tgz",
+      "integrity": "sha512-LJmnGgdWsYHb0QdlYBFfV9Q8lQDSiOSwwtBlphR+xrKunxwx8MfC2xdacuujqMyK29CLZ8NDFrgJhwPWgGgT7g==",
       "requires": {
         "@types/fhir": "0.0.34",
         "axios": "^0.21.1",
         "commander": "^6.1.0",
         "cql-exec-fhir": "^2.1.3",
-        "cql-execution": "^3.0.0",
+        "cql-execution": "^3.0.1",
         "handlebars": "^4.7.7",
         "lodash": "^4.17.21",
         "moment": "^2.29.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "cql-exec-fhir-mongo": "git+https://git@github.com/projecttacoma/cql-exec-fhir-mongo",
         "dotenv": "^10.0.0",
         "express": "^4.17.1",
-        "fqm-execution": "^1.0.5",
+        "fqm-execution": "^1.2.0",
         "lodash": "^4.17.21",
         "mongodb": "^4.1.3",
         "uuid": "^8.3.2",
@@ -3163,17 +3163,6 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
-    "node_modules/atob": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-      "bin": {
-        "atob": "bin/atob.js"
-      },
-      "engines": {
-        "node": ">= 4.5.0"
-      }
-    },
     "node_modules/axios": {
       "version": "0.21.4",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
@@ -3939,13 +3928,13 @@
       }
     },
     "node_modules/cql-execution": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-2.4.3.tgz",
-      "integrity": "sha512-Tqy5JtWmH0QFAEfsCGP2wVYp24J5/rEhOQe1BUGevlZ1lzHRI+I8MHDt8CSAnzQgWhpA6unHLBu5u/SD32Wuyg==",
-      "peer": true,
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.0.tgz",
+      "integrity": "sha512-5nVt7XExWkyUbb76l+xlCnDd9c3cCuTdKgr88kkPnCy5SeFC+TYSo2pVb1zGVppWCOqVw2+ju8nQyuYX5xaYzA==",
       "dependencies": {
         "@lhncbc/ucum-lhc": "^4.1.3",
-        "luxon": "^1.25.0"
+        "immutable": "^4.1.0",
+        "luxon": "^1.28.1"
       }
     },
     "node_modules/cross-env": {
@@ -5244,16 +5233,15 @@
       }
     },
     "node_modules/fqm-execution": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/fqm-execution/-/fqm-execution-1.0.5.tgz",
-      "integrity": "sha512-l8w36jGczmaQUucLMf1MvKRdgPIY+0FFVRTl0ifEgdB/llsleHVrSkwyhgGx0oRaOBwWsq9EapXZUCrSSCHQUw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fqm-execution/-/fqm-execution-1.2.0.tgz",
+      "integrity": "sha512-vvPiMSTliCvO6n188Z+YNEcB4G6ckhSe3B5HH36SlcKe3AZFVi9dXZWULtcDd1RUzUpRNdi0Vv60VU4yi2HlUQ==",
       "dependencies": {
         "@types/fhir": "0.0.34",
-        "atob": "^2.1.2",
         "axios": "^0.21.1",
         "commander": "^6.1.0",
         "cql-exec-fhir": "^2.1.3",
-        "cql-execution": "^3.0.0-beta.3",
+        "cql-execution": "^3.0.0",
         "handlebars": "^4.7.7",
         "lodash": "^4.17.21",
         "moment": "^2.29.4",
@@ -5272,16 +5260,6 @@
       },
       "peerDependencies": {
         "cql-execution": ">=1.3.0 || ^3.0.0-beta"
-      }
-    },
-    "node_modules/fqm-execution/node_modules/cql-execution": {
-      "version": "3.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.0-beta.3.tgz",
-      "integrity": "sha512-Mcr3vUilXfnz2qooyKzKZT3lexWTo/U7ktwt3DXnAFfsKfCYBe4zHyGv9ThRwW7OFMM/mr5LmM4szbm2StSfZw==",
-      "dependencies": {
-        "@lhncbc/ucum-lhc": "^4.1.3",
-        "immutable": "^4.1.0",
-        "luxon": "^1.28.1"
       }
     },
     "node_modules/fraction.js": {
@@ -12662,11 +12640,6 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
-    "atob": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
-    },
     "axios": {
       "version": "0.21.4",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
@@ -13233,13 +13206,13 @@
       }
     },
     "cql-execution": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-2.4.3.tgz",
-      "integrity": "sha512-Tqy5JtWmH0QFAEfsCGP2wVYp24J5/rEhOQe1BUGevlZ1lzHRI+I8MHDt8CSAnzQgWhpA6unHLBu5u/SD32Wuyg==",
-      "peer": true,
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.0.tgz",
+      "integrity": "sha512-5nVt7XExWkyUbb76l+xlCnDd9c3cCuTdKgr88kkPnCy5SeFC+TYSo2pVb1zGVppWCOqVw2+ju8nQyuYX5xaYzA==",
       "requires": {
         "@lhncbc/ucum-lhc": "^4.1.3",
-        "luxon": "^1.25.0"
+        "immutable": "^4.1.0",
+        "luxon": "^1.28.1"
       }
     },
     "cross-env": {
@@ -14212,16 +14185,15 @@
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
     },
     "fqm-execution": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/fqm-execution/-/fqm-execution-1.0.5.tgz",
-      "integrity": "sha512-l8w36jGczmaQUucLMf1MvKRdgPIY+0FFVRTl0ifEgdB/llsleHVrSkwyhgGx0oRaOBwWsq9EapXZUCrSSCHQUw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fqm-execution/-/fqm-execution-1.2.0.tgz",
+      "integrity": "sha512-vvPiMSTliCvO6n188Z+YNEcB4G6ckhSe3B5HH36SlcKe3AZFVi9dXZWULtcDd1RUzUpRNdi0Vv60VU4yi2HlUQ==",
       "requires": {
         "@types/fhir": "0.0.34",
-        "atob": "^2.1.2",
         "axios": "^0.21.1",
         "commander": "^6.1.0",
         "cql-exec-fhir": "^2.1.3",
-        "cql-execution": "^3.0.0-beta.3",
+        "cql-execution": "^3.0.0",
         "handlebars": "^4.7.7",
         "lodash": "^4.17.21",
         "moment": "^2.29.4",
@@ -14234,16 +14206,6 @@
           "integrity": "sha512-UxGpZlvQHCd1Pl47J+J01SsvxBucbRGF1pFqlITw62e2YT3PDDdV4s7ZNfQ1Yy2TigSwITmajnSH0tOZuT4mvQ==",
           "requires": {
             "xml2js": "~0.4.23"
-          }
-        },
-        "cql-execution": {
-          "version": "3.0.0-beta.3",
-          "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.0-beta.3.tgz",
-          "integrity": "sha512-Mcr3vUilXfnz2qooyKzKZT3lexWTo/U7ktwt3DXnAFfsKfCYBe4zHyGv9ThRwW7OFMM/mr5LmM4szbm2StSfZw==",
-          "requires": {
-            "@lhncbc/ucum-lhc": "^4.1.3",
-            "immutable": "^4.1.0",
-            "luxon": "^1.28.1"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "cql-exec-fhir-mongo": "git+https://git@github.com/projecttacoma/cql-exec-fhir-mongo",
     "dotenv": "^10.0.0",
     "express": "^4.17.1",
-    "fqm-execution": "^1.2.0",
+    "fqm-execution": "^1.3.1",
     "lodash": "^4.17.21",
     "mongodb": "^4.1.3",
     "uuid": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "cql-exec-fhir-mongo": "git+https://git@github.com/projecttacoma/cql-exec-fhir-mongo",
     "dotenv": "^10.0.0",
     "express": "^4.17.1",
-    "fqm-execution": "^1.0.5",
+    "fqm-execution": "^1.2.0",
     "lodash": "^4.17.21",
     "mongodb": "^4.1.3",
     "uuid": "^8.3.2",

--- a/src/queue/execQueue.js
+++ b/src/queue/execQueue.js
@@ -41,7 +41,8 @@ class ScaledCalculation {
 
     // Prepare the fqm-execution measure report builder
     try {
-      this._mrBuilder = new MeasureReportBuilder(this._measureBundle, {
+      const measure_entry = this._measureBundle.entry?.find(e => e.resource?.resourceType === 'Measure');
+      this._mrBuilder = new MeasureReportBuilder(measure_entry.resource, {
         measurementPeriodStart: this._periodStart,
         measurementPeriodEnd: this._periodEnd,
         reportType: 'summary'

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -237,7 +237,7 @@ const evaluateMeasure = async (args, { req }) => {
   const { reportType, subject } = req.query;
 
   // If reportType is not specified, default to 'subject', but
-  // only if the 'subject' parameter is also specificed
+  // only if the 'subject' parameter is also specified
   if (reportType === 'subject' || (reportType == null && subject != null)) {
     logger.debug('Evaluating measure for individual');
     return evaluateMeasureForIndividual(args, { req });

--- a/test/services/base.service.test.js
+++ b/test/services/base.service.test.js
@@ -80,8 +80,9 @@ describe('base.service', () => {
               url: expect.stringMatching(/\/4_0_1\/Patient\?page=1$/)
             }
           ]);
-          expect(response.body.entry[0].resource.id).toEqual(testPatient.id);
-          expect(response.body.entry[0].resource.resourceType).toEqual('Patient');
+          const testPatientEntry = response.body.entry.find(e => e.resource.id === testPatient.id);
+          expect(testPatientEntry).toBeDefined();
+          expect(testPatientEntry.resource.resourceType).toEqual('Patient');
         });
     });
 


### PR DESCRIPTION
# Summary
- Updates to use the latest fqm-execution version (`1.3.1`). See [here](https://github.com/projecttacoma/fqm-execution/releases/tag/v1.3.1) for the release notes.

## New behavior
- `npm run check` no longer results in those two lint errors from `ecqm-content-r4-2021/input/images/cql.js`. I added a `.eslintignore` file for the `ecqm-content-r4-2021` directory. I hope this is okay, let me know if it's not. I was tired of seeing those and now the prettier check seems to actually happen. 
- Otherwise, there should be no new behaviors.

## Code changes
- `.eslintignore` - added this file to avoid those errors that we (I think) don't care about
- `package.json` / `package-lock.json` - further upgraded the fqm-execution version

## Code changes Lauren made in previous fqm-e version bump PR
- `ci.yml`, `measure.service.js`, `execQueue.js`, `base.service.test.js`

# Testing guidance
- `npm run check` Reminder that _sometimes_ a couple of these tests will fail. That is okay for now and something we need to address in separate tasking.
- `npm start` make sure that all functionality works the same.

NOTE: 
- We had an in review PR for updating the fqm-execution version that I closed and just branched off of to upgrade the version even further. The previous PR is [here](https://github.com/projecttacoma/deqm-test-server/pull/137) for reference.