### PR TITLE
Make data requirements FHIR queries patient specific

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "dotenv": "^10.0.0",
         "express": "^4.19.2",
         "fhir-spec-tools": "^0.3.0",
-        "fqm-execution": "^1.8.3",
+        "fqm-execution": "github:projecttacoma/fqm-execution#master",
         "lodash": "^4.17.21",
         "mongodb": "^4.1.3",
         "redis": "^5.10.0",
@@ -2366,9 +2366,10 @@
       }
     },
     "node_modules/@lhncbc/ucum-lhc": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@lhncbc/ucum-lhc/-/ucum-lhc-4.1.6.tgz",
-      "integrity": "sha512-5VWDRwPZAcytx19Mh2aVbqrMSoclWPRIn65niGas5OgyIWD8nB5UbpgLQPvmV6+Z7l+a2L4E+7QIqfiimTYvfg==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/@lhncbc/ucum-lhc/-/ucum-lhc-7.1.6.tgz",
+      "integrity": "sha512-QD+NLuRci0gvv5zLpohVGcjlwGFYGmBwBgC6EDPVjVbTYlHkQFgg44PHFV6CVWii/09ne2Gxw89tbO/PhIcPBw==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "coffeescript": "^2.7.0",
         "csv-parse": "^4.4.6",
@@ -2376,7 +2377,6 @@
         "escape-html": "^1.0.3",
         "is-integer": "^1.0.6",
         "jsonfile": "^2.2.3",
-        "stream": "0.0.2",
         "stream-transform": "^0.1.1",
         "string-to-stream": "^1.1.0",
         "xmldoc": "^0.4.0"
@@ -5173,6 +5173,41 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/agent-base/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/agent-base/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -5896,6 +5931,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.7.0.tgz",
       "integrity": "sha512-hzWp6TUE2d/jCcN67LrW1eh5b/rSDKQK6oD6VMLlggYVUUFexgTH9z3dNYihzX4RMhze5FTUsUmOXViJKFQR/A==",
+      "license": "MIT",
       "bin": {
         "cake": "bin/cake",
         "coffee": "bin/coffee"
@@ -6126,6 +6162,17 @@
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw=="
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/core-js-pure": {
       "version": "3.45.1",
       "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.45.1.tgz",
@@ -6201,14 +6248,14 @@
       }
     },
     "node_modules/cql-execution": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.3.0.tgz",
-      "integrity": "sha512-Zs0sD7liz7tqfVUJVcEY281f8HtqFhfyngR4LsqWj5jusCMyy9a0flE914tA1QewOa4dpr90kov2lnm0C3J20w==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.3.2.tgz",
+      "integrity": "sha512-ljV+vvsk8aefwJzQRDD66exTce+LJ8h6+tzWNwEI+0357ZFoVnAs+M5p6PdgWiSIuhg4ywl/H5l+N7WoQL+ogg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@lhncbc/ucum-lhc": "^4.1.3",
-        "immutable": "^4.1.0",
-        "luxon": "^1.28.1"
+        "@lhncbc/ucum-lhc": "^7.1.6",
+        "immutable": "^5.1.4",
+        "luxon": "^3.7.2"
       }
     },
     "node_modules/create-require": {
@@ -6257,12 +6304,14 @@
     "node_modules/csv-parse": {
       "version": "4.16.3",
       "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.16.3.tgz",
-      "integrity": "sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg=="
+      "integrity": "sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg==",
+      "license": "MIT"
     },
     "node_modules/csv-stringify": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-1.1.2.tgz",
       "integrity": "sha512-3NmNhhd+AkYs5YtM1GEh01VR6PKj6qch2ayfQaltx5xpcAdThjnbbI5eT8CzRVpXfGKAxnmrSYLsNl/4f3eWiw==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "lodash.get": "~4.4.2"
       }
@@ -6570,11 +6619,6 @@
         "minimalistic-assert": "^1.0.1",
         "minimalistic-crypto-utils": "^1.0.1"
       }
