### PR TITLE
[DRAFT] Update Capability Statement to be STU5 

### DIFF
--- a/src/config/profileConfig.js
+++ b/src/config/profileConfig.js
@@ -57,25 +57,25 @@ const buildConfig = () => {
               name: 'submitData',
               route: '/$submit-data',
               method: 'POST',
-              reference: 'http://hl7.org/fhir/OperationDefinition/Measure-submit-data'
+              reference: 'https://hl7.org/fhir/operation-measure-submit-data.html'
             },
             {
               name: 'submitData',
               route: '/:id/$submit-data',
               method: 'POST',
-              reference: 'http://hl7.org/fhir/OperationDefinition/Measure-submit-data'
+              reference: 'https://hl7.org/fhir/operation-measure-submit-data.html'
             },
             {
               name: 'bulkSubmitData',
               route: '/$bulk-submit-data',
               method: 'POST',
-              reference: 'http://hl7.org/fhir/us/davinci-deqm/OperationDefinition/bulk-submit-data'
+              reference: 'https://hl7.org/fhir/us/davinci-deqm/STU5/OperationDefinition-bulk-submit-data.html'
             },
             {
               name: 'bulkSubmitData',
               route: '/:id/$bulk-submit-data',
               method: 'POST',
-              reference: 'http://hl7.org/fhir/us/davinci-deqm/OperationDefinition/bulk-submit-data'
+              reference: 'https://hl7.org/fhir/us/davinci-deqm/STU5/OperationDefinition-bulk-submit-data.html'
             },
             {
               name: 'dataRequirements',
@@ -93,25 +93,25 @@ const buildConfig = () => {
               name: 'evaluateMeasure',
               route: '/:id/$evaluate',
               method: 'GET',
-              reference: 'https://hl7.org/fhir/us/davinci-deqm/2024Sep/OperationDefinition-evaluate.html'
+              reference: 'https://hl7.org/fhir/us/davinci-deqm/STU5/OperationDefinition-evaluate.html'
             },
             {
               name: 'evaluateMeasure',
               route: '/:id/$evaluate',
               method: 'POST',
-              reference: 'https://hl7.org/fhir/us/davinci-deqm/2024Sep/OperationDefinition-evaluate.html'
+              reference: 'https://hl7.org/fhir/us/davinci-deqm/STU5/OperationDefinition-evaluate.html'
             },
             {
               name: 'evaluateMeasure',
               route: '/$evaluate',
               method: 'GET',
-              reference: 'https://hl7.org/fhir/us/davinci-deqm/2024Sep/OperationDefinition-evaluate.html'
+              reference: 'https://hl7.org/fhir/us/davinci-deqm/STU5/OperationDefinition-evaluate.html'
             },
             {
               name: 'evaluateMeasure',
               route: '/$evaluate',
               method: 'POST',
-              reference: 'https://hl7.org/fhir/us/davinci-deqm/2024Sep/OperationDefinition-evaluate.html'
+              reference: 'https://hl7.org/fhir/us/davinci-deqm/STU5/OperationDefinition-evaluate.html'
             },
             {
               name: 'careGaps',


### PR DESCRIPTION
*Note sure if there are other things I should be updating or changing*
# Summary
Update CapabilityStatement to be STU5 - 

Sorted through the varying references in this repository to check for any outdated info:
Ran:
`grep -rni --color "HL7" ./ --exclude-dir="*ecqm-content*" --exclude-dir="*node_modules*"`
`grep -rni --color "OperationDefinition" ./ --exclude-dir="*ecqm-content*" --exclude-dir="*node_modules*"`
`grep -rni --color "CapabilityStatement" ./ --exclude-dir="*ecqm-content*" --exclude-dir="*node_modules*"`
`grep -rni --color "davinci-deqm" ./ --exclude-dir="*ecqm-content*" --exclude-dir="*node_modules*"`
and looked through all references to try and find anything that wan't STU5

## New behavior
n/a 
## Code changes
Updated links for: 
```
./src/config/profileConfig.js:60:              reference: 'http://hl7.org/fhir/OperationDefinition/Measure-submit-data'
./src/config/profileConfig.js:66:              reference: 'http://hl7.org/fhir/OperationDefinition/Measure-submit-data'
./src/config/profileConfig.js:72:              reference: 'http://hl7.org/fhir/us/davinci-deqm/OperationDefinition/bulk-submit-data'
./src/config/profileConfig.js:78:              reference: 'http://hl7.org/fhir/us/davinci-deqm/OperationDefinition/bulk-submit-data'
./src/config/profileConfig.js:96:              reference: 'https://hl7.org/fhir/us/davinci-deqm/2024Sep/OperationDefinition-evaluate.html'
./src/config/profileConfig.js:102:              reference: 'https://hl7.org/fhir/us/davinci-deqm/2024Sep/OperationDefinition-evaluate.html'
./src/config/profileConfig.js:108:              reference: 'https://hl7.org/fhir/us/davinci-deqm/2024Sep/OperationDefinition-evaluate.html'
./src/config/profileConfig.js:114:              reference: 'https://hl7.org/fhir/us/davinci-deqm/2024Sep/OperationDefinition-evaluate.html'
./src/config/profileConfig.js:120:              reference: 'https://build.fhir.org/ig/HL7/davinci-deqm/OperationDefinition-care-gaps.html'
./src/config/profileConfig.js:126:              reference: 'https://build.fhir.org/ig/HL7/davinci-deqm/OperationDefinition-care-gaps.html'
```
# Testing guidance
n/a
