### PR TITLE
Docker auto build platforms

### DIFF
--- a/.github/workflows/docker_hub_build.yml
+++ b/.github/workflows/docker_hub_build.yml
@@ -3,7 +3,7 @@ name: Docker Build
 on:
   push:
     branches:
-      - 'main'
+      - main
     tags:
       - 'v*.*.*'
 
@@ -41,5 +41,6 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64, linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker_hub_build.yml
+++ b/.github/workflows/docker_hub_build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - docker-auto-build-platforms
     tags:
       - 'v*.*.*'
 
@@ -42,6 +41,6 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64, linux/arm64
+          platforms: linux/amd64, linux/arm64/v8
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker_hub_build.yml
+++ b/.github/workflows/docker_hub_build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - docker-auto-build-platforms
     tags:
       - 'v*.*.*'
 


### PR DESCRIPTION
# Summary
This PR adds `platforms` to the `docker_hub_build.yml` so that the Docker image is published on both linux/amd64 and linux/arm64 every time a branch is pushed to main. This fixes an error I was getting trying to do `docker compose pull` in [deqm-test-kit](https://github.com/projecttacoma/deqm-test-kit).

## New behavior
- Platform build on linux/arm64 and linux/amd64 when a branch is merged into main
- Should fix errors when running `docker compose pull` in `deqm-test-kit`

## Code changes
- `.github/workflows/docker_hub_build.yml` - added platforms

# Testing guidance
- This is tricky to test, but luckily Nat's instructions were SUPER helpful on his PR [here](https://github.com/projecttacoma/deqm-test-server/pull/20) (thanks Nat!)
- Steps:
    - Checkout this branch 
    - Add `- docker-auto-build-platforms` under `push: branches:` (see [here](https://github.com/projecttacoma/deqm-test-server/commit/809f694a20f025de325987758a557c3a9515bed1))
    - Commit and push 
    - This should trigger the Docker build GH action
    - Look in [Docker hub](https://hub.docker.com/r/mitrehealthdocker/deqm-test-server/tags) to see if both platforms were published
    - Note: when I did this, it took 26 minutes for some reason...I don't think this is a problem but definitely a little curious about it if anyone has any thoughts
    - Once it is built, navigate to deqm-test-kit
    - In deqm-test-kit, change line 34 of `docker-compose.background.yml` to `image: mitrehealthdocker/deqm-test-server:docker-auto-build-platforms`
    - Now you can try `docker compose pull` and it should work!