-    },
-    "node_modules/emitter-component": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/emitter-component/-/emitter-component-1.1.1.tgz",
-      "integrity": "sha512-G+mpdiAySMuB7kesVRLuyvYRqDmshB7ReKEVuyBPkzQlmiDiLrt7hHHIy4Aff552bgknVN7B2/d3lzhGO5dvpQ=="
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -8026,15 +8070,16 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -8139,9 +8184,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -8172,16 +8217,16 @@
       }
     },
     "node_modules/fqm-execution": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/fqm-execution/-/fqm-execution-1.8.3.tgz",
-      "integrity": "sha512-CzDn9Ob2QAjWO68P86QGIjikO46xix70e8WYVMS+2KpsfHsDzugilojshMGlEy0p9B2U3m7Vp9Lsqt8MyOsMxQ==",
+      "version": "1.8.5",
+      "resolved": "git+ssh://git@github.com/projecttacoma/fqm-execution.git#4b01b9e713f1fcdaa3712f1f1215ab93f70be7f5",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/fhir": "0.0.34",
-        "axios": "^0.21.1",
+        "axios": "^1.13.6",
         "commander": "^6.1.0",
+        "core-js": "^3.49.0",
         "cql-exec-fhir": "^2.1.6",
-        "cql-execution": "^3.3.0",
+        "cql-execution": "^3.3.2",
         "fhir-spec-tools": "^0.4.0",
         "handlebars": "^4.7.7",
         "lodash": "^4.17.21",
@@ -8372,12 +8417,15 @@
       "license": "Python-2.0"
     },
     "node_modules/fqm-execution/node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
+      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/fqm-execution/node_modules/cql-exec-fhir": {
@@ -8659,6 +8707,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/fqm-execution/node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/fqm-execution/node_modules/shebang-command": {
@@ -9262,6 +9319,42 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -9323,9 +9416,10 @@
       "license": "MIT"
     },
     "node_modules/immutable": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.2.2.tgz",
-      "integrity": "sha512-fTMKDwtbvO5tldky9QZ2fMX7slR0mYpY5nbnFWYp0fOzDhHqhgIw9KoYgxLWsoNTS9ZHGauHj18DTyEw6BK3Og=="
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.6.tgz",
+      "integrity": "sha512-q1swsS8K7L8usSHuOqF2TAoCCkonYz0SG38wLAggaa4Wml70zixIvt2ql4coQ2C2B3hTjltJry4r6bULwgAXLQ==",
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -9535,6 +9629,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
       "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       },
@@ -9575,6 +9670,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.7.tgz",
       "integrity": "sha512-RPQc/s9yBHSvpi+hs9dYiJ2cuFeU6x3TyyIp8O2H6SKEltIvJOzRj9ToyvcStDvPR/pS4rxgr1oBFajQjZ2Szg==",
+      "license": "WTFPL OR ISC",
       "dependencies": {
         "is-finite": "^1.0.0"
       }
@@ -10641,6 +10737,7 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha512-PKllAqbgLgxHaj8TElYymKCAgrASebJrWpTnEkOaTowt23VKXXN0sUeriJ+eh7y6ufb/CC5ap11pz71/cM0hUw==",
+      "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -10790,7 +10887,9 @@
     "node_modules/lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+      "license": "MIT"
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
@@ -10868,11 +10967,12 @@
       }
     },
     "node_modules/luxon": {
-      "version": "1.28.1",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.1.tgz",
-      "integrity": "sha512-gYHAa180mKrNIUJCbwpmD0aTu9kV0dREDrwNnuyFAsO1Wt0EVYSZelPnJlbj9HplzXX/YWXHFTL45kvZ53M0pw==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
       "engines": {
-        "node": "*"
+        "node": ">=12"
       }
     },
     "node_modules/make-dir": {
@@ -12758,18 +12858,11 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/stream": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/stream/-/stream-0.0.2.tgz",
-      "integrity": "sha512-gCq3NDI2P35B2n6t76YJuOp7d6cN/C7Rt0577l91wllh0sY9ZBuw9KaSGqH/b0hzn3CWWJbpbW0W0WvQ1H/Q7g==",
-      "dependencies": {
-        "emitter-component": "^1.1.1"
-      }
-    },
     "node_modules/stream-transform": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-0.1.2.tgz",
