### PR TITLE
subjectGroup parameter for $evaluate operation

### DIFF
--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -189,6 +189,7 @@ const evaluateMeasure = async (args, { req }) => {
   if (req.method === 'POST') {
     // Creates a new query from a combination of parameters in the body and query
     query = gatherParams(req.query, req.body);
+    logger.info(JSON.stringify(req.body))
   } else {
     query = req.query;
   }
@@ -223,9 +224,14 @@ const evaluateMeasureForPopulation = async (args, query) => {
       : [await getMeasureBundleFromId(args.id ?? query.measureId)];
   // Collect patientId instead of bundles
   let patientIds = [];
-  if (query.subject) {
-    const subjectReference = query.subject.split('/');
-    const group = await findResourceById(subjectReference[1], subjectReference[0]);
+  if (query.subject || query.subjectGroup) {
+    let group;
+    if (query.subject) {
+      const subjectReference = query.subject.split('/');
+      group = await findResourceById(subjectReference[1], subjectReference[0]);
+    } else {
+      group = query.subjectGroup
+    }
     if (!group) {
       throw new ResourceNotFoundError(
         `No resource found in collection: ${subjectReference[0]}, with: id ${subjectReference[1]}.`

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -223,9 +223,11 @@ const evaluateMeasureForPopulation = async (args, query) => {
       : [await getMeasureBundleFromId(args.id ?? query.measureId)];
   // Collect patientId instead of bundles
   let patientIds = [];
-  if (query.subject || query.subjectGroup) {
+  if (query.subject) {
     let group;
-    if (query.subject) {
+    if (query.subjectGroup) {
+      group = query.subjectGroup;
+    } else {
       const subjectReference = query.subject.split('/');
       group = await findResourceById(subjectReference[1], subjectReference[0]);
       if (!group) {
@@ -233,8 +235,6 @@ const evaluateMeasureForPopulation = async (args, query) => {
           `No resource found in collection: ${subjectReference[0]}, with: id ${subjectReference[1]}.`
         );
       }
-    } else {
-      group = query.subjectGroup;
     }
     if (query.practitioner) {
       const patients = await filterPatientIdsFromGroup(group, query.practitioner);

--- a/src/services/measure.service.js
+++ b/src/services/measure.service.js
@@ -189,7 +189,6 @@ const evaluateMeasure = async (args, { req }) => {
   if (req.method === 'POST') {
     // Creates a new query from a combination of parameters in the body and query
     query = gatherParams(req.query, req.body);
-    logger.info(JSON.stringify(req.body))
   } else {
     query = req.query;
   }
@@ -229,13 +228,13 @@ const evaluateMeasureForPopulation = async (args, query) => {
     if (query.subject) {
       const subjectReference = query.subject.split('/');
       group = await findResourceById(subjectReference[1], subjectReference[0]);
+      if (!group) {
+        throw new ResourceNotFoundError(
+          `No resource found in collection: ${subjectReference[0]}, with: id ${subjectReference[1]}.`
+        );
+      }
     } else {
-      group = query.subjectGroup
-    }
-    if (!group) {
-      throw new ResourceNotFoundError(
-        `No resource found in collection: ${subjectReference[0]}, with: id ${subjectReference[1]}.`
-      );
+      group = query.subjectGroup;
     }
     if (query.practitioner) {
       const patients = await filterPatientIdsFromGroup(group, query.practitioner);

--- a/src/util/operationValidationUtils.js
+++ b/src/util/operationValidationUtils.js
@@ -41,6 +41,41 @@ function validateEvalMeasureParams(query, expectedId) {
         `For reportType parameter 'population', subject may only be a Group resource of format "Group/{id}".`
       );
     }
+
+    // check subjectGroup resource if specified
+    if (query.subjectGroup) {
+      // ensure it is a group resource
+      if (query.subjectGroup.resourceType !== 'Group') {
+        throw new BadRequestError("'subjectGroup' must be an embedded Group resource.");
+      }
+      // ensure it is referenced by the subject parameter
+      if (query.subjectGroup.id !== subjectReference[1]) {
+        throw new BadRequestError("'subjectGroup' resource must be referenced by the 'subject' parameter.");
+      }
+      // ensure it has members
+      if (query.subjectGroup.member && query.subjectGroup.member.length > 0) {
+        // check each member to make sure they all have valid references
+        for (let i = 0; i < query.subjectGroup.member.length; i++) {
+          const member = query.subjectGroup.member[i];
+          if (member.entity?.reference) {
+            const patientReference = member.entity.reference.split('/');
+            if (patientReference.length !== 2 || patientReference[0] !== 'Patient') {
+              throw new BadRequestError(
+                '\'subjectGroup\' members may only be Patient resource references of format "Patient/{id}".'
+              );
+            }
+          } else {
+            throw new BadRequestError("'subjectGroup' members must have references to Patients.");
+          }
+        }
+      } else {
+        throw new BadRequestError("'subjectGroup' must contain members.");
+      }
+    }
+  }
+
+  if (query.subjectGroup && !query.subject) {
+    throw new BadRequestError(`"subject" parameter must be included when "subjectGroup" is used.`);
   }
 
   if (query.reportType === 'subject') {
@@ -56,33 +91,6 @@ function validateEvalMeasureParams(query, expectedId) {
     const practitionerReference = query.practitioner.split('/');
     if (practitionerReference.length !== 2 || practitionerReference[0] !== 'Practitioner') {
       throw new BadRequestError(`practitioner may only be a Practitioner resource of format "Practitioner/{id}".`);
-    }
-  }
-
-  // check subjectGroup resource if specified
-  if (query.subjectGroup) {
-    // ensure it is a group resource
-    if (query.subjectGroup.resourceType !== 'Group') {
-      throw new BadRequestError('subjectGroup must be an embedded Group resource.');
-    }
-    // ensure it has members
-    if (query.subjectGroup.member && query.subjectGroup.member.length > 0) {
-      // check each member to make sure they all have valid references
-      for (let i = 0; i < query.subjectGroup.member.length; i++) {
-        const member = query.subjectGroup.member[i];
-        if (member.entity.reference) {
-          const patientReference = member.entity.reference.split('/');
-          if (patientReference.length !== 2 || patientReference[0] !== 'Patient') {
-            throw new BadRequestError(
-              'subjectGroup members may only be Patient resource references of format "Patient/{id}".'
-            );
-          }
-        } else {
-          throw new BadRequestError('subjectGroup members must have references to Patients.');
-        }
-      }
-    } else {
-      throw new BadRequestError('subjectGroup must contain members.');
     }
   }
 }

--- a/src/util/operationValidationUtils.js
+++ b/src/util/operationValidationUtils.js
@@ -73,7 +73,9 @@ function validateEvalMeasureParams(query, expectedId) {
         if (member.entity.reference) {
           const patientReference = member.entity.reference.split('/');
           if (patientReference.length !== 2 || patientReference[0] !== 'Patient') {
-            throw new BadRequestError('subjectGroup members may only be Patient resource references of format "Patient/{id}".')
+            throw new BadRequestError(
+              'subjectGroup members may only be Patient resource references of format "Patient/{id}".'
+            );
           }
         } else {
           throw new BadRequestError('subjectGroup members must have references to Patients.');
@@ -188,20 +190,17 @@ const gatherParams = (query, body) => {
 
   if (body.parameter) {
     body.parameter.reduce((acc, e) => {
-      //if (!e.resource) {
-        // For now, all usable params are expected to be stored under one of these four keys
-        const value = e.valueDate || e.valueString || e.valueId || e.valueCode || e.resource;
-        if (acc[e.name] !== undefined) {
-          // add to existing parameter values
-          if (Array.isArray(acc[e.name])) {
-            acc[e.name].push(value);
-          } else {
-            acc[e.name] = [acc[e.name], value];
-          }
+      const value = e.valueDate || e.valueString || e.valueId || e.valueCode || e.resource;
+      if (acc[e.name] !== undefined) {
+        // add to existing parameter values
+        if (Array.isArray(acc[e.name])) {
+          acc[e.name].push(value);
         } else {
-          acc[e.name] = value;
+          acc[e.name] = [acc[e.name], value];
         }
-      //}
+      } else {
+        acc[e.name] = value;
+      }
       return acc;
     }, params);
   }

--- a/test/services/measure.service.test.js
+++ b/test/services/measure.service.test.js
@@ -482,7 +482,7 @@ describe('measure.service', () => {
               period: {},
               measure: '',
               status: 'complete',
-              type: 'individual'
+              type: 'summary'
             }
           ],
           debugOutput: {}
@@ -524,8 +524,29 @@ describe('measure.service', () => {
               valueString: 'testMeasure'
             },
             {
+              name: 'subject',
+              valueString: 'Group/testSubjectGroup'
+            },
+            {
               name: 'subjectGroup',
-              resource: testGroup
+              resource: {
+                resourceType: 'Group',
+                id: 'testSubjectGroup',
+                type: 'person',
+                actual: 'true',
+                member: [
+                  {
+                    entity: {
+                      reference: 'Patient/testPatient'
+                    }
+                  },
+                  {
+                    entity: {
+                      reference: 'Patient/testPatient2'
+                    }
+                  }
+                ]
+              }
             }
           ]
         })

--- a/test/services/measure.service.test.js
+++ b/test/services/measure.service.test.js
@@ -472,6 +472,69 @@ describe('measure.service', () => {
       });
     });
 
+    test('$evaluate returns 200 when subjectGroup is provided and reportType is set to population', async () => {
+      const { Calculator } = require('fqm-execution');
+      const mrSpy = jest.spyOn(Calculator, 'calculateMeasureReports').mockImplementation(() => {
+        return {
+          results: [
+            {
+              resourceType: 'MeasureReport',
+              period: {},
+              measure: '',
+              status: 'complete',
+              type: 'individual'
+            }
+          ],
+          debugOutput: {}
+        };
+      });
+      jest.spyOn(Calculator, 'calculateDataRequirements').mockImplementation(() => {
+        return {
+          results: {
+            resourceType: 'Library',
+            type: {
+              coding: [{ code: 'module-definition', system: 'http://terminology.hl7.org/CodeSystem/library-type' }]
+            },
+            status: 'draft',
+            dataRequirement: []
+          }
+        };
+      });
+      await supertest(server.app)
+        .post('/4_0_1/Measure/$evaluate')
+        .send({
+          resourceType: 'Parameters',
+          parameter: [
+            {
+              name: 'periodStart',
+              valueString: '01-01-2020'
+            },
+            {
+              name: 'periodEnd',
+              valueString: '01-01-2021'
+            },
+            {
+              name: 'reportType',
+              valueString: 'population'
+            },
+            {
+              name: 'measureId',
+              valueString: 'testMeasure'
+            },
+            {
+              name: 'subjectGroup',
+              resource: testGroup
+            }
+          ]
+        })
+        .expect(200);
+      expect(mrSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(), {
+        measurementPeriodStart: '01-01-2020',
+        measurementPeriodEnd: '01-01-2021',
+        reportType: 'summary'
+      });
+    });
+
     test('$evaluate should default to reportType population when not set and no subject provided', async () => {
       const { Calculator } = require('fqm-execution');
       const mrSpy = jest.spyOn(Calculator, 'calculateMeasureReports').mockImplementation(() => {

--- a/test/services/measure.service.test.js
+++ b/test/services/measure.service.test.js
@@ -502,6 +502,8 @@ describe('measure.service', () => {
       });
       await supertest(server.app)
         .post('/4_0_1/Measure/$evaluate')
+        .set('Accept', 'application/json+fhir')
+        .set('content-type', 'application/json+fhir')
         .send({
           resourceType: 'Parameters',
           parameter: [

--- a/test/util/operationValidationUtils.test.js
+++ b/test/util/operationValidationUtils.test.js
@@ -186,6 +186,231 @@ describe('validateEvalMeasureParams', () => {
     }
   });
 
+  test('error thrown for population $evaluate with subjectGroup without subject parameter set', () => {
+    expect.assertions(2);
+    const POPULATION_REQ = {
+      query: {
+        measureId: 'testId',
+        reportType: 'population',
+        periodStart: '2019-01-01',
+        periodEnd: '2019-12-31',
+        subjectGroup: {
+          resourceType: 'Group',
+          id: 'testGroup',
+          type: 'person',
+          actual: 'true',
+          member: [
+            {
+              entity: {
+                reference: 'Patient/testPatient'
+              }
+            },
+            {
+              entity: {
+                reference: 'Patient/testPatient2'
+              }
+            }
+          ]
+        }
+      }
+    };
+    try {
+      validateEvalMeasureParams(POPULATION_REQ.query);
+    } catch (e) {
+      expect(e.statusCode).toEqual(400);
+      expect(e.issue[0].details.text).toEqual(`"subject" parameter must be included when "subjectGroup" is used.`);
+    }
+  });
+
+  test('error thrown for population $evaluate with subjectGroup without subject parameter referencing the group', () => {
+    expect.assertions(2);
+    const POPULATION_REQ = {
+      query: {
+        measureId: 'testId',
+        reportType: 'population',
+        periodStart: '2019-01-01',
+        periodEnd: '2019-12-31',
+        subject: 'Group/notTheTestGroup',
+        subjectGroup: {
+          resourceType: 'Group',
+          id: 'testGroup',
+          type: 'person',
+          actual: 'true',
+          member: [
+            {
+              entity: {
+                reference: 'Patient/testPatient'
+              }
+            },
+            {
+              entity: {
+                reference: 'Patient/testPatient2'
+              }
+            }
+          ]
+        }
+      }
+    };
+    try {
+      validateEvalMeasureParams(POPULATION_REQ.query);
+    } catch (e) {
+      expect(e.statusCode).toEqual(400);
+      expect(e.issue[0].details.text).toEqual("'subjectGroup' resource must be referenced by the 'subject' parameter.");
+    }
+  });
+
+  test('error thrown for population $evaluate with subjectGroup without valid Patient reference members', () => {
+    expect.assertions(2);
+    const POPULATION_REQ = {
+      query: {
+        measureId: 'testId',
+        reportType: 'population',
+        periodStart: '2019-01-01',
+        periodEnd: '2019-12-31',
+        subject: 'Group/testGroup',
+        subjectGroup: {
+          resourceType: 'Group',
+          id: 'testGroup',
+          type: 'person',
+          actual: 'true',
+          member: [
+            {
+              entity: {
+                reference: 'Patient/testPatient'
+              }
+            },
+            {
+              entity: {
+                reference: 'Medication/testMedication'
+              }
+            }
+          ]
+        }
+      }
+    };
+    try {
+      validateEvalMeasureParams(POPULATION_REQ.query);
+    } catch (e) {
+      expect(e.statusCode).toEqual(400);
+      expect(e.issue[0].details.text).toEqual(
+        '\'subjectGroup\' members may only be Patient resource references of format "Patient/{id}".'
+      );
+    }
+  });
+  test('error thrown for population $evaluate with subjectGroup with members missing references', () => {
+    expect.assertions(2);
+    const POPULATION_REQ = {
+      query: {
+        measureId: 'testId',
+        reportType: 'population',
+        periodStart: '2019-01-01',
+        periodEnd: '2019-12-31',
+        subject: 'Group/testGroup',
+        subjectGroup: {
+          resourceType: 'Group',
+          id: 'testGroup',
+          type: 'person',
+          actual: 'true',
+          member: [
+            {
+              entity: {
+                reference: 'Patient/testPatient'
+              }
+            },
+            {}
+          ]
+        }
+      }
+    };
+    try {
+      validateEvalMeasureParams(POPULATION_REQ.query);
+    } catch (e) {
+      expect(e.statusCode).toEqual(400);
+      expect(e.issue[0].details.text).toEqual("'subjectGroup' members must have references to Patients.");
+    }
+  });
+
+  test('error thrown for population $evaluate with subjectGroup without members list', () => {
+    expect.assertions(2);
+    const POPULATION_REQ = {
+      query: {
+        measureId: 'testId',
+        reportType: 'population',
+        periodStart: '2019-01-01',
+        periodEnd: '2019-12-31',
+        subject: 'Group/testGroup',
+        subjectGroup: {
+          resourceType: 'Group',
+          id: 'testGroup',
+          type: 'person',
+          actual: 'true'
+        }
+      }
+    };
+    try {
+      validateEvalMeasureParams(POPULATION_REQ.query);
+    } catch (e) {
+      expect(e.statusCode).toEqual(400);
+      expect(e.issue[0].details.text).toEqual("'subjectGroup' must contain members.");
+    }
+  });
+
+  test('error thrown for population $evaluate with subjectGroup not a Group resource', () => {
+    expect.assertions(2);
+    const POPULATION_REQ = {
+      query: {
+        measureId: 'testId',
+        reportType: 'population',
+        periodStart: '2019-01-01',
+        periodEnd: '2019-12-31',
+        subject: 'Group/testGroup',
+        subjectGroup: {
+          resourceType: 'Measure',
+          id: 'testMeasure'
+        }
+      }
+    };
+    try {
+      validateEvalMeasureParams(POPULATION_REQ.query);
+    } catch (e) {
+      expect(e.statusCode).toEqual(400);
+      expect(e.issue[0].details.text).toEqual("'subjectGroup' must be an embedded Group resource.");
+    }
+  });
+
+  test('no error thrown for population $evaluate with valid subjectGroup', () => {
+    const POPULATION_REQ = {
+      query: {
+        measureId: 'testId',
+        reportType: 'population',
+        periodStart: '2019-01-01',
+        periodEnd: '2019-12-31',
+        subject: 'Group/testGroup',
+        subjectGroup: {
+          resourceType: 'Group',
+          id: 'testGroup',
+          type: 'person',
+          actual: 'true',
+          member: [
+            {
+              entity: {
+                reference: 'Patient/testPatient'
+              }
+            },
+            {
+              entity: {
+                reference: 'Patient/testPatient2'
+              }
+            }
+          ]
+        }
+      }
+    };
+    expect(() => {
+      validateEvalMeasureParams(POPULATION_REQ.query);
+    }).not.toThrow();
+  });
+
   test('error thrown for subject $evaluate with non-Patient reference subject', () => {
     const INDIVIDUAL_REQ = {
       query: {


### PR DESCRIPTION
# Summary

Implementation of `subjectGroup` for `population` report type evaluate.

## New behavior

If `subjectGroup` is provided in the parameter resource, it will be used as the source of patients for measure evaluation.

## Code changes

- `src/util/operationValidationUtils.js` - Additional validation logic to support `subjectGroup`. Add embedded resource to collected parameters parsed from Parameters resources.
- `src/services/measure.service.js` - Make use of `subjectGroup` if it is provided.

# Testing guidance

Run unit tests. Test manually with insomnia. Example Parameters body:

```json
{
	"resourceType": "Parameters",
	"parameter": [
		{
			"name": "periodStart",
			"valueString": "01-01-2020"
		},
		{
			"name": "periodEnd",
			"valueString": "01-01-2021"
		},
		{
			"name": "reportType",
			"valueString": "population"
		},
		{
			"name": "measureId",
			"valueString": "ColorectalCancerScreeningsFHIR"
		},
		{
			"name": "subject",
			"valueString": "Group/testGroups"
		},
		{
			"name": "subjectGroup",
			"resource": {
				"resourceType": "Group",
					"id": "testGroups",
					"type": "person",
					"actual": "true",
					"member": [
					{
						"entity": {
							"reference": "Patient/Patient-66"
						}
					},
					{
						"entity": {
							"reference": "Patient/Patient-67"
						}
					}
				]
			}
		}
	]
}
```
