### PR TITLE
Replace urls as references not as values

### DIFF
--- a/src/util/bundleUtils.ts
+++ b/src/util/bundleUtils.ts
@@ -6,6 +6,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { findResourceById, findOneResourceWithQuery } from '../database/dbOperations';
 import logger from '../server/logger';
 import { Document, Filter } from 'mongodb';
+import * as fhir4 from 'fhir/r4';
 
 /*
  Some connectathon bundles currently contain incorrect url references from the main library
@@ -255,18 +256,20 @@ export function replaceReferences(entries: any[]) {
 
   let entriesStr = JSON.stringify(entries);
   const postEntries = entries.filter(e => e.isPost);
+  const referenceProperty = (reference: string) => JSON.stringify({ reference }).slice(1, -1);
 
   // For each POST entry, replace existing reference across all entries
   postEntries.forEach(e => {
     logger.debug(`Replacing referenceIds for entry: ${JSON.stringify(e)}`);
+    const newReference = `${e.resource.resourceType}/${e.newId}`;
     // Checking fullUrl and id in separate replace loops will prevent invalid ResourceType/ResourceID -> urn:uuid references
     if (e.oldId) {
-      const idRegexp = new RegExp(`${e.resource.resourceType}/${e.oldId}`, 'g');
-      entriesStr = entriesStr.replace(idRegexp, `${e.resource.resourceType}/${e.newId}`);
+      entriesStr = entriesStr
+        .split(referenceProperty(`${e.resource.resourceType}/${e.oldId}`))
+        .join(referenceProperty(newReference));
     }
     if (e.fullUrl) {
-      const urnRegexp = new RegExp(e.fullUrl, 'g');
-      entriesStr = entriesStr.replace(urnRegexp, `${e.resource.resourceType}/${e.newId}`);
+      entriesStr = entriesStr.split(referenceProperty(e.fullUrl)).join(referenceProperty(newReference));
     }
   });
 

--- a/src/util/bundleUtils.ts
+++ b/src/util/bundleUtils.ts
@@ -6,7 +6,6 @@ import { v4 as uuidv4 } from 'uuid';
 import { findResourceById, findOneResourceWithQuery } from '../database/dbOperations';
 import logger from '../server/logger';
 import { Document, Filter } from 'mongodb';
-import * as fhir4 from 'fhir/r4';
 
 /*
  Some connectathon bundles currently contain incorrect url references from the main library
@@ -234,6 +233,16 @@ export async function getAllDependentLibraries(lib: fhir4.Library): Promise<(fhi
 }
 
 /**
+ * Convert a FHIR reference value into the JSON property fragment used for targeted string replacement.
+ * This ensures only `reference` fields are replaced, rather than every matching string value.
+ * @param {string} reference reference value to encode
+ * @returns {string} JSON property fragment for the reference
+ */
+function referenceProperty(reference: string): string {
+  return JSON.stringify({ reference }).slice(1, -1);
+}
+
+/**
  * For entries in a transaction bundle whose IDs will be auto-generated, replace all instances of an existing reference
  * to the old id with a reference to the newly generated one.
  *
@@ -256,7 +265,6 @@ export function replaceReferences(entries: any[]) {
 
   let entriesStr = JSON.stringify(entries);
   const postEntries = entries.filter(e => e.isPost);
-  const referenceProperty = (reference: string) => JSON.stringify({ reference }).slice(1, -1);
 
   // For each POST entry, replace existing reference across all entries
   postEntries.forEach(e => {
@@ -264,12 +272,13 @@ export function replaceReferences(entries: any[]) {
     const newReference = `${e.resource.resourceType}/${e.newId}`;
     // Checking fullUrl and id in separate replace loops will prevent invalid ResourceType/ResourceID -> urn:uuid references
     if (e.oldId) {
-      entriesStr = entriesStr
-        .split(referenceProperty(`${e.resource.resourceType}/${e.oldId}`))
-        .join(referenceProperty(newReference));
+      entriesStr = entriesStr.replaceAll(
+        referenceProperty(`${e.resource.resourceType}/${e.oldId}`),
+        referenceProperty(newReference)
+      );
     }
     if (e.fullUrl) {
-      entriesStr = entriesStr.split(referenceProperty(e.fullUrl)).join(referenceProperty(newReference));
+      entriesStr = entriesStr.replaceAll(referenceProperty(e.fullUrl), referenceProperty(newReference));
     }
   });
 

--- a/test/fixtures/bundleUtilFixtures.ts
+++ b/test/fixtures/bundleUtilFixtures.ts
@@ -86,6 +86,35 @@ const BOTH_REPLACE_REFERENCES_ENTRIES = [
   }
 ];
 
+const URL_VALUE_REPLACE_REFERENCES_ENTRIES = [
+  {
+    resource: {
+      id: '61ebe359-bfdc-4613-8bf2-c5e300945f0a',
+      resourceType: 'Patient',
+      gender: 'male',
+      birthDate: '1974-12-25'
+    },
+    request: {
+      method: 'POST',
+      url: 'Patient'
+    }
+  },
+  {
+    resource: {
+      id: '88f151c0-a954-468a-88bd-5ae15c08e059',
+      resourceType: 'Observation',
+      subject: {
+        reference: 'Patient/61ebe359-bfdc-4613-8bf2-c5e300945f0a'
+      },
+      valueString: 'https://example.org/fhir/Patient/61ebe359-bfdc-4613-8bf2-c5e300945f0a'
+    },
+    request: {
+      method: 'POST',
+      url: 'Observation'
+    }
+  }
+];
+
 const EXPECTED_REPLACE_REFERENCES_OUTPUT = [
   {
     resource: {
@@ -142,10 +171,41 @@ const EXPECTED_FAILED_REPLACE_REFERENCES_OUTPUT = [
   }
 ];
 
+const EXPECTED_URL_VALUE_REPLACE_REFERENCES_OUTPUT = [
+  {
+    resource: {
+      id: 'Patient-0',
+      resourceType: 'Patient',
+      gender: 'male',
+      birthDate: '1974-12-25'
+    },
+    request: {
+      method: 'PUT',
+      url: 'Patient/Patient-0'
+    }
+  },
+  {
+    resource: {
+      id: 'Observation-1',
+      resourceType: 'Observation',
+      subject: {
+        reference: 'Patient/Patient-0'
+      },
+      valueString: 'https://example.org/fhir/Patient/61ebe359-bfdc-4613-8bf2-c5e300945f0a'
+    },
+    request: {
+      method: 'PUT',
+      url: 'Observation/Observation-1'
+    }
+  }
+];
+
 module.exports = {
   URN_REPLACE_REFERENCES_ENTRIES,
   RESOURCETYPE_REPLACE_REFERENCES_ENTRIES,
   BOTH_REPLACE_REFERENCES_ENTRIES,
+  URL_VALUE_REPLACE_REFERENCES_ENTRIES,
   EXPECTED_REPLACE_REFERENCES_OUTPUT,
-  EXPECTED_FAILED_REPLACE_REFERENCES_OUTPUT
+  EXPECTED_FAILED_REPLACE_REFERENCES_OUTPUT,
+  EXPECTED_URL_VALUE_REPLACE_REFERENCES_OUTPUT
 };

--- a/test/util/bundleUtils.test.ts
+++ b/test/util/bundleUtils.test.ts
@@ -6,8 +6,10 @@ const {
   URN_REPLACE_REFERENCES_ENTRIES,
   RESOURCETYPE_REPLACE_REFERENCES_ENTRIES,
   BOTH_REPLACE_REFERENCES_ENTRIES,
+  URL_VALUE_REPLACE_REFERENCES_ENTRIES,
   EXPECTED_REPLACE_REFERENCES_OUTPUT,
-  EXPECTED_FAILED_REPLACE_REFERENCES_OUTPUT
+  EXPECTED_FAILED_REPLACE_REFERENCES_OUTPUT,
+  EXPECTED_URL_VALUE_REPLACE_REFERENCES_OUTPUT
 } = require('../fixtures/bundleUtilFixtures');
 const { v4: uuidv4 } = require('uuid');
 const libraryWithDependencies = require('../fixtures/fhir-resources/testLibraryDependencies.json');
@@ -48,6 +50,16 @@ describe('Testing functionality of all functions which run uuidv4', () => {
     });
     test('Check that replaceReference does not replace ref on reference: resourceType/resourceId -> fullUrl: urn:uuid: resourceId', () => {
       expect(replaceReferences(BOTH_REPLACE_REFERENCES_ENTRIES)).toEqual(EXPECTED_FAILED_REPLACE_REFERENCES_OUTPUT);
+    });
+  });
+  describe('Testing functionality of bundleUtils when URLs are used as values and references', () => {
+    beforeEach(() => {
+      init(URL_VALUE_REPLACE_REFERENCES_ENTRIES);
+    });
+    test('Check that replaceReference only replaces URL values in reference fields', () => {
+      expect(replaceReferences(URL_VALUE_REPLACE_REFERENCES_ENTRIES)).toEqual(
+        EXPECTED_URL_VALUE_REPLACE_REFERENCES_OUTPUT
+      );
     });
   });
   afterAll(async () => {


### PR DESCRIPTION
# Summary
Differentiate when a url is being used as a reference versus when it's being used as a value instead of replacing all instances of the url

## New behavior
`replaceReferences` now replaces old `ResourceType/id` and `fullUrl` values only when they are used in a `reference` field, and does not replace those same strings when they are used as a value

## Code changes
-  Import fhir/r4 (I was getting errors throughout the whole file without this)
- New replaceReferences replacement algorithm to look for  `reference` properties for replacing instead of replacing all instances
- Added test

# Testing guidance
1. Check out https://github.com/cqframework/ecqm-content-cms-2025
2. Clear (npm run db:reset) and start (npm run start) the deqm-test-server 
3. Create an Insomnia POST request to url: http://localhost:3000/4_0_1/ 
4. Under the Body tab's dropdown, select file
5. Choose the mat CMS130 measure transaction bundle json file from the CMS 2025 repo: bundles/mat/CMS130FHIR-R2-MeasureExport/CMS130FHIR-v0.4.000-FHIR.json
6.Set header Content-Type to application/json+fhir
7. Send request (should receive back 200 OK and transaction-response bundle body)
8. Look at Measure collection to see what the `url` field is for the Measure added to the database. Confirm that it is https://madie.cms.gov/Measure/CMS130FHIRColorectalCancerScreening
9. Run tests (npm run test) and confirm all is passing 

(Previous bug is that the url is `[https://madie.cms.gov/Measure/\](https://madie.cms.gov/Measure/){some uuid}` rather than the original `https://madie.cms.gov/Measure/CMS130FHIRColorectalCancerScreening`)