-      "integrity": "sha512-3HXId/0W8sktQnQM6rOZf2LuDDMbakMgAjpViLk758/h0br+iGqZFFfUxxJSqEvGvT742PyFr4v/TBXUtowdCg=="
+      "integrity": "sha512-3HXId/0W8sktQnQM6rOZf2LuDDMbakMgAjpViLk758/h0br+iGqZFFfUxxJSqEvGvT742PyFr4v/TBXUtowdCg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
@@ -12797,6 +12890,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string-to-stream/-/string-to-stream-1.1.1.tgz",
       "integrity": "sha512-QySF2+3Rwq0SdO3s7BAp4x+c3qsClpPQ6abAmb0DGViiSBAkT5kL6JT2iyzEVP+T1SmzHrQD1TwlP9QAHCc+Sw==",
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.1.0"
@@ -14007,6 +14101,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/xmldoc/-/xmldoc-0.4.0.tgz",
       "integrity": "sha512-rJ/+/UzYCSlFNuAzGuRyYgkH2G5agdX1UQn4+5siYw9pkNC3Hu/grYNDx/dqYLreeSjnY5oKg74CMBKxJHSg6Q==",
+      "license": "MIT",
       "dependencies": {
         "sax": "~1.1.1"
       }
@@ -14014,7 +14109,8 @@
     "node_modules/xmldoc/node_modules/sax": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.6.tgz",
-      "integrity": "sha512-8zci48uUQyfqynGDSkUMD7FCJB96hwLnlZOXlgs1l3TX+LW27t3psSWKUxC0fxVgA86i8tL4NwGcY1h/6t3ESg=="
+      "integrity": "sha512-8zci48uUQyfqynGDSkUMD7FCJB96hwLnlZOXlgs1l3TX+LW27t3psSWKUxC0fxVgA86i8tL4NwGcY1h/6t3ESg==",
+      "license": "ISC"
     },
     "node_modules/xregexp": {
       "version": "4.4.1",
@@ -15879,9 +15975,9 @@
       }
     },
     "@lhncbc/ucum-lhc": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@lhncbc/ucum-lhc/-/ucum-lhc-4.1.6.tgz",
-      "integrity": "sha512-5VWDRwPZAcytx19Mh2aVbqrMSoclWPRIn65niGas5OgyIWD8nB5UbpgLQPvmV6+Z7l+a2L4E+7QIqfiimTYvfg==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/@lhncbc/ucum-lhc/-/ucum-lhc-7.1.6.tgz",
+      "integrity": "sha512-QD+NLuRci0gvv5zLpohVGcjlwGFYGmBwBgC6EDPVjVbTYlHkQFgg44PHFV6CVWii/09ne2Gxw89tbO/PhIcPBw==",
       "requires": {
         "coffeescript": "^2.7.0",
         "csv-parse": "^4.4.6",
@@ -15889,7 +15985,6 @@
         "escape-html": "^1.0.3",
         "is-integer": "^1.0.6",
         "jsonfile": "^2.2.3",
-        "stream": "0.0.2",
         "stream-transform": "^0.1.1",
         "string-to-stream": "^1.1.0",
         "xmldoc": "^0.4.0"
@@ -17814,6 +17909,29 @@
         }
       }
     },
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "requires": {
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+          "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
+      }
+    },
     "ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -18474,6 +18592,11 @@
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw=="
     },
+    "core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg=="
+    },
     "core-js-pure": {
       "version": "3.45.1",
       "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.45.1.tgz",
@@ -18531,13 +18654,13 @@
       }
     },
     "cql-execution": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.3.0.tgz",
