### PR TITLE
Add more info for ndjson errors

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 coverage
+ecqm-content-r4-2021

--- a/src/database/dbOperations.js
+++ b/src/database/dbOperations.js
@@ -292,6 +292,7 @@ const decrementBulkFileCount = async (clientId, resourceCount) => {
 
   // Complete import request when file count reaches 0
   if (value.exportedFileCount === 0) {
+    logger.info(`Completed Import Request for: ${clientId}`);
     await completeBulkImportRequest(clientId);
   }
 };

--- a/src/database/dbOperations.js
+++ b/src/database/dbOperations.js
@@ -203,9 +203,13 @@ const pushBulkFailedOutcomes = async (clientId, failedOutcomes) => {
  * @param {String} fileUrl The url for the resource ndjson
  * @param {Array} failedOutcomes An array of strings with messages detailing why the resource failed import
  */
-const pushNdjsonFailedOutcomes = async (clientId, fileUrl, failedOutcomes) => {
+const pushNdjsonFailedOutcomes = async (clientId, fileUrl, failedOutcomes, successCount) => {
   const collection = db.collection('ndjsonStatuses');
-  await collection.insertOne({ id: clientId + fileUrl, failedOutcomes: failedOutcomes });
+  await collection.insertOne({
+    id: clientId + fileUrl,
+    failedOutcomes: failedOutcomes,
+    successCount: successCount
+  });
   return clientId;
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -63,7 +63,7 @@ process.on('SIGINT', exitHandler);
 process.on('SIGTERM', exitHandler);
 
 let stopping = false;
-function exitHandler(code) {
+function exitHandler() {
   if (!stopping) {
     stopping = true;
     logger.info('Shuting down...');
@@ -72,7 +72,7 @@ function exitHandler(code) {
     });
     setTimeout(() => {
       logger.info('Workers stopped... Goodbye!');
-      process.exit(code ?? 0);
+      process.exit();
     }, 2000);
   }
 }

--- a/src/server/execWorker.js
+++ b/src/server/execWorker.js
@@ -112,4 +112,17 @@ execQueue.process(async job => {
   return res;
 });
 
+process.on('exit', exitHandler);
+process.on('SIGINT', exitHandler);
+process.on('SIGTERM', exitHandler);
+
+let stopping = false;
+function exitHandler() {
+  if (!stopping) {
+    stopping = true;
+    logger.info(`exec-worker-${process.pid}: Execution Worker Stopping`);
+    process.exit();
+  }
+}
+
 module.exports = execQueue;

--- a/src/server/importWorker.js
+++ b/src/server/importWorker.js
@@ -51,3 +51,16 @@ const executeImportWorkflow = async (clientEntryId, inputUrls) => {
     return false;
   }
 };
+
+process.on('exit', exitHandler);
+process.on('SIGINT', exitHandler);
+process.on('SIGTERM', exitHandler);
+
+let stopping = false;
+function exitHandler() {
+  if (!stopping) {
+    stopping = true;
+    logger.info(`import-worker-${process.pid}: Import Worker Stopping`);
+    process.exit();
+  }
+}

--- a/src/server/ndjsonWorker.js
+++ b/src/server/ndjsonWorker.js
@@ -56,7 +56,7 @@ ndjsonWorker.process(async job => {
   const ndjsonLines = ndjsonResources.split(/\n/);
 
   // keep track of when we hit the first non-empty line
-  let hitNonEmpty = false;
+  let firstNonEmptyLine = null;
 
   const insertions = ndjsonLines.map(async (resourceStr, index) => {
     resourceStr = resourceStr.trim();
@@ -66,17 +66,17 @@ ndjsonWorker.process(async job => {
       return null;
     }
 
+    // if this is the first non empty line then mark that we found it
+    if (firstNonEmptyLine === null) {
+      firstNonEmptyLine = index;
+    }
+
     // attempt to parse the line
     try {
-      // capture the value of if we already hit a non empty line incase we can parse this resource
-      const wasNotEmptyHit = hitNonEmpty;
-      // set this to true now that we have reached a non empty line
-      hitNonEmpty = true;
-
       const data = JSON.parse(resourceStr);
 
       // check if first non empty line is a Parameters header and skip it
-      if (!wasNotEmptyHit && data.resourceType === 'Parameters') {
+      if (firstNonEmptyLine === index && data.resourceType === 'Parameters') {
         return null;
       }
 

--- a/src/services/bulkstatus.service.js
+++ b/src/services/bulkstatus.service.js
@@ -140,6 +140,26 @@ async function checkBulkStatus(req, res) {
               };
               response.entry[0].resource.parameter.push(inputResult);
             });
+            const successCountResult = {
+              name: 'outcome',
+              part: [
+                { name: 'associatedInputUrl', valueUrl: url.valueUrl },
+                {
+                  name: 'operationOutcome',
+                  resource: {
+                    resourceType: 'OperationOutcome',
+                    issue: [
+                      {
+                        severity: 'information',
+                        code: 'informational',
+                        details: { text: `Successfully processed ${ndjsonStatus.successCount} rows.` }
+                      }
+                    ]
+                  }
+                }
+              ]
+            };
+            response.entry[0].resource.parameter.push(successCountResult);
           }
         }
       }

--- a/src/services/bulkstatus.service.js
+++ b/src/services/bulkstatus.service.js
@@ -40,13 +40,7 @@ async function checkBulkStatus(req, res) {
   }
 
   logger.debug(`Retrieved the following bulkStatus entry for client: ${clientId}. ${JSON.stringify(bulkStatus)}`);
-  if (
-    bulkStatus.status === 'In Progress' ||
-    (bulkStatus.status === 'In Progress' &&
-      bulkStatus.exportedFileCount &&
-      bulkStatus.totalFileCount &&
-      bulkStatus.exportedFileCount === bulkStatus.totalFileCount)
-  ) {
+  if (bulkStatus.status === 'In Progress') {
     logger.debug(`bulkStatus entry is in progress`);
     res.status(202);
     // Compute percent of files or resources exported

--- a/src/services/bulkstatus.service.js
+++ b/src/services/bulkstatus.service.js
@@ -85,7 +85,7 @@ async function checkBulkStatus(req, res) {
     };
 
     return response;
-  } else if (bulkStatus.status === 'Completed' || bulkStatus.exportedFileCount === bulkStatus.totalFileCount) {
+  } else if (bulkStatus.status === 'Completed') {
     logger.debug(`bulkStatus entry is completed`);
     res.status(200);
     res.set('Expires', 'EXAMPLE_EXPIRATION_DATE');

--- a/test/fixtures/testBulkStatus.json
+++ b/test/fixtures/testBulkStatus.json
@@ -96,6 +96,24 @@
         {
           "name": "requestIdentity",
           "valueString": "request-identity-example"
+        },
+        {
+          "name": "input",
+          "part": [
+            {
+              "name": "url",
+              "valueUrl": "http://localhost:3001/Condition.ndjson"
+            },
+            {
+              "name": "inputDetails",
+              "part": [
+                {
+                  "name": "resourceType",
+                  "valueCode": "Condition"
+                }
+              ]
+            }
+          ]
         }
       ]
     }

--- a/test/fixtures/testNdjsonStatus.json
+++ b/test/fixtures/testNdjsonStatus.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": "COMPLETED_REQUEST_WITH_RESOURCE_ERRORShttp://localhost:3001/Condition.ndjson",
+    "failedOutcomes": ["Test error message"],
+    "successCount": 3
+  }
+]

--- a/test/populateTestData.js
+++ b/test/populateTestData.js
@@ -1,5 +1,6 @@
 const { db, client } = require('../src/database/connection');
 const testStatuses = require('./fixtures/testBulkStatus.json');
+const testNdjsonStatuses = require('./fixtures/testNdjsonStatus.json');
 const testOperationOutcome = require('./fixtures/fhir-resources/testOperationOutcome.json');
 const importQueue = require('../src/queue/importQueue');
 const { execQueue } = require('../src/queue/execQueue');
@@ -44,7 +45,11 @@ const bulkStatusSetup = async () => {
   const promises = testStatuses.map(async status => {
     await createTestResource(status, 'bulkImportStatuses');
   });
+  const ndjsonStatus = testNdjsonStatuses.map(async ndjsonStatus => {
+    await createTestResource(ndjsonStatus, 'ndjsonStatuses');
+  });
   await Promise.all(promises);
+  await Promise.all(ndjsonStatus);
 };
 
 const clientFileSetup = async () => {

--- a/test/services/bulkstatus.service.test.js
+++ b/test/services/bulkstatus.service.test.js
@@ -27,7 +27,7 @@ describe('bulkstatus.service', () => {
       expect(response.headers['content-type']).toEqual('application/json; charset=utf-8');
       expect(response.body).toBeDefined();
       expect(response.body.entry[0].response.status).toEqual('200');
-      // add check for All OK OperationOutcome ?
+      expect(response.body.entry[0].resource.parameter[1].part[0].resource.issue[0].details.text).toEqual('All OK');
     });
 
     it('returns 200 status and a batch-response bundle with 400 status when $import failed', async () => {
@@ -35,10 +35,23 @@ describe('bulkstatus.service', () => {
       expect(response.headers['content-type']).toEqual('application/json; charset=utf-8');
       expect(response.body).toBeDefined();
       expect(response.body.entry[0].response.status).toEqual('400');
-      // add check for fatal OperationOutcome ?
+      expect(response.body.entry[0].response.outcome.issue[0].severity).toEqual('fatal');
     });
 
-    // TODO: Add tests for when a 200 status is returned but there were failed outcomes
+    it('returns 200 status for completed request but with one failed outcome', async () => {
+      const response = await supertest(server.app)
+        .get('/4_0_1/bulkstatus/COMPLETED_REQUEST_WITH_RESOURCE_ERRORS')
+        .expect(200);
+      expect(response.headers['content-type']).toEqual('application/json; charset=utf-8');
+      expect(response.body).toBeDefined();
+      expect(response.body.entry[0].response.status).toEqual('200');
+      expect(response.body.entry[0].resource.parameter[1].part[1].resource.issue[0].details.text).toEqual(
+        'Test error message'
+      );
+      expect(response.body.entry[0].resource.parameter[2].part[1].resource.issue[0].details.text).toEqual(
+        'Successfully processed 3 rows.'
+      );
+    });
 
     it('returns 404 status for request with unknown ID', async () => {
       await supertest(server.app)


### PR DESCRIPTION
# Summary
This PR adds specific import bulkstatus responses to align more closely with examples for bulk import responses in the [DEQM IG](https://build.fhir.org/ig/HL7/davinci-deqm/branches/bulk-import-draft/StructureDefinition-ImportResult.html). Specifically, it includes the row number for any ndjson errors that occur as well as the total number of resources uploaded by a single ndjson file. This follows the guidance in [this](https://build.fhir.org/ig/HL7/davinci-deqm/branches/bulk-import-draft/Parameters-example-import-result-resource-identity-input-error-embedded.json.html) example import result. 

## New behavior
If any of the resources in an ndjson file resulted in errors, the embedded OperationOutcome now includes the row number in which that error occurs. Additionally, an informational OperationOutcome is included to communicate the number of resources that were successfully processed.

## Code changes
- `.prettierignore` - added `ecqm-content-r4-2021`
- `src/database/dbOperations.js` - added `successCount` to track the number of successful resources for each individual ndjson file 
- `src/server/ndjsonWorker.js` - include `successCount` for individual ndjson files
- `src/services/bulkstatus.service.js` - added informational OperationOutcome for the number of resources successfully processed (follows the example import result in the DEQM IG linked above)
- `test/fixtures/testBulkStatus.json` - added input to the `COMPLETED_REQUEST_WITH_RESOURCE_ERRORS` bulkstatus object for unit testing
- `test/fixtures/testNdjsonStatus.json` - added an ndjson status object for unit testing
- `test/populateTestData.js` - add the new `ndjsonStatus` to the test database
- `test/services/bulkstatus.service.ts` - added additional unit testing checks and unit test for when the status is 200 but there was a failed outcome

# Testing guidance
- `npm run check` 

The following process is how I tested different error scenarios in the ndjsonWorker. I am not sure if it is the easiest/best process but it worked for me! Let me know if there are easier/better ways to test:

Utilize the attached Insomnia requests: 
- `npm run db:reset` in `deqm-test-server` to clear the database
- `npm run start` in `deqm-test-server`
- Checkout the `malformed-ndjson-testing` branch in `bulk-export-server`. NOTE: this branch is NOT to be merged ever, just for testing purposes. Lines 262-278 in `exportToNDJson.js` include three different arrays for input into the new function `writeStringToFile`. `ndjsonBadResourceType` contains a resource with a resourceType that is not supported. `malformedNDJSON` contains a resource with malformed ndjson. `goodNdjson` contains three entries that should have no issues.
- `npm run upload-bundles` in `bulk-export-server`
- `PORT=3001 npm run start` in `bulk-export-server`
- Do a get to the Condition endpoint in `deqm-test-server` to confirm that there are 0 Condition resources on the server (last request in Insomnia collection)
- Do a `$export` in the `bulk-export-server` (first request in Insomnia collection) 
- Do a `bulkstatus` in the `bulk-export-server` (second request in Insomnia collection) to get the ndjson endpoints 
- Do a `$import` in the `deqm-test-server` (third request in Insomnia collection)
- Check the bulkstatus of that import in the `deqm-test-server` (fourth request in Insomnia collection). Make sure the response matches whatever array was used in the `malformed-ndjson-testing` branch of `bulk-export-server` (`goodNjson` results in "All OK", `malformedNDJSON` results in an error at row 2 for `Condition.ndjson` and informational OperationOutcome says 2 resources were successfully processed, `ndjsonBadResourceType` results in an error at row 2 for `Condition.ndjson` and informational OperationOutcome says 2 resources were successfully processed)

[ndjson-error-handling-requests.json](https://github.com/user-attachments/files/16600695/ndjson-error-handling-requests.json)
