### PR TITLE
Update $evaluate-measure to $evaluate

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ This operation will execute in a multi-process manner by chunking up the patient
 | `SCALED_EXEC_MAX_JOBSIZE` | Maximum patients to put in each worker job.                                 | 15            |
 | `SCALED_EXEC_STRATEGY`    | Patient source strategy to use for scaled calculation (`mongo` or `bundle`) | bundle        |
 
-Check out the [$evaluate operation spec](https://www.hl7.org/fhir/measure-operation-evaluate.html) for more information.
+Check out the [$evaluate operation spec](https://hl7.org/fhir/us/davinci-deqm/2024Sep/OperationDefinition-evaluate.html) for more information. Note: The server does not currently return a Bundle, but updates will be made to reflect this latest OperationDefinition.
 
 #### `$care-gaps`
 

--- a/README.md
+++ b/README.md
@@ -2,24 +2,26 @@
 
 Test server for executing FHIR-based Electronic Clinical Quality Measures (eCQMs).
 
-- [Installation](#installation)
-
-  - [Prerequisites](#prerequisites)
-  - [Local Installation](#local-installation)
-  - [Testing](#testing)
-  - [MongoDB](#mongodb)
-  - [Redis Installation](#redis-installation)
-  - [Docker](#docker)
-
-- [Usage](#usage)
-
-  - [Database Setup](#database-setup)
-  - [CRUD Operations](#crud-operations)
-  - [Searches](#searches)
-  - [Supported FHIR Operations](#supported-fhir-operations)
-  - [Bulk Import](#bulk-import)
-
-- [License](#license)
+- [Data Exchange for Quality Measures (DEQM) Test Server](#data-exchange-for-quality-measures-deqm-test-server)
+  - [Installation](#installation)
+    - [Prerequisites](#prerequisites)
+    - [Local Installation](#local-installation)
+    - [Testing](#testing)
+    - [MongoDB](#mongodb)
+    - [Redis Installation](#redis-installation)
+    - [Docker](#docker)
+  - [Usage](#usage)
+    - [Database Setup](#database-setup)
+    - [CRUD Operations](#crud-operations)
+    - [Searches](#searches)
+    - [Supported FHIR Operations](#supported-fhir-operations)
+      - [`$evaluate`](#evaluate)
+      - [`$care-gaps`](#care-gaps)
+      - [`$data-requirements`](#data-requirements)
+      - [`$submit-data`](#submit-data)
+      - [`Patient/$everything`](#patienteverything)
+    - [Bulk Import](#bulk-import)
+  - [License](#license)
 
 ## Installation
 
@@ -124,7 +126,7 @@ The test server's resource searching capabilities support searches by identifier
 
 ### Supported FHIR Operations
 
-#### `$evaluate-measure`
+#### `$evaluate`
 
 This operation calculates a measure for a given patient. Currently, individual and population measure reports are supported. Subject-list measure reports are not yet supported.
 
@@ -141,7 +143,7 @@ Optional parameters include:
 Currently, `measure` and `lastReceivedOn` parameters are not supported by the test server. The `subject-list` `reportType` is not supported by the test server - only `subject` and `population` `reportTypes` are supported at this time,
 which will generate `individual` and `summary` `MeasureReport`s respectively.
 
-To use, first POST a measure bundle into your database, then send a GET request to `http://localhost:3000/4_0_1/Measure/<your-measure-id>/$evaluate-measure` with the required parameters.
+To use, first POST a measure bundle into your database, then send a GET request to `http://localhost:3000/4_0_1/Measure/<your-measure-id>/$evaluate` with the required parameters.
 
 This operation will execute in a multi-process manner by chunking up the patients to smaller groups and executing across 5 processes if there are more than 100 patients to execute. The settings for this multi-process "Scaled" calculation can be configured in the `.env` file:
 
@@ -152,7 +154,7 @@ This operation will execute in a multi-process manner by chunking up the patient
 | `SCALED_EXEC_MAX_JOBSIZE` | Maximum patients to put in each worker job.                                 | 15            |
 | `SCALED_EXEC_STRATEGY`    | Patient source strategy to use for scaled calculation (`mongo` or `bundle`) | bundle        |
 
-Check out the [$evaluate-measure operation spec](https://www.hl7.org/fhir/measure-operation-evaluate-measure.html) for more information.
+Check out the [$evaluate operation spec](https://www.hl7.org/fhir/measure-operation-evaluate.html) for more information.
 
 #### `$care-gaps`
 

--- a/README.md
+++ b/README.md
@@ -3,25 +3,24 @@
 Test server for executing FHIR-based Electronic Clinical Quality Measures (eCQMs).
 
 - [Data Exchange for Quality Measures (DEQM) Test Server](#data-exchange-for-quality-measures-deqm-test-server)
-  - [Installation](#installation)
-    - [Prerequisites](#prerequisites)
-    - [Local Installation](#local-installation)
-    - [Testing](#testing)
-    - [MongoDB](#mongodb)
-    - [Redis Installation](#redis-installation)
-    - [Docker](#docker)
-  - [Usage](#usage)
-    - [Database Setup](#database-setup)
-    - [CRUD Operations](#crud-operations)
-    - [Searches](#searches)
-    - [Supported FHIR Operations](#supported-fhir-operations)
-      - [`$evaluate`](#evaluate)
-      - [`$care-gaps`](#care-gaps)
-      - [`$data-requirements`](#data-requirements)
-      - [`$submit-data`](#submit-data)
-      - [`Patient/$everything`](#patienteverything)
-    - [Bulk Import](#bulk-import)
-  - [License](#license)
+- [Installation](#installation)
+
+  - [Prerequisites](#prerequisites)
+  - [Local Installation](#local-installation)
+  - [Testing](#testing)
+  - [MongoDB](#mongodb)
+  - [Redis Installation](#redis-installation)
+  - [Docker](#docker)
+
+- [Usage](#usage)
+
+  - [Database Setup](#database-setup)
+  - [CRUD Operations](#crud-operations)
+  - [Searches](#searches)
+  - [Supported FHIR Operations](#supported-fhir-operations)
+  - [Bulk Import](#bulk-import)
+
+- [License](#license)
 
 ## Installation
 

--- a/src/config/profileConfig.js
+++ b/src/config/profileConfig.js
@@ -93,13 +93,13 @@ const buildConfig = () => {
               name: 'evaluateMeasure',
               route: '/:id/$evaluate',
               method: 'GET',
-              reference: 'https://www.hl7.org/fhir/measure-operation-evaluate.html'
+              reference: 'https://hl7.org/fhir/us/davinci-deqm/2024Sep/OperationDefinition-evaluate.html'
             },
             {
               name: 'evaluateMeasure',
               route: '/:id/$evaluate',
               method: 'POST',
-              reference: 'https://www.hl7.org/fhir/measure-operation-evaluate.html'
+              reference: 'https://hl7.org/fhir/us/davinci-deqm/2024Sep/OperationDefinition-evaluate.html'
             },
             {
               name: 'careGaps',

--- a/src/config/profileConfig.js
+++ b/src/config/profileConfig.js
@@ -91,15 +91,15 @@ const buildConfig = () => {
             },
             {
               name: 'evaluateMeasure',
-              route: '/:id/$evaluate-measure',
+              route: '/:id/$evaluate',
               method: 'GET',
-              reference: 'https://www.hl7.org/fhir/measure-operation-evaluate-measure.html'
+              reference: 'https://www.hl7.org/fhir/measure-operation-evaluate.html'
             },
             {
               name: 'evaluateMeasure',
-              route: '/:id/$evaluate-measure',
+              route: '/:id/$evaluate',
               method: 'POST',
-              reference: 'https://www.hl7.org/fhir/measure-operation-evaluate-measure.html'
+              reference: 'https://www.hl7.org/fhir/measure-operation-evaluate.html'
             },
             {
               name: 'careGaps',

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -186,7 +186,7 @@ const dataRequirements = async (args, { req }) => {
  * @returns {Object} FHIR MeasureReport with population results
  */
 const evaluateMeasure = async (args, { req }) => {
-  logger.info('Measure >>> $evaluate-measure');
+  logger.info('Measure >>> $evaluate');
   logger.debug(`Request headers: ${JSON.stringify(req.header)}`);
   logger.debug(`Request args: ${JSON.stringify(args)}`);
   logger.debug(`Request body: ${JSON.stringify(req.body)}`);
@@ -277,7 +277,7 @@ const evaluateMeasureForPopulation = async (args, { req }) => {
       reportType: 'summary'
     });
 
-    logger.info('Successfully generated $evaluate-measure report');
+    logger.info('Successfully generated $evaluate report');
     return results;
   }
 };

--- a/src/util/operationValidationUtils.js
+++ b/src/util/operationValidationUtils.js
@@ -23,9 +23,7 @@ function validateEvalMeasureParams(query) {
   }
 
   if (!query.subject && query.reportType === 'subject') {
-    throw new BadRequestError(
-      `Must specify subject for all $evaluate requests with reportType parameter: subject`
-    );
+    throw new BadRequestError(`Must specify subject for all $evaluate requests with reportType parameter: subject`);
   }
 
   if (query.reportType === 'population' && query.subject) {

--- a/src/util/operationValidationUtils.js
+++ b/src/util/operationValidationUtils.js
@@ -1,7 +1,7 @@
 const { BadRequestError, NotImplementedError } = require('./errorUtils');
 
 /**
- * Checks that the parameters input to $evaluate-measure are valid. Throws an error
+ * Checks that the parameters input to $evaluate are valid. Throws an error
  * for missing parameters, the use of unsupported parameters, and the use of unsupported
  * report types.
  * @param {Object} query query from http request object
@@ -10,8 +10,8 @@ function validateEvalMeasureParams(query) {
   const REQUIRED_PARAMS = ['periodStart', 'periodEnd'];
   const UNSUPPORTED_PARAMS = ['measure', 'lastReceivedOn'];
 
-  checkRequiredParams(query, REQUIRED_PARAMS, '$evaluate-measure');
-  checkNoUnsupportedParams(query, UNSUPPORTED_PARAMS, '$evaluate-measure');
+  checkRequiredParams(query, REQUIRED_PARAMS, '$evaluate');
+  checkNoUnsupportedParams(query, UNSUPPORTED_PARAMS, '$evaluate');
 
   if (query.reportType === 'subject-list') {
     throw new NotImplementedError(`The subject-list reportType is not currently supported by the server.`);
@@ -19,12 +19,12 @@ function validateEvalMeasureParams(query) {
 
   // returns unsupported report type that is included in the http request
   if (!['subject', 'population', 'subject-list', undefined].includes(query.reportType)) {
-    throw new BadRequestError(`reportType ${query.reportType} is not supported for $evaluate-measure`);
+    throw new BadRequestError(`reportType ${query.reportType} is not supported for $evaluate`);
   }
 
   if (!query.subject && query.reportType === 'subject') {
     throw new BadRequestError(
-      `Must specify subject for all $evaluate-measure requests with reportType parameter: subject`
+      `Must specify subject for all $evaluate requests with reportType parameter: subject`
     );
   }
 

--- a/src/util/patientUtils.js
+++ b/src/util/patientUtils.js
@@ -115,7 +115,7 @@ const retrievePatientIds = async ({ subject, organization, practitioner }) => {
 };
 
 /**
- * Takes in a Group resource and practitioner from an evaluate-measure query and filters the
+ * Takes in a Group resource and practitioner from an evaluate query and filters the
  * patients from the Group to those which reference the Practitioner resource
  * @param {Object} group A Group Resource
  * @param {string} practitioner A reference to a FHIR Practitioner. All patients which list the referenced practitioner

--- a/test/services/measure.service.test.js
+++ b/test/services/measure.service.test.js
@@ -200,7 +200,7 @@ describe('measure.service', () => {
         });
     });
 
-    test('$evaluate-measure returns 200 when subject is omitted and reportType is set to population', async () => {
+    test('$evaluate returns 200 when subject is omitted and reportType is set to population', async () => {
       const { Calculator } = require('fqm-execution');
       const mrSpy = jest.spyOn(Calculator, 'calculateMeasureReports').mockImplementation(() => {
         return {
@@ -229,7 +229,7 @@ describe('measure.service', () => {
         };
       });
       await supertest(server.app)
-        .get('/4_0_1/Measure/testMeasure/$evaluate-measure')
+        .get('/4_0_1/Measure/testMeasure/$evaluate')
         .query({
           periodStart: '01-01-2020',
           periodEnd: '01-01-2021',
@@ -243,7 +243,7 @@ describe('measure.service', () => {
       });
     });
 
-    test('$evaluate-measure returns 200 when subject is existing group and reportType is set to population', async () => {
+    test('$evaluate returns 200 when subject is existing group and reportType is set to population', async () => {
       const { Calculator } = require('fqm-execution');
       const mrSpy = jest.spyOn(Calculator, 'calculateMeasureReports').mockImplementation(() => {
         return {
@@ -272,7 +272,7 @@ describe('measure.service', () => {
         };
       });
       await supertest(server.app)
-        .get('/4_0_1/Measure/testMeasure/$evaluate-measure')
+        .get('/4_0_1/Measure/testMeasure/$evaluate')
         .query({
           periodStart: '01-01-2020',
           periodEnd: '01-01-2021',
@@ -287,7 +287,7 @@ describe('measure.service', () => {
       });
     });
 
-    test('$evaluate-measure should default to reportType population when not set and no subject provided', async () => {
+    test('$evaluate should default to reportType population when not set and no subject provided', async () => {
       const { Calculator } = require('fqm-execution');
       const mrSpy = jest.spyOn(Calculator, 'calculateMeasureReports').mockImplementation(() => {
         return {
@@ -318,7 +318,7 @@ describe('measure.service', () => {
       });
 
       await supertest(server.app)
-        .get('/4_0_1/Measure/testMeasure/$evaluate-measure')
+        .get('/4_0_1/Measure/testMeasure/$evaluate')
         .query({
           periodStart: '01-01-2020',
           periodEnd: '01-01-2021'
@@ -332,7 +332,7 @@ describe('measure.service', () => {
       });
     });
 
-    test('$evaluate-measure should default to reportType subject when not set and subject is provided', async () => {
+    test('$evaluate should default to reportType subject when not set and subject is provided', async () => {
       const { Calculator } = require('fqm-execution');
       const mrSpy = jest.spyOn(Calculator, 'calculateMeasureReports').mockImplementation(() => {
         return {
@@ -363,7 +363,7 @@ describe('measure.service', () => {
       });
 
       await supertest(server.app)
-        .get('/4_0_1/Measure/testMeasure/$evaluate-measure')
+        .get('/4_0_1/Measure/testMeasure/$evaluate')
         .query({
           periodStart: '01-01-2020',
           periodEnd: '01-01-2021',
@@ -378,7 +378,7 @@ describe('measure.service', () => {
       });
     });
 
-    test('$evaluate-measure returns 200 when passed a practitioner referenced by a Patient subject, individual report type', async () => {
+    test('$evaluate returns 200 when passed a practitioner referenced by a Patient subject, individual report type', async () => {
       const { Calculator } = require('fqm-execution');
       const mrSpy = jest.spyOn(Calculator, 'calculateMeasureReports').mockImplementation(() => {
         return {
@@ -407,7 +407,7 @@ describe('measure.service', () => {
         };
       });
       await supertest(server.app)
-        .get('/4_0_1/Measure/testMeasure/$evaluate-measure')
+        .get('/4_0_1/Measure/testMeasure/$evaluate')
         .query({
           periodStart: '01-01-2020',
           periodEnd: '01-01-2021',
@@ -423,7 +423,7 @@ describe('measure.service', () => {
       });
     });
 
-    test('$evaluate-measure returns 200 when passed a practitioner referenced by a patient in the Group subject, population report type', async () => {
+    test('$evaluate returns 200 when passed a practitioner referenced by a patient in the Group subject, population report type', async () => {
       const { Calculator } = require('fqm-execution');
       const mrSpy = jest.spyOn(Calculator, 'calculateMeasureReports').mockImplementation(() => {
         return {
@@ -452,7 +452,7 @@ describe('measure.service', () => {
         };
       });
       await supertest(server.app)
-        .get('/4_0_1/Measure/testMeasure/$evaluate-measure')
+        .get('/4_0_1/Measure/testMeasure/$evaluate')
         .query({
           periodStart: '01-01-2020',
           periodEnd: '01-01-2021',
@@ -468,7 +468,7 @@ describe('measure.service', () => {
       });
     });
 
-    test('$evaluate-measure returns 200 when passed a practitioner referenced by a patient, population report type, no subject', async () => {
+    test('$evaluate returns 200 when passed a practitioner referenced by a patient, population report type, no subject', async () => {
       const { Calculator } = require('fqm-execution');
       const mrSpy = jest.spyOn(Calculator, 'calculateMeasureReports').mockImplementation(() => {
         return {
@@ -497,7 +497,7 @@ describe('measure.service', () => {
         };
       });
       await supertest(server.app)
-        .get('/4_0_1/Measure/testMeasure/$evaluate-measure')
+        .get('/4_0_1/Measure/testMeasure/$evaluate')
         .query({
           periodStart: '01-01-2020',
           periodEnd: '01-01-2021',
@@ -512,9 +512,9 @@ describe('measure.service', () => {
       });
     });
 
-    test('$evaluate-measure returns 400 when practitioner is not referenced by Patient subject, individual report type', async () => {
+    test('$evaluate returns 400 when practitioner is not referenced by Patient subject, individual report type', async () => {
       await supertest(server.app)
-        .get('/4_0_1/Measure/testMeasure/$evaluate-measure')
+        .get('/4_0_1/Measure/testMeasure/$evaluate')
         .query({
           reportType: 'subject',
           periodStart: '01-01-2020',
@@ -531,9 +531,9 @@ describe('measure.service', () => {
         });
     });
 
-    test('$evaluate-measure returns 400 when practitioner is not referenced by any patients in Group subject, population report type', async () => {
+    test('$evaluate returns 400 when practitioner is not referenced by any patients in Group subject, population report type', async () => {
       await supertest(server.app)
-        .get('/4_0_1/Measure/testMeasure/$evaluate-measure')
+        .get('/4_0_1/Measure/testMeasure/$evaluate')
         .query({
           reportType: 'population',
           periodStart: '01-01-2020',
@@ -550,9 +550,9 @@ describe('measure.service', () => {
         });
     });
 
-    test('$evaluate-measure returns 400 when practitioner is not referenced by any patients, population report type, no subject', async () => {
+    test('$evaluate returns 400 when practitioner is not referenced by any patients, population report type, no subject', async () => {
       await supertest(server.app)
-        .get('/4_0_1/Measure/testMeasure/$evaluate-measure')
+        .get('/4_0_1/Measure/testMeasure/$evaluate')
         .query({
           reportType: 'population',
           periodStart: '01-01-2020',

--- a/test/util/operationValidationUtils.test.js
+++ b/test/util/operationValidationUtils.test.js
@@ -109,7 +109,7 @@ describe('checkRequiredParams', () => {
 });
 
 describe('validateEvalMeasureParams', () => {
-  test('error thrown for unsupported $evaluate-measure params', () => {
+  test('error thrown for unsupported $evaluate params', () => {
     const UNSUPPORTEDREQ = {
       query: { lastReceivedOn: '2019-01-01', periodStart: '2019-01-01', periodEnd: '2019-12-31' }
     };
@@ -119,12 +119,12 @@ describe('validateEvalMeasureParams', () => {
     } catch (e) {
       expect(e.statusCode).toEqual(501);
       expect(e.issue[0].details.text).toEqual(
-        `The following parameters were included and are not supported for $evaluate-measure: lastReceivedOn`
+        `The following parameters were included and are not supported for $evaluate: lastReceivedOn`
       );
     }
   });
 
-  test('error thrown for unsupported $evaluate-measure reportType', () => {
+  test('error thrown for unsupported $evaluate reportType', () => {
     const UNSUPPORTEDREQ = {
       query: { reportType: 'subject-list', periodStart: '2019-01-01', periodEnd: '2019-12-31' }
     };
@@ -137,7 +137,7 @@ describe('validateEvalMeasureParams', () => {
     }
   });
 
-  test('error thrown for invalid $evaluate-measure reportType', () => {
+  test('error thrown for invalid $evaluate reportType', () => {
     const INVALIDREQ = {
       query: { reportType: 'invalid', periodStart: '2019-01-01', periodEnd: '2019-12-31' }
     };
@@ -146,11 +146,11 @@ describe('validateEvalMeasureParams', () => {
       expect.fail('validateEvalMeasureParams failed to throw error for invalid reportType');
     } catch (e) {
       expect(e.statusCode).toEqual(400);
-      expect(e.issue[0].details.text).toEqual(`reportType invalid is not supported for $evaluate-measure`);
+      expect(e.issue[0].details.text).toEqual(`reportType invalid is not supported for $evaluate`);
     }
   });
 
-  test('error thrown for missing subject for $evaluate-measure', () => {
+  test('error thrown for missing subject for $evaluate', () => {
     const MISSING_SUBJECT_REQ = {
       query: { reportType: 'subject', periodStart: '2019-01-01', periodEnd: '2019-12-31' }
     };
@@ -160,12 +160,12 @@ describe('validateEvalMeasureParams', () => {
     } catch (e) {
       expect(e.statusCode).toEqual(400);
       expect(e.issue[0].details.text).toEqual(
-        `Must specify subject for all $evaluate-measure requests with reportType parameter: subject`
+        `Must specify subject for all $evaluate requests with reportType parameter: subject`
       );
     }
   });
 
-  test('error thrown for population $evaluate-measure with non-Group subject', () => {
+  test('error thrown for population $evaluate with non-Group subject', () => {
     const POPULATION_REQ = {
       query: {
         reportType: 'population',
@@ -185,7 +185,7 @@ describe('validateEvalMeasureParams', () => {
     }
   });
 
-  test('error thrown for subject $evaluate-measure with non-Patient reference subject', () => {
+  test('error thrown for subject $evaluate with non-Patient reference subject', () => {
     const INDIVIDUAL_REQ = {
       query: {
         reportType: 'subject',


### PR DESCRIPTION
# Summary
`$evaluate-measure` was renamed to `$evaluate`. Updated the name of the endpoint in all instances of the `deqm-test-server`.

## New behavior
No changes in behavior, endpoint should work as normal. 

## Code changes
Naming changes in:
- `README.md`
- `profileConfig.js`
- `measure.service.js`
- `operationValidationUtils.js`
- `PatientUtils.js`
- `measure.service.test.js`
- `operationValidationUtils.test.js`

# Testing guidance
`npm run check`
`npm run start`
Check different endpoints to make sure they all work as expected!
