### PR TITLE
Updated $evaluate output to parameters resource 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,24 +3,25 @@
 Test server for executing FHIR-based Electronic Clinical Quality Measures (eCQMs).
 
 - [Data Exchange for Quality Measures (DEQM) Test Server](#data-exchange-for-quality-measures-deqm-test-server)
-- [Installation](#installation)
-
-  - [Prerequisites](#prerequisites)
-  - [Local Installation](#local-installation)
-  - [Testing](#testing)
-  - [MongoDB](#mongodb)
-  - [Redis Installation](#redis-installation)
-  - [Docker](#docker)
-
-- [Usage](#usage)
-
-  - [Database Setup](#database-setup)
-  - [CRUD Operations](#crud-operations)
-  - [Searches](#searches)
-  - [Supported FHIR Operations](#supported-fhir-operations)
-  - [Bulk Import](#bulk-import)
-
-- [License](#license)
+  - [Installation](#installation)
+    - [Prerequisites](#prerequisites)
+    - [Local Installation](#local-installation)
+    - [Testing](#testing)
+    - [MongoDB](#mongodb)
+    - [Redis Installation](#redis-installation)
+    - [Docker](#docker)
+  - [Usage](#usage)
+    - [Database Setup](#database-setup)
+    - [CRUD Operations](#crud-operations)
+    - [Searches](#searches)
+    - [Supported FHIR Operations](#supported-fhir-operations)
+      - [`$evaluate`](#evaluate)
+      - [`$care-gaps`](#care-gaps)
+      - [`$data-requirements`](#data-requirements)
+      - [`$submit-data`](#submit-data)
+      - [`Patient/$everything`](#patienteverything)
+    - [Bulk Import](#bulk-import)
+  - [License](#license)
 
 ## Installation
 
@@ -153,7 +154,7 @@ This operation will execute in a multi-process manner by chunking up the patient
 | `SCALED_EXEC_MAX_JOBSIZE` | Maximum patients to put in each worker job.                                 | 15            |
 | `SCALED_EXEC_STRATEGY`    | Patient source strategy to use for scaled calculation (`mongo` or `bundle`) | bundle        |
 
-Check out the [$evaluate operation spec](https://hl7.org/fhir/us/davinci-deqm/2024Sep/OperationDefinition-evaluate.html) for more information. Note: The server does not currently return a Bundle, but updates will be made to reflect this latest OperationDefinition.
+This operation returns a Parameters object with 0..* Bundles, each of which must contain at least one MeasureReport. Check out the [$evaluate operation spec](https://build.fhir.org/ig/HL7/davinci-deqm/OperationDefinition-evaluate.html) for more information.
 
 #### `$care-gaps`
 

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -278,7 +278,7 @@ const evaluateMeasureForPopulation = async (args, { req }) => {
     });
 
     logger.info('Successfully generated $evaluate report');
-    return wrapReportsInBundlesParameters(results);
+    return wrapReportsInBundlesParameters([results]);
   }
 };
 

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -278,10 +278,7 @@ const evaluateMeasureForPopulation = async (args, { req }) => {
     });
 
     logger.info('Successfully generated $evaluate report');
-
-    // grouping measureReports by patient
-    const groupedMeasureReports = results.map(report => [report]);
-    return wrapReportsInBundlesParameters(groupedMeasureReports);
+    return wrapReportsInBundlesParameters(results);
   }
 };
 
@@ -329,36 +326,32 @@ const evaluateMeasureForIndividual = async (args, { req }) => {
     measurementPeriodEnd: periodEnd,
     reportType: 'individual'
   });
-  const groupedMeasureReports = [[results[0]]];
-  return wrapReportsInBundlesParameters(groupedMeasureReports);
+
+  return wrapReportsInBundlesParameters(results);
 };
 
 /**
  * Wraps groups of measureReports to bundles and wraps each Bundle in a parameter
- * @param {Array<Array<Object>>} groupedMeasureReports An array of arrays of
- * MeasureReports (one array per Bundle).
+ * @param {Array<Object>} measureReports An array of measureReports.
  * @returns {Object} A FHIR Parameters resource containing one parameter per Bundle.
  */
-const wrapReportsInBundlesParameters = groupedMeasureReports => {
-  const parameters = groupedMeasureReports.map(reportGroup => {
-    const bundle = {
-      resourceType: 'Bundle',
-      // TODO: do we need an id here?
-      type: 'collection',
-      entry: reportGroup.map(report => ({
-        resource: report
-      }))
-    };
+const wrapReportsInBundlesParameters = measureReports => {
+  const bundle = {
+    resourceType: 'Bundle',
+    type: 'collection',
+    entry: measureReports.map(report => ({
+      resource: report
+    }))
+  };
 
-    return {
-      name: 'return',
-      resource: bundle
-    };
-  });
+  const parameter = {
+    name: 'return',
+    resource: bundle
+  };
 
   return {
     resourceType: 'Parameters',
-    parameter: parameters
+    parameter: [parameter]
   };
 };
 

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -212,7 +212,7 @@ const evaluateMeasure = async (args, { req }) => {
  * Evaluate measure for "population" report type
  * @param {Object} args the args object passed in by the user, includes measure id
  * @param {Object} req http request object
- * @returns {Object} Parameters resource containing one or more Bundles of MeasureReports.
+ * @returns {Object} Parameters resource containing one Bundle with measureReports.
  */
 const evaluateMeasureForPopulation = async (args, { req }) => {
   const measureBundle = await getMeasureBundleFromId(args.id);
@@ -331,7 +331,7 @@ const evaluateMeasureForIndividual = async (args, { req }) => {
 };
 
 /**
- * Wraps groups of measureReports to bundles and wraps each Bundle in a parameter
+ * Wraps groups of measureReports in a Bundle and wraps the Bundle in a parameter
  * @param {Array<Object>} measureReports An array of measureReports.
  * @returns {Object} A FHIR Parameters resource containing one parameter per Bundle.
  */

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -183,7 +183,7 @@ const dataRequirements = async (args, { req }) => {
  * Execute the measure for a given Patient or Group
  * @param {Object} args the args object passed in by the user, includes measure id
  * @param {Object} req http request object
- * @returns {Object} FHIR MeasureReport with population results
+ * @returns {Object} Parameters resource containing one or more Bundles of MeasureReports.
  */
 const evaluateMeasure = async (args, { req }) => {
   logger.info('Measure >>> $evaluate');
@@ -212,7 +212,7 @@ const evaluateMeasure = async (args, { req }) => {
  * Evaluate measure for "population" report type
  * @param {Object} args the args object passed in by the user, includes measure id
  * @param {Object} req http request object
- * @returns {Object} FHIR MeasureReport with population results
+ * @returns {Object} Parameters resource containing one or more Bundles of MeasureReports.
  */
 const evaluateMeasureForPopulation = async (args, { req }) => {
   const measureBundle = await getMeasureBundleFromId(args.id);
@@ -278,7 +278,10 @@ const evaluateMeasureForPopulation = async (args, { req }) => {
     });
 
     logger.info('Successfully generated $evaluate report');
-    return results;
+
+    // grouping measureReports by patient
+    const groupedMeasureReports = results.map(report => [report]);
+    return wrapReportsInBundlesParameters(groupedMeasureReports);
   }
 };
 
@@ -286,7 +289,7 @@ const evaluateMeasureForPopulation = async (args, { req }) => {
  * Evaluate measure for "individual" report type
  * @param {Object} args the args object passed in by the user, includes measure id
  * @param {Object} req http request object
- * @returns {Object} FHIR MeasureReport with population results
+ * @returns {Object} Parameters resource containing one Bundle with a single MeasureReport.
  */
 const evaluateMeasureForIndividual = async (args, { req }) => {
   const measureBundle = await getMeasureBundleFromId(args.id);
@@ -326,7 +329,37 @@ const evaluateMeasureForIndividual = async (args, { req }) => {
     measurementPeriodEnd: periodEnd,
     reportType: 'individual'
   });
-  return results[0];
+  const groupedMeasureReports = [[results[0]]];
+  return wrapReportsInBundlesParameters(groupedMeasureReports);
+};
+
+/**
+ * Wraps groups of measureReports to bundles and wraps each Bundle in a parameter
+ * @param {Array<Array<Object>>} groupedMeasureReports An array of arrays of
+ * MeasureReports (one array per Bundle).
+ * @returns {Object} A FHIR Parameters resource containing one parameter per Bundle.
+ */
+const wrapReportsInBundlesParameters = groupedMeasureReports => {
+  const parameters = groupedMeasureReports.map(reportGroup => {
+    const bundle = {
+      resourceType: 'Bundle',
+      // TODO: do we need an id here?
+      type: 'collection',
+      entry: reportGroup.map(report => ({
+        resource: report
+      }))
+    };
+
+    return {
+      name: 'return',
+      resource: bundle
+    };
+  });
+
+  return {
+    resourceType: 'Parameters',
+    parameter: parameters
+  };
 };
 
 /**


### PR DESCRIPTION
# Summary
Updated the $evaluate [Implementation Guide specification](https://build.fhir.org/ig/HL7/davinci-deqm/OperationDefinition-evaluate.html). Previously, the server returned a single MeasureReport directly. Now, the response is wrapped in a FHIR Parameters resource containing one or more Bundle resources, each of which includes one or more MeasureReports.

## New behavior
The changes work both for `reportType=subject` (individual) and `reportType=population` responses

## Code changes
Updated `evaluateMeasureForPopulation` and `evaluateMeasureForIndividual` to wrap results in one or more Bundles.

Added new utility function `wrapReportsInBundlesParameters` to generate the Parameters resource from grouped `MeasureReports`.

# Testing guidance
`npm run check`
`npm run db:reset`
`npm run upload-bundles --test`

Using insomnia/ postman or curl, test the endpoints using:
GET `http://localhost:3000/4_0_1/Measure/{measureId}/$evaluate?periodStart=2025-01-01&periodEnd=2025-12-31&reportType=subject&subject=Patient/{patientId}` 
and
GET `http://localhost:3000/4_0_1/Measure/{measureId}/$evaluate?periodStart=2025-01-01&periodEnd=2025-12-31&reportType=population`