-      "integrity": "sha512-Zs0sD7liz7tqfVUJVcEY281f8HtqFhfyngR4LsqWj5jusCMyy9a0flE914tA1QewOa4dpr90kov2lnm0C3J20w==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.3.2.tgz",
+      "integrity": "sha512-ljV+vvsk8aefwJzQRDD66exTce+LJ8h6+tzWNwEI+0357ZFoVnAs+M5p6PdgWiSIuhg4ywl/H5l+N7WoQL+ogg==",
       "requires": {
-        "@lhncbc/ucum-lhc": "^4.1.3",
-        "immutable": "^4.1.0",
-        "luxon": "^1.28.1"
+        "@lhncbc/ucum-lhc": "^7.1.6",
+        "immutable": "^5.1.4",
+        "luxon": "^3.7.2"
       }
     },
     "create-require": {
@@ -18802,11 +18925,6 @@
         "minimalistic-assert": "^1.0.1",
         "minimalistic-crypto-utils": "^1.0.1"
       }
-    },
-    "emitter-component": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/emitter-component/-/emitter-component-1.1.1.tgz",
-      "integrity": "sha512-G+mpdiAySMuB7kesVRLuyvYRqDmshB7ReKEVuyBPkzQlmiDiLrt7hHHIy4Aff552bgknVN7B2/d3lzhGO5dvpQ=="
     },
     "emittery": {
       "version": "0.13.1",
@@ -19775,9 +19893,9 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "follow-redirects": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="
     },
     "foreground-child": {
       "version": "3.3.1",
@@ -19839,9 +19957,9 @@
       }
     },
     "form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -19861,15 +19979,15 @@
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
     },
     "fqm-execution": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/fqm-execution/-/fqm-execution-1.8.3.tgz",
-      "integrity": "sha512-CzDn9Ob2QAjWO68P86QGIjikO46xix70e8WYVMS+2KpsfHsDzugilojshMGlEy0p9B2U3m7Vp9Lsqt8MyOsMxQ==",
+      "version": "git+ssh://git@github.com/projecttacoma/fqm-execution.git#4b01b9e713f1fcdaa3712f1f1215ab93f70be7f5",
+      "from": "fqm-execution@github:projecttacoma/fqm-execution#master",
       "requires": {
         "@types/fhir": "0.0.34",
-        "axios": "^0.21.1",
+        "axios": "^1.13.6",
         "commander": "^6.1.0",
+        "core-js": "^3.49.0",
         "cql-exec-fhir": "^2.1.6",
-        "cql-execution": "^3.3.0",
+        "cql-execution": "^3.3.2",
         "fhir-spec-tools": "^0.4.0",
         "handlebars": "^4.7.7",
         "lodash": "^4.17.21",
@@ -19974,11 +20092,14 @@
           "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
         },
         "axios": {
-          "version": "0.21.4",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-          "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
+          "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
           "requires": {
-            "follow-redirects": "^1.14.0"
+            "follow-redirects": "^1.16.0",
+            "form-data": "^4.0.5",
+            "https-proxy-agent": "^5.0.1",
+            "proxy-from-env": "^2.1.0"
           }
         },
         "cql-exec-fhir": {
@@ -20161,6 +20282,11 @@
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
           "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+        },
+        "proxy-from-env": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+          "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="
         },
         "shebang-command": {
           "version": "2.0.0",
@@ -20566,6 +20692,30 @@
         "toidentifier": "1.0.1"
       }
     },
+    "https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+          "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
+      }
+    },
     "human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -20602,9 +20752,9 @@
       "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
     },
     "immutable": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.2.2.tgz",
