### PR TITLE
Add write permissions in yml for dependabot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
         run: npm ci
 
       - name: Run Jest Coverage Report
-        uses: artiomtr/jest-coverage-report-action@v2.0-rc.4
+        uses: artiomtr/jest-coverage-report-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           threshold: 60

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,3 +79,4 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           threshold: 60
+          test-script: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,10 @@ jobs:
         run: npm run test
 
   coverage:
+    permissions:
+      checks: write
+      pull-requests: write
+      contents: write
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
# Summary
Recently, there was some sort of update to dependabot permissions so that the GITHUB_TOKEN is only given read permissions by default when a GitHub action is triggered by dependabot. Hoss, Lauren, and I did investigation into this and found that the solution is to add the permission explicitly in the `ci.yml` file (also did this in `bulk-export-server`: https://github.com/projecttacoma/bulk-export-server/pull/38)

## New behavior
Dependabot PRs should no longer fail on coverage jest checks.

## Code changes
- `ci.yml` - add write permissions for checks, pull-requests, and contents

# Testing guidance
- Unfortunately we have to merge this in order to see if it works, but it did work in `bulk-export-server`.