-      "integrity": "sha512-fTMKDwtbvO5tldky9QZ2fMX7slR0mYpY5nbnFWYp0fOzDhHqhgIw9KoYgxLWsoNTS9ZHGauHj18DTyEw6BK3Og=="
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.6.tgz",
+      "integrity": "sha512-q1swsS8K7L8usSHuOqF2TAoCCkonYz0SG38wLAggaa4Wml70zixIvt2ql4coQ2C2B3hTjltJry4r6bULwgAXLQ=="
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -21738,9 +21888,9 @@
       }
     },
     "luxon": {
-      "version": "1.28.1",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.1.tgz",
-      "integrity": "sha512-gYHAa180mKrNIUJCbwpmD0aTu9kV0dREDrwNnuyFAsO1Wt0EVYSZelPnJlbj9HplzXX/YWXHFTL45kvZ53M0pw=="
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew=="
     },
     "make-dir": {
       "version": "4.0.0",
@@ -23069,14 +23219,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
-    },
-    "stream": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/stream/-/stream-0.0.2.tgz",
-      "integrity": "sha512-gCq3NDI2P35B2n6t76YJuOp7d6cN/C7Rt0577l91wllh0sY9ZBuw9KaSGqH/b0hzn3CWWJbpbW0W0WvQ1H/Q7g==",
-      "requires": {
-        "emitter-component": "^1.1.1"
-      }
     },
     "stream-transform": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "dotenv": "^10.0.0",
     "express": "^4.19.2",
     "fhir-spec-tools": "^0.3.0",
-    "fqm-execution": "^1.8.3",
+    "fqm-execution": "github:projecttacoma/fqm-execution#master",
     "lodash": "^4.17.21",
     "mongodb": "^4.1.3",
     "redis": "^5.10.0",

--- a/src/util/collectDataUtils.ts
+++ b/src/util/collectDataUtils.ts
@@ -1,0 +1,37 @@
+import { getMeasureBundleFromId } from './bundleUtils';
+import { Calculator, DRCalculationOutput } from 'fqm-execution';
+
+const PATIENT_ID_CONTEXT_TOKEN = '{{context.patientId}}';
+
+function populatePatientIdContext(dataRequirements: DRCalculationOutput, patientId: string): DRCalculationOutput {
+  return {
+    ...dataRequirements,
+    results: {
+      ...dataRequirements.results,
+      dataRequirement: dataRequirements.results.dataRequirement?.map(dataRequirement => ({
+        ...dataRequirement,
+        extension: dataRequirement.extension?.map(extension => ({
+          ...extension,
+          valueString: extension.valueString?.includes(PATIENT_ID_CONTEXT_TOKEN)
+            ? extension.valueString.split(PATIENT_ID_CONTEXT_TOKEN).join(patientId)
+            : extension.valueString
+        }))
+      }))
+    }
+  };
+}
+
+/**
+ * To be used in a future $collect-data workflow, this function takes a measure bundle ID
+ * and a patient ID and returns the results of calculateDataRequirements with the patient
+ * ID injected into the cqfm FHIR queries in the output
+ */
+export async function patientSpecificDataRequirements(
+  measureId: string,
+  patientId: string
+): Promise<DRCalculationOutput> {
+  const measureBundle = await getMeasureBundleFromId(measureId);
+
+  const dataRequirements = await Calculator.calculateDataRequirements(measureBundle);
+  return populatePatientIdContext(dataRequirements, patientId);
+}

--- a/src/util/collectDataUtils.ts
+++ b/src/util/collectDataUtils.ts
@@ -1,5 +1,5 @@
 import { getMeasureBundleFromId } from './bundleUtils';
-import { Calculator, DRCalculationOutput } from 'fqm-execution';
+import { Calculator, CalculationOptions, DRCalculationOutput } from 'fqm-execution';
 
 const PATIENT_ID_CONTEXT_TOKEN = '{{context.patientId}}';
 
@@ -10,12 +10,14 @@ function populatePatientIdContext(dataRequirements: DRCalculationOutput, patient
       ...dataRequirements.results,
       dataRequirement: dataRequirements.results.dataRequirement?.map(dataRequirement => ({
         ...dataRequirement,
-        extension: dataRequirement.extension?.map(extension => ({
-          ...extension,
-          valueString: extension.valueString?.includes(PATIENT_ID_CONTEXT_TOKEN)
-            ? extension.valueString.split(PATIENT_ID_CONTEXT_TOKEN).join(patientId)
-            : extension.valueString
-        }))
+        extension: dataRequirement.extension?.map(extension =>
+          extension.valueString?.includes(PATIENT_ID_CONTEXT_TOKEN)
+            ? {
+                ...extension,
+                valueString: extension.valueString.split(PATIENT_ID_CONTEXT_TOKEN).join(patientId)
+              }
+            : extension
+        )
       }))
     }
   };
@@ -28,10 +30,11 @@ function populatePatientIdContext(dataRequirements: DRCalculationOutput, patient
  */
 export async function patientSpecificDataRequirements(
   measureId: string,
-  patientId: string
+  patientId: string,
+  options?: CalculationOptions
 ): Promise<DRCalculationOutput> {
   const measureBundle = await getMeasureBundleFromId(measureId);
 
-  const dataRequirements = await Calculator.calculateDataRequirements(measureBundle);
+  const dataRequirements = await Calculator.calculateDataRequirements(measureBundle, options);
   return populatePatientIdContext(dataRequirements, patientId);
 }

--- a/src/util/collectDataUtils.ts
+++ b/src/util/collectDataUtils.ts
@@ -4,23 +4,14 @@ import { Calculator, CalculationOptions, DRCalculationOutput } from 'fqm-executi
 const PATIENT_ID_CONTEXT_TOKEN = '{{context.patientId}}';
 
 function populatePatientIdContext(dataRequirements: DRCalculationOutput, patientId: string): DRCalculationOutput {
-  return {
-    ...dataRequirements,
-    results: {
-      ...dataRequirements.results,
-      dataRequirement: dataRequirements.results.dataRequirement?.map(dataRequirement => ({
-        ...dataRequirement,
-        extension: dataRequirement.extension?.map(extension =>
-          extension.valueString?.includes(PATIENT_ID_CONTEXT_TOKEN)
-            ? {
-                ...extension,
-                valueString: extension.valueString.split(PATIENT_ID_CONTEXT_TOKEN).join(patientId)
-              }
-            : extension
-        )
-      }))
-    }
-  };
+  dataRequirements.results.dataRequirement?.forEach(dataRequirement => {
+    dataRequirement.extension?.forEach(extension => {
+      if (extension.valueString) {
+        extension.valueString = extension.valueString.replaceAll(PATIENT_ID_CONTEXT_TOKEN, patientId);
+      }
+    });
+  });
+  return dataRequirements;
 }
 
 /**

--- a/test/util/collectDataUtils.test.ts
+++ b/test/util/collectDataUtils.test.ts
@@ -83,10 +83,10 @@ describe('patientSpecificDataRequirements', () => {
     bundleUtils.getMeasureBundleFromId.mockResolvedValue(measureBundle);
     jest.spyOn(Calculator, 'calculateDataRequirements').mockResolvedValue(dataRequirementsOutput);
 
-    const result = await patientSpecificDataRequirements('measure-1', 'patient-123');
+    const result = await patientSpecificDataRequirements('measure-1', 'patient-123', { useExpandedCodeQueries: true });
 
     expect(bundleUtils.getMeasureBundleFromId).toHaveBeenCalledWith('measure-1');
-    expect(Calculator.calculateDataRequirements).toHaveBeenCalledWith(measureBundle);
+    expect(Calculator.calculateDataRequirements).toHaveBeenCalledWith(measureBundle, { useExpandedCodeQueries: true });
     expect(result.results.dataRequirement[0].extension[0].valueString).toBe(
       '/Coverage?type=1,2,3&policy-holder=Patient/patient-123'
     );

--- a/test/util/collectDataUtils.test.ts
+++ b/test/util/collectDataUtils.test.ts
@@ -1,0 +1,100 @@
+//@ts-nocheck
+const { Calculator } = require('fqm-execution');
+const bundleUtils = require('../../src/util/bundleUtils');
+const { patientSpecificDataRequirements } = require('../../src/util/collectDataUtils');
+
+jest.mock('../../src/util/bundleUtils');
+
+describe('patientSpecificDataRequirements', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('populates context patientId placeholders in dataRequirement extensions', async () => {
+    const measureBundle = {
+      resourceType: 'Bundle',
+      type: 'collection',
+      entry: []
+    };
+    const dataRequirementsOutput = {
+      results: {
+        resourceType: 'Library',
+        type: {
+          coding: [
+            {
+              system: 'http://terminology.hl7.org/CodeSystem/library-type',
+              code: 'module-definition'
+            }
+          ]
+        },
+        dataRequirement: [
+          {
+            type: 'Coverage',
+            codeFilter: [
+              {
+                path: 'subject',
+                valueSet: 'http://example.com/ValueSet/exampleVS'
+              }
+            ],
+            extension: [
+              {
+                url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-fhirQueryPattern',
+                valueString: '/Coverage?type=1,2,3&policy-holder=Patient/{{context.patientId}}'
+              },
+              {
+                url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-fhirQueryPattern',
+                valueString: '/Coverage?type=1,2,3&subscriber=Patient/{{context.patientId}}'
+              }
+            ]
+          },
+          {
+            type: 'Encounter',
+            codeFilter: [
+              {
+                path: 'type',
+                valueSet: 'http://exmaple.com/ValueSet/exampleVS'
+              }
+            ],
+            dateFilter: [
+              {
+                path: 'period',
+                valuePeriod: {
+                  start: '2026-01-01T00:00:00.000Z',
+                  end: '2026-12-31T00:00:00.000Z'
+                }
+              }
+            ],
+            extension: [
+              {
+                url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-fhirQueryPattern',
+                valueString:
+                  '/Encounter?type=1,2,3&date=ge2026-01-01T00:00:00.000Z&date=le2026-12-31T00:00:00.000Z&patient=Patient/{{context.patientId}}'
+              }
+            ]
+          }
+        ]
+      }
+    };
+
+    bundleUtils.getMeasureBundleFromId.mockResolvedValue(measureBundle);
+    jest.spyOn(Calculator, 'calculateDataRequirements').mockResolvedValue(dataRequirementsOutput);
+
+    const result = await patientSpecificDataRequirements('measure-1', 'patient-123');
+
+    expect(bundleUtils.getMeasureBundleFromId).toHaveBeenCalledWith('measure-1');
+    expect(Calculator.calculateDataRequirements).toHaveBeenCalledWith(measureBundle);
+    expect(result.results.dataRequirement[0].extension[0].valueString).toBe(
+      '/Coverage?type=1,2,3&policy-holder=Patient/patient-123'
+    );
+    expect(result.results.dataRequirement[0].extension[1].valueString).toBe(
+      '/Coverage?type=1,2,3&subscriber=Patient/patient-123'
+    );
+    expect(result.results.dataRequirement[1].extension[0].valueString).toBe(
+      '/Encounter?type=1,2,3&date=ge2026-01-01T00:00:00.000Z&date=le2026-12-31T00:00:00.000Z&patient=Patient/patient-123'
+    );
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "forceConsistentCasingInFileNames": true,
     "declaration": true,
     "sourceMap": true,
-    "moduleResolution": "nodenext"
+    "moduleResolution": "nodenext",
+    "types": ["node", "fhir"]
   },
   "ts-node": {
     "files": true


### PR DESCRIPTION
# Summary
This PR adds a function that will be used later in the `$collect-data` workflow that takes a measure's data-requirements and uses patient information to make the queries patient-specific.

## New behavior
There should be no new behavior on the server itself, just the addition of the `collectUtils.ts` file and its functions.

## Code changes
- `src/util/collectDataUtils.ts` - new file for functions to make data-requirements patient-specific
- `test/util/collectDataUtils.test.ts` - associated unit test
- `tsconfig.json` - added "node" and "fhir" types to avoid editor errors

# Testing guidance
- `npm run check`